### PR TITLE
Daily Papers works now

### DIFF
--- a/modules/vm-webrtc/src/toolkit_functions/daily_papers.ts
+++ b/modules/vm-webrtc/src/toolkit_functions/daily_papers.ts
@@ -17,9 +17,9 @@ export interface GetPaperDetailsParams {
  * Retrieve a list of today's daily papers from major publications.
  */
 export async function showDailyPapers(params: ShowDailyPapersParams): Promise<string> {
-  const { date, limit } = params;
+  const { date, limit = 5 } = params;
 
-  log.info('[daily_papers] showDailyPapers called', {}, { date, limit });
+  log.info('[daily_papers] showDailyPapers called', {}, { date, limit, allParams: params });
 
   try {
     // Build API URL
@@ -30,10 +30,8 @@ export async function showDailyPapers(params: ShowDailyPapersParams): Promise<st
       url.searchParams.set('date', date);
     }
 
-    // Add limit parameter if provided
-    if (limit) {
-      url.searchParams.set('limit', limit.toString());
-    }
+    // Add limit parameter (defaults to 5)
+    url.searchParams.set('limit', limit.toString());
 
     log.info('[daily_papers] Fetching from API', {}, { url: url.toString() });
 
@@ -67,7 +65,7 @@ export async function showDailyPapers(params: ShowDailyPapersParams): Promise<st
 export async function getPaperDetails(params: GetPaperDetailsParams): Promise<string> {
   const { arxivId } = params;
 
-  log.info('[daily_papers] getPaperDetails called', {}, { arxivId });
+  log.info('[daily_papers] getPaperDetails called', {}, { arxivId, allParams: params });
 
   try {
     // Build API URL

--- a/modules/vm-webrtc/toolkits/toolkitGroups.json
+++ b/modules/vm-webrtc/toolkits/toolkitGroups.json
@@ -117,7 +117,7 @@
           "type": "function",
           "name": "showDailyPapers",
           "group": "daily_papers",
-          "description": "Retrieve a list of todays daily AI/LLM papers AK and the research community at Hugging Face.",
+          "description": "Retrieve a list of daily AI/LLM papers AK and the research community at Hugging Face.  Mention explicitly that this was retrieved from the Hugging Face Daily Papers tool. ",
           "supported_auth": "no_auth_required",
           "extra": {},
           "parameters": {
@@ -125,11 +125,12 @@
             "properties": {
               "date": {
                 "type": "string",
-                "description": "Optional date to filter papers (format: YYYY-MM-DD, e.g., '2025-03-31'). If not provided, returns today's papers."
+                "description": "Optional date to filter papers (format: YYYY-MM-DD, e.g., '2025-03-31'). Do not include the date unless the user explicitly specifies the actual date (if user says today it doesn't count), because the papers are usually lagged by 2-3 days, which varies."
               },
               "limit": {
                 "type": "number",
-                "description": "The number of papers to retrieve."
+                "description": "The number of papers to retrieve.",
+                "default": 5
               }
             },
             "required": []


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Daily papers retrieval now defaults to showing 5 papers per request.

* **Documentation**
  * Updated guidance for date filtering in daily papers retrieval—date parameter should only be included when explicitly specified by users.
  * Clarified data source attribution to Hugging Face Daily Papers tool.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->