### PR TITLE
Language lesson tool

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -53,6 +53,7 @@
         "react-native-web": "~0.21.0",
         "react-native-worklets": "0.5.1",
         "striptags": "^3.2.0",
+        "zod": "^4.3.6",
       },
       "devDependencies": {
         "@types/bun": "latest",
@@ -2319,7 +2320,7 @@
 
     "yocto-queue": ["yocto-queue@0.1.0", "", {}, "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q=="],
 
-    "zod": ["zod@4.2.1", "", {}, "sha512-0wZ1IRqGGhMP76gLqz8EyfBXKk0J2qo2+H3fi4mcUP/KtTocoX08nmIAHl1Z2kJIZbZee8KOpBCSNPRgauucjw=="],
+    "zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
 
     "zod-to-json-schema": ["zod-to-json-schema@3.24.6", "", { "peerDependencies": { "zod": "^3.24.1" } }, "sha512-h/z3PKvcTcTetyjl1fkj79MHNEjm+HpD6NXheWjzOekY7kV+lwDYnHw+ivHkijnCSMz1yJaWBD9vu/Fcmk+vEg=="],
 
@@ -2428,6 +2429,8 @@
     "@expo/eas-build-job/joi": ["joi@17.13.3", "", { "dependencies": { "@hapi/hoek": "^9.3.0", "@hapi/topo": "^5.1.0", "@sideway/address": "^4.1.5", "@sideway/formula": "^3.0.1", "@sideway/pinpoint": "^2.0.0" } }, "sha512-otDA4ldcIx+ZXsKHWmp0YizCweVRZG96J10b0FevjfuncLO1oX59THoAmHkNubYJ+9gWsYsp5k8v4ib6oDv1fA=="],
 
     "@expo/eas-build-job/semver": ["semver@7.7.2", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA=="],
+
+    "@expo/eas-build-job/zod": ["zod@4.2.1", "", {}, "sha512-0wZ1IRqGGhMP76gLqz8EyfBXKk0J2qo2+H3fi4mcUP/KtTocoX08nmIAHl1Z2kJIZbZee8KOpBCSNPRgauucjw=="],
 
     "@expo/eas-json/@babel/code-frame": ["@babel/code-frame@7.23.5", "", { "dependencies": { "@babel/highlight": "^7.23.4", "chalk": "^2.4.2" } }, "sha512-CgH3s1a96LipHCmSUmYFPwY7MNx8C3avkq7i4Wl3cfa662ldtUe4VM1TPXX70pfmrlWTb6jLqTYrZyT2ZTJBgA=="],
 
@@ -2634,6 +2637,8 @@
     "dom-serializer/entities": ["entities@4.5.0", "", {}, "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw=="],
 
     "dotenv-expand/dotenv": ["dotenv@16.4.7", "", {}, "sha512-47qPchRCykZC03FhkYAhrvwU4xDBFIj1QPqaarj6mdM/hgUzfPHcpkHJOn3mJAufFeeAxAzeGsr5X0M4k6fLZQ=="],
+
+    "eas-cli/zod": ["zod@4.2.1", "", {}, "sha512-0wZ1IRqGGhMP76gLqz8EyfBXKk0J2qo2+H3fi4mcUP/KtTocoX08nmIAHl1Z2kJIZbZee8KOpBCSNPRgauucjw=="],
 
     "error-ex/is-arrayish": ["is-arrayish@0.2.1", "", {}, "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg=="],
 
@@ -2867,8 +2872,6 @@
 
     "xml2js/xmlbuilder": ["xmlbuilder@11.0.1", "", {}, "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA=="],
 
-    "zod-to-json-schema/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
-
     "@babel/helper-compilation-targets/lru-cache/yallist": ["yallist@3.1.1", "", {}, "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="],
 
     "@babel/highlight/chalk/ansi-styles": ["ansi-styles@3.2.1", "", { "dependencies": { "color-convert": "^1.9.0" } }, "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA=="],
@@ -2929,6 +2932,8 @@
 
     "@expo/eas-json/@expo/eas-build-job/semver": ["semver@7.7.2", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA=="],
 
+    "@expo/eas-json/@expo/eas-build-job/zod": ["zod@4.2.1", "", {}, "sha512-0wZ1IRqGGhMP76gLqz8EyfBXKk0J2qo2+H3fi4mcUP/KtTocoX08nmIAHl1Z2kJIZbZee8KOpBCSNPRgauucjw=="],
+
     "@expo/metro-config/@expo/config/@babel/code-frame": ["@babel/code-frame@7.10.4", "", { "dependencies": { "@babel/highlight": "^7.10.4" } }, "sha512-vG6SvB6oYEhvgisZNFRmRCUkLz11c7rp+tbNTynGqc6mS1d5ATd/sGyV6W0KZZnXRKMTzZDRgQT3Ou9jhpAfUg=="],
 
     "@expo/metro-config/@expo/config/@expo/config-plugins": ["@expo/config-plugins@54.0.2", "", { "dependencies": { "@expo/config-types": "^54.0.8", "@expo/json-file": "~10.0.7", "@expo/plist": "^0.4.7", "@expo/sdk-runtime-versions": "^1.0.0", "chalk": "^4.1.2", "debug": "^4.3.5", "getenv": "^2.0.0", "glob": "^10.4.2", "resolve-from": "^5.0.0", "semver": "^7.5.4", "slash": "^3.0.0", "slugify": "^1.6.6", "xcode": "^3.0.1", "xml2js": "0.6.0" } }, "sha512-jD4qxFcURQUVsUFGMcbo63a/AnviK8WUGard+yrdQE3ZrB/aurn68SlApjirQQLEizhjI5Ar2ufqflOBlNpyPg=="],
@@ -2962,6 +2967,8 @@
     "@expo/prebuild-config/@expo/image-utils/fs-extra": ["fs-extra@9.0.0", "", { "dependencies": { "at-least-node": "^1.0.0", "graceful-fs": "^4.2.0", "jsonfile": "^6.0.1", "universalify": "^1.0.0" } }, "sha512-pmEYSk3vYsG/bF651KPUXZ+hvjpgWYw/Gc7W9NFUe3ZVLczKKWIij3IKpOrQcdw4TILtibFslZ0UmR8Vvzig4g=="],
 
     "@expo/steps/@expo/eas-build-job/semver": ["semver@7.7.2", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA=="],
+
+    "@expo/steps/@expo/eas-build-job/zod": ["zod@4.2.1", "", {}, "sha512-0wZ1IRqGGhMP76gLqz8EyfBXKk0J2qo2+H3fi4mcUP/KtTocoX08nmIAHl1Z2kJIZbZee8KOpBCSNPRgauucjw=="],
 
     "@expo/xcpretty/js-yaml/argparse": ["argparse@2.0.1", "", {}, "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="],
 

--- a/components/settings/ConfigureToolsSheet.tsx
+++ b/components/settings/ConfigureToolsSheet.tsx
@@ -1,15 +1,12 @@
 import React, { useCallback, useMemo, useState } from "react";
-import { Alert, StyleSheet, View } from "react-native";
+import { StyleSheet, View } from "react-native";
 
 import { BottomSheet } from "../ui/BottomSheet";
 import { ConfigurePromptModal } from "./ConfigurePromptModal";
+import { LanguageLessonConfigModal } from "./LanguageLessonConfigModal";
 import { ToolGroupList, type ToolGroup } from "./ToolGroupList";
 import { ToolList, type Tool } from "./ToolList";
-import {
-  CONNECTOR_OPTIONS,
-  type ConnectorId,
-  type ConnectorOption,
-} from "./connectorOptions";
+import { CONNECTOR_OPTIONS, type ConnectorOption } from "./connectorOptions";
 import {
   loadToolPromptAddition,
   saveToolPromptAddition,
@@ -24,6 +21,35 @@ export interface ConfigureToolsSheetProps {
 
 type ViewMode = "groups" | "tools";
 
+type GroupDisplayOption = Pick<
+  ConnectorOption,
+  "name" | "icon" | "backgroundColor" | "iconBackgroundColor"
+>;
+
+const DEFAULT_GROUP_OPTION: GroupDisplayOption = {
+  name: "",
+  icon: "🛠️",
+  backgroundColor: "#F5F5F7",
+  iconBackgroundColor: "#ECECF0",
+};
+
+const GROUP_OPTION_OVERRIDES: Record<string, Partial<GroupDisplayOption>> = {
+  language_lesson: {
+    name: "Language Lesson",
+    icon: "🧠",
+    backgroundColor: "#ECF6FF",
+    iconBackgroundColor: "#D7EAFF",
+  },
+};
+
+function humanizeGroupName(groupId: string): string {
+  return groupId
+    .split("_")
+    .filter((segment) => segment.length > 0)
+    .map((segment) => segment.charAt(0).toUpperCase() + segment.slice(1))
+    .join(" ");
+}
+
 export const ConfigureToolsSheet: React.FC<ConfigureToolsSheetProps> = ({
   visible,
   onClose,
@@ -34,6 +60,8 @@ export const ConfigureToolsSheet: React.FC<ConfigureToolsSheetProps> = ({
   const [activeTool, setActiveTool] = useState<Tool | null>(null);
   const [promptDrafts, setPromptDrafts] = useState<Record<string, string>>({});
   const [isGroupPrompt, setIsGroupPrompt] = useState(false);
+  const [languageLessonConfigVisible, setLanguageLessonConfigVisible] =
+    useState(false);
 
   // Build tool groups from toolkitGroups.json
   const toolGroups = useMemo(() => {
@@ -43,12 +71,14 @@ export const ConfigureToolsSheet: React.FC<ConfigureToolsSheetProps> = ({
     Object.keys(toolkitGroups).forEach((groupKey) => {
       const group = toolkitGroups[groupKey as keyof typeof toolkitGroups];
       const connectorOption = CONNECTOR_OPTIONS.find(
-        (opt) => opt.id === (groupKey as ConnectorId),
+        (opt) => opt.id === groupKey,
       );
-
-      if (!connectorOption) {
-        return;
-      }
+      const overrideOption = GROUP_OPTION_OVERRIDES[groupKey] || {};
+      const mergedOption: GroupDisplayOption = {
+        ...DEFAULT_GROUP_OPTION,
+        ...connectorOption,
+        ...overrideOption,
+      };
 
       const toolkits = group.toolkits || [];
       const isRemoteMcp = toolkits.some(
@@ -57,10 +87,13 @@ export const ConfigureToolsSheet: React.FC<ConfigureToolsSheetProps> = ({
 
       groups.push({
         id: groupKey,
-        name: connectorOption.name,
-        icon: connectorOption.icon,
-        backgroundColor: connectorOption.backgroundColor,
-        iconBackgroundColor: connectorOption.iconBackgroundColor,
+        name:
+          mergedOption.name && mergedOption.name.length > 0
+            ? mergedOption.name
+            : humanizeGroupName(groupKey),
+        icon: mergedOption.icon,
+        backgroundColor: mergedOption.backgroundColor,
+        iconBackgroundColor: mergedOption.iconBackgroundColor,
         toolCount: isRemoteMcp ? 0 : toolkits.length,
         isRemoteMcp,
       });
@@ -161,6 +194,17 @@ export const ConfigureToolsSheet: React.FC<ConfigureToolsSheetProps> = ({
   };
 
   const handleToolPress = (tool: Tool) => {
+    if (
+      tool.group === "language_lesson" &&
+      tool.name === "get_next_language_exercise"
+    ) {
+      onClose();
+      requestAnimationFrame(() => {
+        setLanguageLessonConfigVisible(true);
+      });
+      return;
+    }
+
     onClose();
     requestAnimationFrame(() => {
       setActiveTool(tool);
@@ -276,6 +320,11 @@ export const ConfigureToolsSheet: React.FC<ConfigureToolsSheetProps> = ({
           }
         />
       ) : null}
+
+      <LanguageLessonConfigModal
+        visible={languageLessonConfigVisible}
+        onClose={() => setLanguageLessonConfigVisible(false)}
+      />
     </>
   );
 };

--- a/components/settings/ConfigureToolsSheet.tsx
+++ b/components/settings/ConfigureToolsSheet.tsx
@@ -42,6 +42,12 @@ const GROUP_OPTION_OVERRIDES: Record<string, Partial<GroupDisplayOption>> = {
   },
 };
 
+const LANGUAGE_LESSON_CONFIG_TOOL_NAMES = [
+  "start_first_exercise",
+  "grade_user_exercise",
+  "start_next_exercise",
+];
+
 function humanizeGroupName(groupId: string): string {
   return groupId
     .split("_")
@@ -196,7 +202,7 @@ export const ConfigureToolsSheet: React.FC<ConfigureToolsSheetProps> = ({
   const handleToolPress = (tool: Tool) => {
     if (
       tool.group === "language_lesson" &&
-      tool.name === "get_next_language_exercise"
+      LANGUAGE_LESSON_CONFIG_TOOL_NAMES.includes(tool.name)
     ) {
       onClose();
       requestAnimationFrame(() => {

--- a/components/settings/ConnectorsConfig.tsx
+++ b/components/settings/ConnectorsConfig.tsx
@@ -24,6 +24,7 @@ import { Context7ConnectorInfo } from "./Context7ConnectorInfo";
 import { DailyPapersConnectorInfo } from "./DailyPapersConnectorInfo";
 import { GithubLegacyConnectorInfo } from "./GithubLegacyConnectorInfo";
 import { GDriveLegacyConnectorInfo } from "./GDriveLegacyConnectorInfo";
+import { LanguageLessonConnectorInfo } from "./LanguageLessonConnectorInfo";
 
 export interface ConnectorsConfigProps {
   visible: boolean;
@@ -42,6 +43,8 @@ export const ConnectorsConfig: React.FC<ConnectorsConfigProps> = ({
   const [deepwikiInfoVisible, setDeepwikiInfoVisible] = useState(false);
   const [context7InfoVisible, setContext7InfoVisible] = useState(false);
   const [dailyPapersInfoVisible, setDailyPapersInfoVisible] = useState(false);
+  const [languageLessonInfoVisible, setLanguageLessonInfoVisible] =
+    useState(false);
   const [githubLegacyInfoVisible, setGithubLegacyInfoVisible] = useState(false);
   const [gdriveLegacyInfoVisible, setGDriveLegacyInfoVisible] = useState(false);
 
@@ -60,6 +63,8 @@ export const ConnectorsConfig: React.FC<ConnectorsConfigProps> = ({
       setContext7InfoVisible(true);
     } else if (connectorId === "daily_papers") {
       setDailyPapersInfoVisible(true);
+    } else if (connectorId === "language_lesson") {
+      setLanguageLessonInfoVisible(true);
     } else if (connectorId === "github_legacy") {
       setGithubLegacyInfoVisible(true);
     } else if (connectorId === "gdrive_legacy") {
@@ -173,6 +178,11 @@ export const ConnectorsConfig: React.FC<ConnectorsConfigProps> = ({
       <DailyPapersConnectorInfo
         visible={dailyPapersInfoVisible}
         onClose={() => setDailyPapersInfoVisible(false)}
+      />
+
+      <LanguageLessonConnectorInfo
+        visible={languageLessonInfoVisible}
+        onClose={() => setLanguageLessonInfoVisible(false)}
       />
 
       <GithubLegacyConnectorInfo

--- a/components/settings/LanguageLessonConfigModal.tsx
+++ b/components/settings/LanguageLessonConfigModal.tsx
@@ -1,0 +1,265 @@
+import React, { useCallback, useEffect, useState } from "react";
+import {
+  Alert,
+  KeyboardAvoidingView,
+  Modal,
+  Platform,
+  Pressable,
+  SafeAreaView,
+  StyleSheet,
+  Text,
+  TextInput,
+  View,
+} from "react-native";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
+import {
+  loadLanguageLessonExercisesJson,
+  saveLanguageLessonExercisesJson,
+} from "../../lib/languageLessonConfig";
+import { log } from "../../lib/logger";
+
+export interface LanguageLessonConfigModalProps {
+  visible: boolean;
+  onClose: () => void;
+}
+
+export const LanguageLessonConfigModal: React.FC<
+  LanguageLessonConfigModalProps
+> = ({ visible, onClose }) => {
+  const insets = useSafeAreaInsets();
+  const [jsonText, setJsonText] = useState("");
+  const [isLoading, setIsLoading] = useState(false);
+  const [isSaving, setIsSaving] = useState(false);
+
+  useEffect(() => {
+    if (!visible) {
+      return;
+    }
+
+    let isMounted = true;
+
+    const loadStoredConfig = async () => {
+      try {
+        setIsLoading(true);
+        const stored = await loadLanguageLessonExercisesJson();
+        if (!isMounted) {
+          return;
+        }
+        setJsonText(stored);
+      } catch (error) {
+        log.error(
+          "[LanguageLessonConfigModal] Failed loading stored JSON",
+          {},
+          {
+            errorMessage: error instanceof Error ? error.message : String(error),
+          },
+          error instanceof Error ? error : new Error(String(error)),
+        );
+      } finally {
+        if (isMounted) {
+          setIsLoading(false);
+        }
+      }
+    };
+
+    loadStoredConfig();
+
+    return () => {
+      isMounted = false;
+    };
+  }, [visible]);
+
+  const handleSave = useCallback(async () => {
+    if (isSaving) {
+      return;
+    }
+
+    const trimmed = jsonText.trim();
+
+    if (trimmed.length > 0) {
+      try {
+        JSON.parse(trimmed);
+      } catch (error) {
+        Alert.alert(
+          "Invalid JSON",
+          "Please paste valid JSON before saving.",
+        );
+        log.warn(
+          "[LanguageLessonConfigModal] Invalid JSON submitted",
+          {},
+          {
+            jsonText,
+            errorMessage: error instanceof Error ? error.message : String(error),
+          },
+        );
+        return;
+      }
+    }
+
+    try {
+      setIsSaving(true);
+      await saveLanguageLessonExercisesJson(jsonText);
+      Alert.alert("Saved", "Language lesson JSON has been saved.");
+      onClose();
+    } catch (error) {
+      log.error(
+        "[LanguageLessonConfigModal] Failed saving JSON",
+        {},
+        {
+          jsonText,
+          errorMessage: error instanceof Error ? error.message : String(error),
+        },
+        error instanceof Error ? error : new Error(String(error)),
+      );
+      Alert.alert("Save Failed", "Unable to save language lesson JSON.");
+    } finally {
+      setIsSaving(false);
+    }
+  }, [isSaving, jsonText, onClose]);
+
+  return (
+    <Modal
+      animationType="slide"
+      presentationStyle="pageSheet"
+      visible={visible}
+      onRequestClose={onClose}
+    >
+      <KeyboardAvoidingView
+        behavior={Platform.OS === "ios" ? "padding" : undefined}
+        style={styles.keyboardAvoider}
+        keyboardVerticalOffset={insets.top}
+      >
+        <SafeAreaView style={styles.safeArea}>
+          <View style={styles.header}>
+            <Pressable
+              onPress={onClose}
+              disabled={isSaving}
+              style={({ pressed }) => [
+                styles.headerAction,
+                pressed && styles.headerActionPressed,
+              ]}
+            >
+              <Text
+                style={[styles.headerActionText, isSaving && styles.disabledText]}
+              >
+                Cancel
+              </Text>
+            </Pressable>
+            <Text style={styles.headerTitle}>Language Lesson JSON</Text>
+            <Pressable
+              onPress={handleSave}
+              disabled={isSaving || isLoading}
+              style={({ pressed }) => [
+                styles.headerAction,
+                pressed &&
+                  !isSaving &&
+                  !isLoading &&
+                  styles.headerActionPressed,
+              ]}
+            >
+              <Text
+                style={[
+                  styles.headerActionText,
+                  styles.saveText,
+                  (isSaving || isLoading) && styles.disabledText,
+                ]}
+              >
+                {isSaving ? "Saving..." : "Save"}
+              </Text>
+            </Pressable>
+          </View>
+
+          <View style={styles.content}>
+            <Text style={styles.description}>
+              Paste the full exercises JSON used by the language lesson tool.
+            </Text>
+
+            <TextInput
+              style={styles.textArea}
+              value={jsonText}
+              onChangeText={setJsonText}
+              editable={!isLoading && !isSaving}
+              placeholder="Paste language_issues JSON here..."
+              placeholderTextColor="#8E8E93"
+              multiline
+              autoCorrect={false}
+              autoCapitalize="none"
+              spellCheck={false}
+              textAlignVertical="top"
+            />
+          </View>
+        </SafeAreaView>
+      </KeyboardAvoidingView>
+    </Modal>
+  );
+};
+
+const styles = StyleSheet.create({
+  keyboardAvoider: {
+    flex: 1,
+  },
+  safeArea: {
+    flex: 1,
+    backgroundColor: "#F5F5F7",
+  },
+  header: {
+    paddingHorizontal: 20,
+    paddingTop: 12,
+    paddingBottom: 14,
+    borderBottomWidth: 1,
+    borderBottomColor: "#E5E5EA",
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "space-between",
+  },
+  headerTitle: {
+    fontSize: 18,
+    fontWeight: "700",
+    color: "#1C1C1E",
+  },
+  headerAction: {
+    paddingVertical: 8,
+    paddingHorizontal: 6,
+    borderRadius: 8,
+    minWidth: 64,
+    alignItems: "center",
+  },
+  headerActionPressed: {
+    backgroundColor: "rgba(10, 132, 255, 0.12)",
+  },
+  headerActionText: {
+    fontSize: 16,
+    color: "#0A84FF",
+    fontWeight: "500",
+  },
+  saveText: {
+    fontWeight: "700",
+  },
+  disabledText: {
+    color: "#8E8E93",
+  },
+  content: {
+    flex: 1,
+    paddingHorizontal: 20,
+    paddingTop: 20,
+    paddingBottom: 20,
+    gap: 12,
+  },
+  description: {
+    fontSize: 15,
+    lineHeight: 21,
+    color: "#3A3A3C",
+  },
+  textArea: {
+    flex: 1,
+    borderWidth: 1,
+    borderColor: "#D1D1D6",
+    borderRadius: 12,
+    backgroundColor: "#FFFFFF",
+    padding: 14,
+    fontSize: 14,
+    lineHeight: 20,
+    color: "#1C1C1E",
+    fontFamily: Platform.OS === "ios" ? "Menlo" : "monospace",
+  },
+});

--- a/components/settings/LanguageLessonConfigModal.tsx
+++ b/components/settings/LanguageLessonConfigModal.tsx
@@ -11,6 +11,7 @@ import {
   TextInput,
   View,
 } from "react-native";
+import * as Clipboard from "expo-clipboard";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import {
   loadLanguageLessonExercisesJson,
@@ -51,7 +52,8 @@ export const LanguageLessonConfigModal: React.FC<
           "[LanguageLessonConfigModal] Failed loading stored JSON",
           {},
           {
-            errorMessage: error instanceof Error ? error.message : String(error),
+            errorMessage:
+              error instanceof Error ? error.message : String(error),
           },
           error instanceof Error ? error : new Error(String(error)),
         );
@@ -80,16 +82,14 @@ export const LanguageLessonConfigModal: React.FC<
       try {
         JSON.parse(trimmed);
       } catch (error) {
-        Alert.alert(
-          "Invalid JSON",
-          "Please paste valid JSON before saving.",
-        );
+        Alert.alert("Invalid JSON", "Please paste valid JSON before saving.");
         log.warn(
           "[LanguageLessonConfigModal] Invalid JSON submitted",
           {},
           {
             jsonText,
-            errorMessage: error instanceof Error ? error.message : String(error),
+            errorMessage:
+              error instanceof Error ? error.message : String(error),
           },
         );
         return;
@@ -117,6 +117,50 @@ export const LanguageLessonConfigModal: React.FC<
     }
   }, [isSaving, jsonText, onClose]);
 
+  const handleClear = useCallback(() => {
+    if (isLoading || isSaving) {
+      return;
+    }
+
+    log.info(
+      "[LanguageLessonConfigModal] Clearing JSON text",
+      {},
+      {
+        previousJsonText: jsonText,
+      },
+    );
+    setJsonText("");
+  }, [isLoading, isSaving, jsonText]);
+
+  const handleCopy = useCallback(async () => {
+    if (isLoading || isSaving) {
+      return;
+    }
+
+    try {
+      await Clipboard.setStringAsync(jsonText);
+      log.info(
+        "[LanguageLessonConfigModal] Copied JSON text to clipboard",
+        {},
+        {
+          jsonText,
+        },
+      );
+      Alert.alert("Copied", "Language lesson JSON copied to clipboard.");
+    } catch (error) {
+      log.error(
+        "[LanguageLessonConfigModal] Failed copying JSON to clipboard",
+        {},
+        {
+          jsonText,
+          errorMessage: error instanceof Error ? error.message : String(error),
+        },
+        error instanceof Error ? error : new Error(String(error)),
+      );
+      Alert.alert("Copy Failed", "Unable to copy language lesson JSON.");
+    }
+  }, [isLoading, isSaving, jsonText]);
+
   return (
     <Modal
       animationType="slide"
@@ -140,7 +184,10 @@ export const LanguageLessonConfigModal: React.FC<
               ]}
             >
               <Text
-                style={[styles.headerActionText, isSaving && styles.disabledText]}
+                style={[
+                  styles.headerActionText,
+                  isSaving && styles.disabledText,
+                ]}
               >
                 Cancel
               </Text>
@@ -173,6 +220,52 @@ export const LanguageLessonConfigModal: React.FC<
             <Text style={styles.description}>
               Paste the full exercises JSON used by the language lesson tool.
             </Text>
+
+            <View style={styles.actionRow}>
+              <Pressable
+                onPress={handleClear}
+                disabled={isLoading || isSaving}
+                style={({ pressed }) => [
+                  styles.actionButton,
+                  pressed &&
+                    !isLoading &&
+                    !isSaving &&
+                    styles.actionButtonPressed,
+                ]}
+              >
+                <Text
+                  style={[
+                    styles.actionButtonText,
+                    (isLoading || isSaving) && styles.disabledText,
+                  ]}
+                >
+                  ❌ Clear
+                </Text>
+              </Pressable>
+
+              <Pressable
+                onPress={handleCopy}
+                disabled={isLoading || isSaving || jsonText.length === 0}
+                style={({ pressed }) => [
+                  styles.actionButton,
+                  pressed &&
+                    !isLoading &&
+                    !isSaving &&
+                    jsonText.length > 0 &&
+                    styles.actionButtonPressed,
+                ]}
+              >
+                <Text
+                  style={[
+                    styles.actionButtonText,
+                    (isLoading || isSaving || jsonText.length === 0) &&
+                      styles.disabledText,
+                  ]}
+                >
+                  Copy
+                </Text>
+              </Pressable>
+            </View>
 
             <TextInput
               style={styles.textArea}
@@ -249,6 +342,26 @@ const styles = StyleSheet.create({
     fontSize: 15,
     lineHeight: 21,
     color: "#3A3A3C",
+  },
+  actionRow: {
+    flexDirection: "row",
+    gap: 10,
+  },
+  actionButton: {
+    borderWidth: 1,
+    borderColor: "#D1D1D6",
+    borderRadius: 10,
+    backgroundColor: "#FFFFFF",
+    paddingVertical: 8,
+    paddingHorizontal: 12,
+  },
+  actionButtonPressed: {
+    backgroundColor: "#F2F2F7",
+  },
+  actionButtonText: {
+    fontSize: 14,
+    color: "#0A84FF",
+    fontWeight: "600",
   },
   textArea: {
     flex: 1,

--- a/components/settings/LanguageLessonConfigModal.tsx
+++ b/components/settings/LanguageLessonConfigModal.tsx
@@ -16,6 +16,7 @@ import { useSafeAreaInsets } from "react-native-safe-area-context";
 import {
   loadLanguageLessonExercisesJson,
   saveLanguageLessonExercisesJson,
+  validateAndNormalizeLanguageLessonExercisesJson,
 } from "../../lib/languageLessonConfig";
 import { log } from "../../lib/logger";
 
@@ -76,29 +77,34 @@ export const LanguageLessonConfigModal: React.FC<
       return;
     }
 
-    const trimmed = jsonText.trim();
+    const validationResult =
+      validateAndNormalizeLanguageLessonExercisesJson(jsonText);
 
-    if (trimmed.length > 0) {
-      try {
-        JSON.parse(trimmed);
-      } catch (error) {
-        Alert.alert("Invalid JSON", "Please paste valid JSON before saving.");
-        log.warn(
-          "[LanguageLessonConfigModal] Invalid JSON submitted",
-          {},
-          {
-            jsonText,
-            errorMessage:
-              error instanceof Error ? error.message : String(error),
-          },
-        );
-        return;
-      }
+    if (!validationResult.success || !validationResult.normalizedJson) {
+      const validationMessage = validationResult.validationErrors
+        .slice(0, 3)
+        .join("\n");
+
+      Alert.alert(
+        "Invalid Lesson JSON",
+        validationMessage.length > 0
+          ? validationMessage
+          : "Please fix the lesson JSON before saving.",
+      );
+      log.warn(
+        "[LanguageLessonConfigModal] Invalid language lesson config submitted",
+        {},
+        {
+          jsonText,
+          validationErrors: validationResult.validationErrors,
+        },
+      );
+      return;
     }
 
     try {
       setIsSaving(true);
-      await saveLanguageLessonExercisesJson(jsonText);
+      await saveLanguageLessonExercisesJson(validationResult.normalizedJson);
       Alert.alert("Saved", "Language lesson JSON has been saved.");
       onClose();
     } catch (error) {

--- a/components/settings/LanguageLessonConnectorInfo.tsx
+++ b/components/settings/LanguageLessonConnectorInfo.tsx
@@ -1,0 +1,162 @@
+import React, { useEffect, useState } from "react";
+import {
+  DeviceEventEmitter,
+  Modal,
+  Pressable,
+  SafeAreaView,
+  StyleSheet,
+  Switch,
+  Text,
+  View,
+} from "react-native";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
+import AsyncStorage from "@react-native-async-storage/async-storage";
+import { CONNECTOR_SETTINGS_CHANGED_EVENT } from "@/modules/vm-webrtc";
+
+type LanguageLessonConnectorInfoProps = {
+  visible: boolean;
+  onClose: () => void;
+};
+
+export const LanguageLessonConnectorInfo: React.FC<
+  LanguageLessonConnectorInfoProps
+> = ({ visible, onClose }) => {
+  const insets = useSafeAreaInsets();
+  const [isEnabled, setIsEnabled] = useState(false);
+
+  useEffect(() => {
+    if (visible) {
+      const loadEnabled = async () => {
+        try {
+          const enabledValue = await AsyncStorage.getItem(
+            "language_lesson_connector_enabled",
+          );
+          setIsEnabled(enabledValue === null ? false : enabledValue === "true");
+        } catch {
+          // ignore errors
+        }
+      };
+      loadEnabled();
+    }
+  }, [visible]);
+
+  const handleToggleEnabled = async (value: boolean) => {
+    setIsEnabled(value);
+    try {
+      await AsyncStorage.setItem(
+        "language_lesson_connector_enabled",
+        value.toString(),
+      );
+      DeviceEventEmitter.emit(CONNECTOR_SETTINGS_CHANGED_EVENT);
+    } catch {
+      // ignore errors
+    }
+  };
+
+  return (
+    <Modal
+      animationType="slide"
+      presentationStyle="pageSheet"
+      visible={visible}
+      onRequestClose={onClose}
+    >
+      <SafeAreaView style={styles.safeArea}>
+        <View style={styles.header}>
+          <Text style={styles.headerTitle}>Language Lesson</Text>
+          <Pressable
+            onPress={onClose}
+            style={({ pressed }) => [
+              styles.headerAction,
+              pressed && styles.headerActionPressed,
+            ]}
+          >
+            <Text style={styles.headerActionText}>Done</Text>
+          </Pressable>
+        </View>
+
+        <View
+          style={[
+            styles.content,
+            { paddingBottom: insets.bottom > 0 ? insets.bottom : 24 },
+          ]}
+        >
+          <View style={styles.enableSection}>
+            <Text style={styles.enableLabel}>Enable Language Lesson</Text>
+            <Switch
+              value={isEnabled}
+              onValueChange={handleToggleEnabled}
+              trackColor={{ false: "#E5E5EA", true: "#34C759" }}
+              thumbColor="#FFFFFF"
+            />
+          </View>
+
+          <Text style={styles.bodyText}>
+            This enables the language lesson toolkit group. Use Configure Tools
+            to paste or update the lesson JSON content.
+          </Text>
+        </View>
+      </SafeAreaView>
+    </Modal>
+  );
+};
+
+const styles = StyleSheet.create({
+  safeArea: {
+    flex: 1,
+    backgroundColor: "#F5F5F7",
+  },
+  header: {
+    paddingHorizontal: 24,
+    paddingTop: 12,
+    paddingBottom: 16,
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "space-between",
+    borderBottomWidth: 1,
+    borderBottomColor: "#E5E5EA",
+  },
+  headerTitle: {
+    fontSize: 24,
+    fontWeight: "700",
+    color: "#1C1C1E",
+  },
+  headerAction: {
+    paddingVertical: 8,
+    paddingHorizontal: 4,
+    borderRadius: 8,
+  },
+  headerActionPressed: {
+    backgroundColor: "rgba(10, 132, 255, 0.08)",
+  },
+  headerActionText: {
+    color: "#0A84FF",
+    fontSize: 16,
+    fontWeight: "600",
+  },
+  content: {
+    flex: 1,
+    paddingHorizontal: 24,
+    paddingTop: 24,
+  },
+  enableSection: {
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "space-between",
+    backgroundColor: "#FFFFFF",
+    borderRadius: 12,
+    paddingVertical: 14,
+    paddingHorizontal: 16,
+    marginBottom: 24,
+  },
+  enableLabel: {
+    fontSize: 16,
+    fontWeight: "600",
+    color: "#1C1C1E",
+  },
+  bodyText: {
+    fontSize: 17,
+    lineHeight: 24,
+    color: "#1C1C1E",
+    textAlign: "left",
+  },
+});

--- a/components/settings/LanguageLessonConnectorInfo.tsx
+++ b/components/settings/LanguageLessonConnectorInfo.tsx
@@ -12,6 +12,7 @@ import {
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import AsyncStorage from "@react-native-async-storage/async-storage";
 import { CONNECTOR_SETTINGS_CHANGED_EVENT } from "@/modules/vm-webrtc";
+import { LanguageLessonConfigModal } from "./LanguageLessonConfigModal";
 
 type LanguageLessonConnectorInfoProps = {
   visible: boolean;
@@ -23,6 +24,7 @@ export const LanguageLessonConnectorInfo: React.FC<
 > = ({ visible, onClose }) => {
   const insets = useSafeAreaInsets();
   const [isEnabled, setIsEnabled] = useState(false);
+  const [configModalVisible, setConfigModalVisible] = useState(false);
 
   useEffect(() => {
     if (visible) {
@@ -91,11 +93,33 @@ export const LanguageLessonConnectorInfo: React.FC<
           </View>
 
           <Text style={styles.bodyText}>
-            This enables the language lesson toolkit group. Use Configure Tools
-            to paste or update the lesson JSON content.
+            This enables the language lesson toolkit group. The lesson JSON is
+            shared across all language lesson tools.
           </Text>
+
+          <View style={styles.jsonSection}>
+            <Text style={styles.jsonTitle}>Lesson JSON</Text>
+            <Text style={styles.jsonDescription}>
+              Paste or update your lesson JSON for the entire language lesson
+              flow.
+            </Text>
+            <Pressable
+              onPress={() => setConfigModalVisible(true)}
+              style={({ pressed }) => [
+                styles.editButton,
+                pressed && styles.editButtonPressed,
+              ]}
+            >
+              <Text style={styles.editButtonText}>Edit Lesson JSON</Text>
+            </Pressable>
+          </View>
         </View>
       </SafeAreaView>
+
+      <LanguageLessonConfigModal
+        visible={configModalVisible}
+        onClose={() => setConfigModalVisible(false)}
+      />
     </Modal>
   );
 };
@@ -158,5 +182,38 @@ const styles = StyleSheet.create({
     lineHeight: 24,
     color: "#1C1C1E",
     textAlign: "left",
+    marginBottom: 24,
+  },
+  jsonSection: {
+    backgroundColor: "#FFFFFF",
+    borderRadius: 12,
+    paddingHorizontal: 16,
+    paddingVertical: 16,
+    gap: 10,
+  },
+  jsonTitle: {
+    fontSize: 17,
+    fontWeight: "700",
+    color: "#1C1C1E",
+  },
+  jsonDescription: {
+    fontSize: 15,
+    lineHeight: 21,
+    color: "#3A3A3C",
+  },
+  editButton: {
+    alignSelf: "flex-start",
+    backgroundColor: "#0A84FF",
+    borderRadius: 10,
+    paddingHorizontal: 14,
+    paddingVertical: 10,
+  },
+  editButtonPressed: {
+    opacity: 0.85,
+  },
+  editButtonText: {
+    fontSize: 15,
+    fontWeight: "600",
+    color: "#FFFFFF",
   },
 });

--- a/components/settings/LanguageLessonConnectorInfo.tsx
+++ b/components/settings/LanguageLessonConnectorInfo.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from "react";
 import {
+  Alert,
   DeviceEventEmitter,
   Modal,
   Pressable,
@@ -12,6 +13,7 @@ import {
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import AsyncStorage from "@react-native-async-storage/async-storage";
 import { CONNECTOR_SETTINGS_CHANGED_EVENT } from "@/modules/vm-webrtc";
+import { log } from "../../lib/logger";
 import { LanguageLessonConfigModal } from "./LanguageLessonConfigModal";
 
 type LanguageLessonConnectorInfoProps = {
@@ -34,8 +36,15 @@ export const LanguageLessonConnectorInfo: React.FC<
             "language_lesson_connector_enabled",
           );
           setIsEnabled(enabledValue === null ? false : enabledValue === "true");
-        } catch {
-          // ignore errors
+        } catch (error) {
+          log.warn(
+            "[LanguageLessonConnectorInfo] Failed to load enabled state",
+            {},
+            {
+              errorMessage:
+                error instanceof Error ? error.message : String(error),
+            },
+          );
         }
       };
       loadEnabled();
@@ -43,15 +52,31 @@ export const LanguageLessonConnectorInfo: React.FC<
   }, [visible]);
 
   const handleToggleEnabled = async (value: boolean) => {
+    const previous = isEnabled;
     setIsEnabled(value);
+
     try {
       await AsyncStorage.setItem(
         "language_lesson_connector_enabled",
         value.toString(),
       );
       DeviceEventEmitter.emit(CONNECTOR_SETTINGS_CHANGED_EVENT);
-    } catch {
-      // ignore errors
+    } catch (error) {
+      setIsEnabled(previous);
+      log.error(
+        "[LanguageLessonConnectorInfo] Failed to persist enabled state",
+        {},
+        {
+          previous,
+          attemptedValue: value,
+          errorMessage: error instanceof Error ? error.message : String(error),
+        },
+        error instanceof Error ? error : new Error(String(error)),
+      );
+      Alert.alert(
+        "Update Failed",
+        "Could not update the Language Lesson setting.",
+      );
     }
   };
 

--- a/components/settings/connectorOptions.ts
+++ b/components/settings/connectorOptions.ts
@@ -6,6 +6,7 @@ export type ConnectorId =
   | "deepwiki"
   | "context7"
   | "daily_papers"
+  | "language_lesson"
   | "github_legacy"
   | "gdrive_legacy";
 
@@ -67,6 +68,13 @@ export const CONNECTOR_OPTIONS: ConnectorOption[] = [
     icon: "📰",
     backgroundColor: "#FFF0F5",
     iconBackgroundColor: "#FFE4EC",
+  },
+  {
+    id: "language_lesson",
+    name: "Language Lesson",
+    icon: "🗣️",
+    backgroundColor: "#EEF7FF",
+    iconBackgroundColor: "#DDEEFF",
   },
   {
     id: "github_legacy",

--- a/lib/languageLessonConfig.ts
+++ b/lib/languageLessonConfig.ts
@@ -165,3 +165,16 @@ export async function saveLanguageLessonExercisesJson(
     },
   );
 }
+
+export async function saveLanguageLessonConfigRaw(
+  value: string,
+): Promise<void> {
+  await saveLanguageLessonExercisesJson(value);
+}
+
+export async function saveParsedLanguageLessonConfig(
+  config: NormalizedLanguageLessonConfig,
+): Promise<void> {
+  const raw = JSON.stringify(config, null, 2);
+  await saveLanguageLessonExercisesJson(raw);
+}

--- a/lib/languageLessonConfig.ts
+++ b/lib/languageLessonConfig.ts
@@ -1,0 +1,39 @@
+import AsyncStorage from "@react-native-async-storage/async-storage";
+import { log } from "./logger";
+
+const LANGUAGE_LESSON_EXERCISES_JSON_KEY =
+  "@vibemachine/language_lesson/exercises_json";
+
+export async function loadLanguageLessonExercisesJson(): Promise<string> {
+  try {
+    const stored = await AsyncStorage.getItem(
+      LANGUAGE_LESSON_EXERCISES_JSON_KEY,
+    );
+    return stored ?? "";
+  } catch (error) {
+    log.error(
+      "[LanguageLessonConfig] Failed to load exercises JSON",
+      {},
+      {
+        errorMessage: error instanceof Error ? error.message : String(error),
+      },
+      error instanceof Error ? error : new Error(String(error)),
+    );
+    return "";
+  }
+}
+
+export async function saveLanguageLessonExercisesJson(
+  value: string,
+): Promise<void> {
+  await AsyncStorage.setItem(LANGUAGE_LESSON_EXERCISES_JSON_KEY, value);
+
+  log.info(
+    "[LanguageLessonConfig] Saved exercises JSON",
+    {},
+    {
+      value,
+      valueLength: value.length,
+    },
+  );
+}

--- a/lib/languageLessonConfig.ts
+++ b/lib/languageLessonConfig.ts
@@ -20,6 +20,43 @@ export interface LoadParsedLanguageLessonConfigResult {
   parsedConfig: NormalizedLanguageLessonConfig | null;
   summary: LanguageLessonConfigSummary;
   validationErrors: string[];
+  hashError: string | null;
+}
+
+export type ValidateLanguageLessonExercisesJsonResult =
+  | {
+      success: true;
+      normalizedJson: string;
+      parsedConfig: NormalizedLanguageLessonConfig;
+      validationErrors: [];
+    }
+  | {
+      success: false;
+      normalizedJson: null;
+      parsedConfig: null;
+      validationErrors: string[];
+    };
+
+export function validateAndNormalizeLanguageLessonExercisesJson(
+  raw: string,
+): ValidateLanguageLessonExercisesJsonResult {
+  const parseResult = parseAndNormalizeLanguageLessonConfig(raw);
+
+  if (!parseResult.success || !parseResult.data) {
+    return {
+      success: false,
+      normalizedJson: null,
+      parsedConfig: null,
+      validationErrors: parseResult.errors,
+    };
+  }
+
+  return {
+    success: true,
+    normalizedJson: JSON.stringify(parseResult.data, null, 2),
+    parsedConfig: parseResult.data,
+    validationErrors: [],
+  };
 }
 
 function summarizeLanguageLessonConfig(
@@ -74,15 +111,15 @@ export async function loadLanguageLessonExercisesJson(): Promise<string> {
 
 export async function loadParsedLanguageLessonConfig(): Promise<LoadParsedLanguageLessonConfigResult> {
   const raw = await loadLanguageLessonConfigRaw();
-  const parseResult = parseAndNormalizeLanguageLessonConfig(raw);
+  const validationResult = validateAndNormalizeLanguageLessonExercisesJson(raw);
 
-  if (!parseResult.success || !parseResult.data) {
+  if (!validationResult.success || !validationResult.parsedConfig) {
     log.warn(
       "[LanguageLessonConfig] Parsed language lesson config is invalid",
       {},
       {
         raw,
-        parseResult,
+        validationErrors: validationResult.validationErrors,
       },
     );
 
@@ -94,12 +131,13 @@ export async function loadParsedLanguageLessonConfig(): Promise<LoadParsedLangua
         issueCount: 0,
         exerciseCount: 0,
       },
-      validationErrors: parseResult.errors,
+      validationErrors: validationResult.validationErrors,
+      hashError: null,
     };
   }
 
-  const summary = summarizeLanguageLessonConfig(parseResult.data);
-  const canonicalNormalizedJson = JSON.stringify(parseResult.data);
+  const summary = summarizeLanguageLessonConfig(validationResult.parsedConfig);
+  const canonicalNormalizedJson = JSON.stringify(validationResult.parsedConfig);
 
   try {
     const hash = await Crypto.digestStringAsync(
@@ -113,7 +151,7 @@ export async function loadParsedLanguageLessonConfig(): Promise<LoadParsedLangua
       {
         raw,
         hash,
-        parsedConfig: parseResult.data,
+        parsedConfig: validationResult.parsedConfig,
         summary,
       },
     );
@@ -121,9 +159,10 @@ export async function loadParsedLanguageLessonConfig(): Promise<LoadParsedLangua
     return {
       raw,
       hash,
-      parsedConfig: parseResult.data,
+      parsedConfig: validationResult.parsedConfig,
       summary,
       validationErrors: [],
+      hashError: null,
     };
   } catch (error) {
     const hashErrorMessage = `Failed to hash normalized language lesson config - ${error instanceof Error ? error.message : String(error)}`;
@@ -133,7 +172,7 @@ export async function loadParsedLanguageLessonConfig(): Promise<LoadParsedLangua
       {},
       {
         raw,
-        parsedConfig: parseResult.data,
+        parsedConfig: validationResult.parsedConfig,
         summary,
         canonicalNormalizedJson,
         hashErrorMessage,
@@ -144,9 +183,10 @@ export async function loadParsedLanguageLessonConfig(): Promise<LoadParsedLangua
     return {
       raw,
       hash: null,
-      parsedConfig: parseResult.data,
+      parsedConfig: validationResult.parsedConfig,
       summary,
-      validationErrors: [hashErrorMessage],
+      validationErrors: [],
+      hashError: hashErrorMessage,
     };
   }
 }
@@ -154,14 +194,37 @@ export async function loadParsedLanguageLessonConfig(): Promise<LoadParsedLangua
 export async function saveLanguageLessonExercisesJson(
   value: string,
 ): Promise<void> {
-  await AsyncStorage.setItem(LANGUAGE_LESSON_EXERCISES_JSON_KEY, value);
+  const validationResult =
+    validateAndNormalizeLanguageLessonExercisesJson(value);
+
+  if (!validationResult.success || !validationResult.normalizedJson) {
+    log.warn(
+      "[LanguageLessonConfig] Rejected invalid exercises JSON save",
+      {},
+      {
+        value,
+        validationErrors: validationResult.validationErrors,
+      },
+    );
+
+    throw new Error(
+      `Invalid language lesson config: ${validationResult.validationErrors.join(" | ")}`,
+    );
+  }
+
+  await AsyncStorage.setItem(
+    LANGUAGE_LESSON_EXERCISES_JSON_KEY,
+    validationResult.normalizedJson,
+  );
 
   log.info(
     "[LanguageLessonConfig] Saved exercises JSON",
     {},
     {
       value,
+      normalizedValue: validationResult.normalizedJson,
       valueLength: value.length,
+      normalizedValueLength: validationResult.normalizedJson.length,
     },
   );
 }

--- a/lib/languageLessonConfig.ts
+++ b/lib/languageLessonConfig.ts
@@ -1,18 +1,62 @@
 import AsyncStorage from "@react-native-async-storage/async-storage";
+import * as Crypto from "expo-crypto";
+import {
+  parseAndNormalizeLanguageLessonConfig,
+  type NormalizedLanguageLessonConfig,
+} from "../modules/vm-webrtc/src/toolkit_functions/language_lesson_schema";
 import { log } from "./logger";
 
 const LANGUAGE_LESSON_EXERCISES_JSON_KEY =
   "@vibemachine/language_lesson/exercises_json";
 
-export async function loadLanguageLessonExercisesJson(): Promise<string> {
+export interface LanguageLessonConfigSummary {
+  issueCount: number;
+  exerciseCount: number;
+}
+
+export interface LoadParsedLanguageLessonConfigResult {
+  raw: string;
+  hash: string | null;
+  parsedConfig: NormalizedLanguageLessonConfig | null;
+  summary: LanguageLessonConfigSummary;
+  validationErrors: string[];
+}
+
+function summarizeLanguageLessonConfig(
+  config: NormalizedLanguageLessonConfig,
+): LanguageLessonConfigSummary {
+  const issueCount = config.language_issues.length;
+  const exerciseCount = config.language_issues.reduce(
+    (total, issue) => total + issue.exercises.length,
+    0,
+  );
+
+  return {
+    issueCount,
+    exerciseCount,
+  };
+}
+
+export async function loadLanguageLessonConfigRaw(): Promise<string> {
   try {
     const stored = await AsyncStorage.getItem(
       LANGUAGE_LESSON_EXERCISES_JSON_KEY,
     );
+
+    log.info(
+      "[LanguageLessonConfig] Loaded raw language lesson JSON",
+      {},
+      {
+        storageKey: LANGUAGE_LESSON_EXERCISES_JSON_KEY,
+        stored,
+        storedLength: stored?.length ?? 0,
+      },
+    );
+
     return stored ?? "";
   } catch (error) {
     log.error(
-      "[LanguageLessonConfig] Failed to load exercises JSON",
+      "[LanguageLessonConfig] Failed to load raw language lesson JSON",
       {},
       {
         errorMessage: error instanceof Error ? error.message : String(error),
@@ -20,6 +64,90 @@ export async function loadLanguageLessonExercisesJson(): Promise<string> {
       error instanceof Error ? error : new Error(String(error)),
     );
     return "";
+  }
+}
+
+// Backward-compatible alias used by existing UI.
+export async function loadLanguageLessonExercisesJson(): Promise<string> {
+  return loadLanguageLessonConfigRaw();
+}
+
+export async function loadParsedLanguageLessonConfig(): Promise<LoadParsedLanguageLessonConfigResult> {
+  const raw = await loadLanguageLessonConfigRaw();
+  const parseResult = parseAndNormalizeLanguageLessonConfig(raw);
+
+  if (!parseResult.success || !parseResult.data) {
+    log.warn(
+      "[LanguageLessonConfig] Parsed language lesson config is invalid",
+      {},
+      {
+        raw,
+        parseResult,
+      },
+    );
+
+    return {
+      raw,
+      hash: null,
+      parsedConfig: null,
+      summary: {
+        issueCount: 0,
+        exerciseCount: 0,
+      },
+      validationErrors: parseResult.errors,
+    };
+  }
+
+  const summary = summarizeLanguageLessonConfig(parseResult.data);
+  const canonicalNormalizedJson = JSON.stringify(parseResult.data);
+
+  try {
+    const hash = await Crypto.digestStringAsync(
+      Crypto.CryptoDigestAlgorithm.SHA256,
+      canonicalNormalizedJson,
+    );
+
+    log.info(
+      "[LanguageLessonConfig] Parsed language lesson config loaded",
+      {},
+      {
+        raw,
+        hash,
+        parsedConfig: parseResult.data,
+        summary,
+      },
+    );
+
+    return {
+      raw,
+      hash,
+      parsedConfig: parseResult.data,
+      summary,
+      validationErrors: [],
+    };
+  } catch (error) {
+    const hashErrorMessage = `Failed to hash normalized language lesson config - ${error instanceof Error ? error.message : String(error)}`;
+
+    log.error(
+      "[LanguageLessonConfig] Failed to hash normalized language lesson config",
+      {},
+      {
+        raw,
+        parsedConfig: parseResult.data,
+        summary,
+        canonicalNormalizedJson,
+        hashErrorMessage,
+      },
+      error instanceof Error ? error : new Error(String(error)),
+    );
+
+    return {
+      raw,
+      hash: null,
+      parsedConfig: parseResult.data,
+      summary,
+      validationErrors: [hashErrorMessage],
+    };
   }
 }
 

--- a/modules/vm-webrtc/src/ToolkitManager.ts
+++ b/modules/vm-webrtc/src/ToolkitManager.ts
@@ -41,15 +41,17 @@ function getConnectorStorageKey(groupName: string): string {
 
 /**
  * Check if a toolkit group is enabled based on stored settings.
- * Returns true by default if no setting is found, except for legacy connectors which default to false.
+ * Returns true by default if no setting is found, except for
+ * legacy connectors and explicitly default-disabled groups.
  */
 async function isToolkitGroupEnabled(groupName: string): Promise<boolean> {
   const storageKey = getConnectorStorageKey(groupName);
 
-  // Legacy connectors default to disabled
+  // Legacy connectors and selected groups default to disabled
   const isLegacyConnector =
     groupName === "github_legacy" || groupName === "gdrive_legacy";
-  const defaultEnabled = !isLegacyConnector;
+  const isDefaultDisabledGroup = groupName === "language_lesson";
+  const defaultEnabled = !isLegacyConnector && !isDefaultDisabledGroup;
 
   try {
     const enabledValue = await AsyncStorage.getItem(storageKey);
@@ -66,6 +68,7 @@ async function isToolkitGroupEnabled(groupName: string): Promise<boolean> {
         enabledValue,
         isEnabled,
         isLegacyConnector,
+        isDefaultDisabledGroup,
         defaultEnabled,
       },
     );

--- a/modules/vm-webrtc/src/toolkit_functions/language_lesson.ts
+++ b/modules/vm-webrtc/src/toolkit_functions/language_lesson.ts
@@ -209,7 +209,7 @@ function buildIssuePayload(issue: LanguageIssue): LanguageIssuePayload {
 function buildNextActionSuggestion(status: LanguageExerciseToolStatus): string {
   switch (status) {
     case "next_exercise_ready":
-      return "Assume the user wants to keep going, so give the next exercise to the user.";
+      return "Assume the user wants to keep going, so give the next exercise to the user. The next exercise details are in the next_exercise field.";
     case "all_exercises_finished":
       return "Congratulate the user for finishing all exercises and ask if they want to practice a new issue.";
     case "no_exercises_available":
@@ -763,7 +763,7 @@ async function handleFollowUpCall(
     status: "next_exercise_ready",
     mode: "follow_up",
     message:
-      "Previous exercise was marked finished and persisted. Returning the next exercise to give to the user. The exercise details are in the next_exercise field, and see the issue field for more context.",
+      "Previous exercise was marked finished and persisted. Returning the next exercise to give to the user. The next exercise details are in the next_exercise field, and see the issue field for more context.",
     config_hash: reloadOutcome.reloadedConfigResult.hash,
     summary: reloadOutcome.reloadedConfigResult.summary,
     progress: progressAfter,
@@ -858,7 +858,8 @@ function handleInitialCall(
   const returnPayload = buildLanguageExerciseToolResponse({
     status: "next_exercise_ready",
     mode: "initial",
-    message: "Returning next unfinished exercise.",
+    message:
+      "Returning the next exercise to give to the user. The next exercise details are in the next_exercise field.",
     config_hash: loadedConfigState.parsedConfigResult.hash,
     summary: loadedConfigState.parsedConfigResult.summary,
     progress: loadedConfigState.progressBefore,

--- a/modules/vm-webrtc/src/toolkit_functions/language_lesson.ts
+++ b/modules/vm-webrtc/src/toolkit_functions/language_lesson.ts
@@ -226,11 +226,11 @@ function buildNextActionSuggestion(status: LanguageExerciseToolStatus): string {
     case "all_exercises_finished":
       return "Congratulate the user for finishing all exercises and ask if they want to practice a new issue.";
     case "no_exercises_available":
-      return "Tell the user no exercises are currently configured and ask them to add language lesson JSON in Configure Tools.";
+      return "Tell the user no exercises are currently configured and ask them to add language lesson JSON in Language Lesson settings.";
     case "invalid_follow_up_input":
       return "Apologize to the user and tell them we hit an internal error that is not their fault. Ask them what they want help with next.";
     case "config_invalid":
-      return "Tell the user the lesson JSON is invalid or missing and ask them to fix it in Configure Tools.";
+      return "Tell the user the lesson JSON is invalid or missing and ask them to fix it in Language Lesson settings.";
     case "persist_failed":
     case "persist_reload_invalid":
       return "Tell the user progress could not be saved reliably and ask them to retry the exercise flow.";
@@ -366,7 +366,7 @@ async function loadValidatedConfigOrResult(
       status: "config_invalid",
       mode,
       message:
-        "Language lesson config is invalid or missing. Update the JSON in Configure Tools.",
+        "Language lesson config is invalid or missing. Update the JSON in Language Lesson settings.",
       config_hash: parsedConfigResult.hash,
       summary: parsedConfigResult.summary,
       validationErrors: parsedConfigResult.validationErrors,

--- a/modules/vm-webrtc/src/toolkit_functions/language_lesson.ts
+++ b/modules/vm-webrtc/src/toolkit_functions/language_lesson.ts
@@ -1,5 +1,9 @@
 import { log } from "../../../../lib/logger";
-import { loadParsedLanguageLessonConfig } from "../../../../lib/languageLessonConfig";
+import {
+  loadParsedLanguageLessonConfig,
+  saveParsedLanguageLessonConfig,
+} from "../../../../lib/languageLessonConfig";
+import type { NormalizedLanguageLessonConfig } from "./language_lesson_schema";
 import type { ToolSessionContext, ToolkitResult } from "./types";
 
 export interface GetNextLanguageExerciseParams {
@@ -8,11 +12,155 @@ export interface GetNextLanguageExerciseParams {
   performance_notes?: string | null;
 }
 
+type LanguageIssue = NormalizedLanguageLessonConfig["language_issues"][number];
+type LanguageExercise = LanguageIssue["exercises"][number];
+
+interface ExerciseLocator {
+  issueIndex: number;
+  exerciseIndex: number;
+  issue: LanguageIssue;
+  exercise: LanguageExercise;
+}
+
+interface ProgressSummary {
+  issueCount: number;
+  totalExerciseCount: number;
+  finishedExerciseCount: number;
+  pendingExerciseCount: number;
+}
+
+function isExerciseFinished(exercise: LanguageExercise): boolean {
+  return exercise.status === "finished";
+}
+
+function findExerciseById(
+  config: NormalizedLanguageLessonConfig,
+  exerciseId: string,
+): ExerciseLocator | null {
+  for (
+    let issueIndex = 0;
+    issueIndex < config.language_issues.length;
+    issueIndex += 1
+  ) {
+    const issue = config.language_issues[issueIndex];
+    const exerciseIndex = issue.exercises.findIndex(
+      (exercise) => exercise.exercise_id === exerciseId,
+    );
+
+    if (exerciseIndex >= 0) {
+      return {
+        issueIndex,
+        exerciseIndex,
+        issue,
+        exercise: issue.exercises[exerciseIndex],
+      };
+    }
+  }
+
+  return null;
+}
+
+function findFirstUnfinishedExercise(
+  config: NormalizedLanguageLessonConfig,
+): ExerciseLocator | null {
+  for (
+    let issueIndex = 0;
+    issueIndex < config.language_issues.length;
+    issueIndex += 1
+  ) {
+    const issue = config.language_issues[issueIndex];
+    for (
+      let exerciseIndex = 0;
+      exerciseIndex < issue.exercises.length;
+      exerciseIndex += 1
+    ) {
+      const exercise = issue.exercises[exerciseIndex];
+      if (!isExerciseFinished(exercise)) {
+        return {
+          issueIndex,
+          exerciseIndex,
+          issue,
+          exercise,
+        };
+      }
+    }
+  }
+
+  return null;
+}
+
+function summarizeProgress(config: NormalizedLanguageLessonConfig): ProgressSummary {
+  const issueCount = config.language_issues.length;
+  const totalExerciseCount = config.language_issues.reduce(
+    (count, issue) => count + issue.exercises.length,
+    0,
+  );
+  const finishedExerciseCount = config.language_issues.reduce(
+    (count, issue) =>
+      count + issue.exercises.filter((exercise) => isExerciseFinished(exercise)).length,
+    0,
+  );
+
+  return {
+    issueCount,
+    totalExerciseCount,
+    finishedExerciseCount,
+    pendingExerciseCount: totalExerciseCount - finishedExerciseCount,
+  };
+}
+
+function buildIssuePayload(issue: LanguageIssue) {
+  return {
+    errorId: issue.errorId,
+    title: issue.title,
+    area: issue.area,
+    impact: issue.impact,
+    description: issue.description,
+    theory: issue.theory,
+    theory_voice: issue.theory_voice,
+    categoryCode: issue.categoryCode,
+    subcategoryCode: issue.subcategoryCode,
+    subcategoryName: issue.subcategoryName,
+  };
+}
+
+function buildUpdatedToolSessionContext(
+  base: ToolSessionContext,
+  currentLocator: ExerciseLocator | null,
+  configHash: string | null,
+  fallbackIssueErrorId?: string,
+): ToolSessionContext {
+  const updated: ToolSessionContext = {
+    ...base,
+  };
+
+  if (currentLocator) {
+    updated.current_issue_error_id = currentLocator.issue.errorId;
+    updated.current_exercise_id = currentLocator.exercise.exercise_id;
+    updated.current_issue_index = String(currentLocator.issueIndex);
+    updated.current_exercise_index = String(currentLocator.exerciseIndex);
+  } else {
+    updated.current_issue_error_id =
+      fallbackIssueErrorId || updated.current_issue_error_id || "";
+    updated.current_exercise_id = "";
+    updated.current_issue_index = updated.current_issue_index || "0";
+    updated.current_exercise_index = "-1";
+  }
+
+  if (configHash) {
+    updated.language_lesson_config_hash = configHash;
+  }
+
+  return updated;
+}
+
 /**
- * Stub implementation for the language lesson exercise flow.
- * Step 1 implementation:
- * - First call (no previous exercise result): return first exercise in config.
- * - Follow-up calls: log previous result only (no progression/storage yet).
+ * POC implementation:
+ * - Initial call: return first unfinished exercise.
+ * - Follow-up call: mark previous exercise finished in persisted JSON, save,
+ *   then return next unfinished exercise.
+ *
+ * This intentionally mutates user lesson JSON in storage for rapid prototyping.
  */
 export async function get_next_language_exercise(
   params: GetNextLanguageExerciseParams = {},
@@ -39,7 +187,6 @@ export async function get_next_language_exercise(
   const normalizedPreviousExerciseId = (previous_exercise_id || "").trim();
   const hasPreviousExerciseId = normalizedPreviousExerciseId.length > 0;
   const hasUserScore = user_score !== null && user_score !== undefined;
-
   const isInitialCall = !hasPreviousExerciseId && !hasUserScore;
 
   log.info(
@@ -140,53 +287,33 @@ export async function get_next_language_exercise(
     };
   }
 
-  if (!isInitialCall) {
-    const languageIssues = parsedConfigResult.parsedConfig.language_issues;
+  const mutableConfig = parsedConfigResult.parsedConfig;
+  const progressBefore = summarizeProgress(mutableConfig);
 
-    log.info(
-      "[language_lesson] Resolving follow-up previous_exercise_id",
-      {},
-      {
-        normalizedPreviousExerciseId,
-        previous_exercise_id,
-        user_score,
-        performance_notes,
-        issueCount: languageIssues.length,
-        searchableExercises: languageIssues.map((issue, issueIndex) => ({
-          issueIndex,
-          errorId: issue.errorId,
-          title: issue.title,
-          exerciseIds: issue.exercises.map((exercise) => exercise.exercise_id),
-        })),
-        toolSessionContext,
-      },
+  log.info(
+    "[language_lesson] Current progress before operation",
+    {},
+    {
+      progressBefore,
+      config_hash: parsedConfigResult.hash,
+      summary: parsedConfigResult.summary,
+      toolSessionContext,
+    },
+  );
+
+  if (!isInitialCall) {
+    const numericScore = user_score as number;
+    const normalizedPerformanceNotes =
+      performance_notes && performance_notes.trim().length > 0
+        ? performance_notes
+        : null;
+
+    const previousExerciseLocator = findExerciseById(
+      mutableConfig,
+      normalizedPreviousExerciseId,
     );
 
-    let matchedIssueIndex = -1;
-    let matchedExerciseIndex = -1;
-    let matchedIssue:
-      | (typeof parsedConfigResult.parsedConfig.language_issues)[number]
-      | null = null;
-    let matchedExercise:
-      | (typeof parsedConfigResult.parsedConfig.language_issues)[number]["exercises"][number]
-      | null = null;
-
-    for (let issueIndex = 0; issueIndex < languageIssues.length; issueIndex++) {
-      const issue = languageIssues[issueIndex];
-      const exerciseIndex = issue.exercises.findIndex(
-        (exercise) => exercise.exercise_id === normalizedPreviousExerciseId,
-      );
-
-      if (exerciseIndex >= 0) {
-        matchedIssueIndex = issueIndex;
-        matchedExerciseIndex = exerciseIndex;
-        matchedIssue = issue;
-        matchedExercise = issue.exercises[exerciseIndex];
-        break;
-      }
-    }
-
-    if (!matchedIssue || !matchedExercise) {
+    if (!previousExerciseLocator) {
       const returnPayload = {
         status: "previous_exercise_not_found",
         mode: "follow_up",
@@ -196,8 +323,8 @@ export async function get_next_language_exercise(
         summary: parsedConfigResult.summary,
         input: {
           previous_exercise_id: normalizedPreviousExerciseId,
-          user_score,
-          performance_notes,
+          user_score: numericScore,
+          performance_notes: normalizedPerformanceNotes,
         },
       };
 
@@ -207,9 +334,9 @@ export async function get_next_language_exercise(
         {
           normalizedPreviousExerciseId,
           previous_exercise_id,
-          user_score,
-          performance_notes,
-          availableExerciseIds: languageIssues.flatMap((issue) =>
+          user_score: numericScore,
+          performance_notes: normalizedPerformanceNotes,
+          availableExerciseIds: mutableConfig.language_issues.flatMap((issue) =>
             issue.exercises.map((exercise) => exercise.exercise_id),
           ),
           returnPayload,
@@ -223,104 +350,264 @@ export async function get_next_language_exercise(
       };
     }
 
-    const followUpLogPayload = {
-      previous_exercise_id: normalizedPreviousExerciseId,
-      user_score,
-      performance_notes,
-      config_hash: parsedConfigResult.hash,
-      matched_issue_index: matchedIssueIndex,
-      matched_exercise_index: matchedExerciseIndex,
-      matched_issue: {
-        errorId: matchedIssue.errorId,
-        title: matchedIssue.title,
-        area: matchedIssue.area,
-        impact: matchedIssue.impact,
-        description: matchedIssue.description,
-        theory: matchedIssue.theory,
-        categoryCode: matchedIssue.categoryCode,
-        subcategoryCode: matchedIssue.subcategoryCode,
-        subcategoryName: matchedIssue.subcategoryName,
-      },
-      matched_exercise: matchedExercise,
-      toolSessionContext,
-    };
+    const previousExerciseBeforeUpdate = { ...previousExerciseLocator.exercise };
+    const existingAttempts =
+      typeof previousExerciseLocator.exercise.attempts === "number"
+        ? previousExerciseLocator.exercise.attempts
+        : 0;
+
+    previousExerciseLocator.exercise.attempts = existingAttempts + 1;
+    previousExerciseLocator.exercise.last_score = numericScore;
+    previousExerciseLocator.exercise.last_notes = normalizedPerformanceNotes;
+    previousExerciseLocator.exercise.status = "finished";
+    previousExerciseLocator.exercise.finished_at = new Date().toISOString();
 
     log.info(
-      "[language_lesson] Logged previous exercise result (no progression yet)",
+      "[language_lesson] Updated previous exercise state before persistence",
       {},
-      followUpLogPayload,
+      {
+        previous_exercise_id: normalizedPreviousExerciseId,
+        previousExerciseBeforeUpdate,
+        previousExerciseAfterUpdate: previousExerciseLocator.exercise,
+        issueIndex: previousExerciseLocator.issueIndex,
+        exerciseIndex: previousExerciseLocator.exerciseIndex,
+        config_hash_before_save: parsedConfigResult.hash,
+        progressBefore,
+        toolSessionContext,
+      },
+    );
+
+    try {
+      await saveParsedLanguageLessonConfig(mutableConfig);
+    } catch (error) {
+      const errorMessage =
+        error instanceof Error ? error.message : String(error);
+
+      const returnPayload = {
+        status: "persist_failed",
+        mode: "follow_up",
+        message: "Failed to persist updated language lesson progress.",
+        error: errorMessage,
+        config_hash: parsedConfigResult.hash,
+      };
+
+      log.error(
+        "[language_lesson] Failed to persist updated lesson progress",
+        {},
+        {
+          errorMessage,
+          returnPayload,
+          mutableConfig,
+          toolSessionContext,
+        },
+        error instanceof Error ? error : new Error(String(error)),
+      );
+
+      return {
+        result: JSON.stringify(returnPayload, null, 2),
+        updatedToolSessionContext: toolSessionContext,
+      };
+    }
+
+    log.info(
+      "[language_lesson] Persisted updated lesson progress",
+      {},
+      {
+        previous_exercise_id: normalizedPreviousExerciseId,
+        config_hash_before_save: parsedConfigResult.hash,
+        mutableConfig,
+        toolSessionContext,
+      },
+    );
+
+    const reloadedConfigResult = await loadParsedLanguageLessonConfig();
+
+    log.info(
+      "[language_lesson] Reloaded config after persistence",
+      {},
+      {
+        reloadedConfigResult,
+        toolSessionContext,
+      },
+    );
+
+    if (
+      reloadedConfigResult.validationErrors.length > 0 ||
+      !reloadedConfigResult.parsedConfig
+    ) {
+      const returnPayload = {
+        status: "persist_reload_invalid",
+        mode: "follow_up",
+        message:
+          "Progress was saved but reloading the updated config failed validation.",
+        config_hash: reloadedConfigResult.hash,
+        summary: reloadedConfigResult.summary,
+        validationErrors: reloadedConfigResult.validationErrors,
+      };
+
+      log.error(
+        "[language_lesson] Persisted config failed reload validation",
+        {},
+        {
+          returnPayload,
+          reloadedConfigResult,
+          toolSessionContext,
+        },
+      );
+
+      return {
+        result: JSON.stringify(returnPayload, null, 2),
+        updatedToolSessionContext: toolSessionContext,
+      };
+    }
+
+    const nextLocator = findFirstUnfinishedExercise(
+      reloadedConfigResult.parsedConfig,
+    );
+    const progressAfter = summarizeProgress(reloadedConfigResult.parsedConfig);
+
+    log.info(
+      "[language_lesson] Selected next unfinished exercise after save",
+      {},
+      {
+        nextLocator,
+        progressAfter,
+        config_hash_after_save: reloadedConfigResult.hash,
+        toolSessionContext,
+      },
+    );
+
+    if (!nextLocator) {
+      const updatedToolSessionContext = buildUpdatedToolSessionContext(
+        toolSessionContext,
+        null,
+        reloadedConfigResult.hash,
+        previousExerciseLocator.issue.errorId,
+      );
+
+      const returnPayload = {
+        status: "all_exercises_finished",
+        mode: "follow_up",
+        message: "All exercises are finished.",
+        config_hash: reloadedConfigResult.hash,
+        summary: reloadedConfigResult.summary,
+        progress: progressAfter,
+        completed_exercise: {
+          exercise_id: previousExerciseLocator.exercise.exercise_id,
+          issue_error_id: previousExerciseLocator.issue.errorId,
+          issue_title: previousExerciseLocator.issue.title,
+          score: numericScore,
+          notes: normalizedPerformanceNotes,
+          finished_at: previousExerciseLocator.exercise.finished_at,
+        },
+      };
+
+      log.info(
+        "[language_lesson] Returning all_exercises_finished",
+        {},
+        {
+          returnPayload,
+          updatedToolSessionContext,
+          toolSessionContext,
+        },
+      );
+
+      return {
+        result: JSON.stringify(returnPayload, null, 2),
+        updatedToolSessionContext,
+      };
+    }
+
+    const updatedToolSessionContext = buildUpdatedToolSessionContext(
+      toolSessionContext,
+      nextLocator,
+      reloadedConfigResult.hash,
     );
 
     const returnPayload = {
-      status: "previous_result_logged",
+      status: "exercise_ready",
       mode: "follow_up",
       message:
-        "Previous exercise result logged. Progression/selection is not enabled yet.",
-      config_hash: parsedConfigResult.hash,
-      summary: parsedConfigResult.summary,
-      logged_result: {
-        previous_exercise_id: normalizedPreviousExerciseId,
-        user_score,
-        performance_notes,
-        issue_index: matchedIssueIndex,
-        exercise_index: matchedExerciseIndex,
-        issue_error_id: matchedIssue.errorId,
-        issue_title: matchedIssue.title,
-        exercise_type: matchedExercise.type,
-        logged_at: new Date().toISOString(),
+        "Previous exercise was marked finished and persisted. Returning next unfinished exercise.",
+      config_hash: reloadedConfigResult.hash,
+      summary: reloadedConfigResult.summary,
+      progress: progressAfter,
+      completed_exercise: {
+        exercise_id: previousExerciseLocator.exercise.exercise_id,
+        issue_error_id: previousExerciseLocator.issue.errorId,
+        issue_title: previousExerciseLocator.issue.title,
+        score: numericScore,
+        notes: normalizedPerformanceNotes,
+        finished_at: previousExerciseLocator.exercise.finished_at,
       },
-      next_exercise: null,
+      overview: {
+        issueIndex: nextLocator.issueIndex,
+        exerciseIndex: nextLocator.exerciseIndex,
+        issueCount: reloadedConfigResult.summary.issueCount,
+        totalExerciseCount: reloadedConfigResult.summary.exerciseCount,
+        exerciseCountInIssue: nextLocator.issue.exercises.length,
+      },
+      issue: buildIssuePayload(nextLocator.issue),
+      exercise: nextLocator.exercise,
     };
 
     log.info(
-      "[language_lesson] Returning follow-up result (log-only mode)",
+      "[language_lesson] Returning next unfinished exercise after follow-up",
       {},
       {
         returnPayload,
+        updatedToolSessionContext,
         toolSessionContext,
       },
     );
 
     return {
       result: JSON.stringify(returnPayload, null, 2),
-      updatedToolSessionContext: toolSessionContext,
+      updatedToolSessionContext,
     };
   }
 
-  const languageIssues = parsedConfigResult.parsedConfig.language_issues;
-  const firstIssue = languageIssues[0];
+  const initialLocator = findFirstUnfinishedExercise(mutableConfig);
 
   log.info(
-    "[language_lesson] Selecting first exercise for initial call",
+    "[language_lesson] Selecting first unfinished exercise for initial call",
     {},
     {
-      issueCount: languageIssues.length,
-      firstIssue,
-      firstIssueExerciseIds: firstIssue?.exercises?.map(
-        (exercise) => exercise.exercise_id,
-      ),
+      initialLocator,
+      progressBefore,
       config_hash: parsedConfigResult.hash,
       summary: parsedConfigResult.summary,
       toolSessionContext,
     },
   );
 
-  if (!firstIssue || firstIssue.exercises.length === 0) {
-    const returnPayload = {
-      status: "no_exercises_available",
-      mode: "initial",
-      message: "No exercises were found in the language lesson config.",
-      config_hash: parsedConfigResult.hash,
-      summary: parsedConfigResult.summary,
-    };
+  if (!initialLocator) {
+    const returnPayload =
+      progressBefore.totalExerciseCount === 0
+        ? {
+            status: "no_exercises_available",
+            mode: "initial",
+            message: "No exercises were found in the language lesson config.",
+            config_hash: parsedConfigResult.hash,
+            summary: parsedConfigResult.summary,
+            progress: progressBefore,
+          }
+        : {
+            status: "all_exercises_finished",
+            mode: "initial",
+            message: "All exercises are already finished.",
+            config_hash: parsedConfigResult.hash,
+            summary: parsedConfigResult.summary,
+            progress: progressBefore,
+          };
 
     log.warn(
-      "[language_lesson] Returning no_exercises_available",
+      "[language_lesson] No initial unfinished exercise available",
       {},
       {
-        firstIssue,
-        languageIssues,
         returnPayload,
+        progressBefore,
+        config_hash: parsedConfigResult.hash,
         toolSessionContext,
       },
     );
@@ -331,48 +618,31 @@ export async function get_next_language_exercise(
     };
   }
 
-  const firstExercise = firstIssue.exercises[0];
-
-  const updatedToolSessionContext: ToolSessionContext = {
-    ...toolSessionContext,
-    current_issue_error_id: firstIssue.errorId,
-    current_exercise_id: firstExercise.exercise_id,
-    current_issue_index: "0",
-    current_exercise_index: "0",
-  };
-
-  if (parsedConfigResult.hash) {
-    updatedToolSessionContext.language_lesson_config_hash =
-      parsedConfigResult.hash;
-  }
+  const updatedToolSessionContext = buildUpdatedToolSessionContext(
+    toolSessionContext,
+    initialLocator,
+    parsedConfigResult.hash,
+  );
 
   const returnPayload = {
     status: "exercise_ready",
     mode: "initial",
     config_hash: parsedConfigResult.hash,
+    summary: parsedConfigResult.summary,
+    progress: progressBefore,
     overview: {
-      issueIndex: 0,
-      exerciseIndex: 0,
+      issueIndex: initialLocator.issueIndex,
+      exerciseIndex: initialLocator.exerciseIndex,
       issueCount: parsedConfigResult.summary.issueCount,
       totalExerciseCount: parsedConfigResult.summary.exerciseCount,
-      exerciseCountInIssue: firstIssue.exercises.length,
+      exerciseCountInIssue: initialLocator.issue.exercises.length,
     },
-    issue: {
-      errorId: firstIssue.errorId,
-      title: firstIssue.title,
-      area: firstIssue.area,
-      impact: firstIssue.impact,
-      description: firstIssue.description,
-      theory: firstIssue.theory,
-      categoryCode: firstIssue.categoryCode,
-      subcategoryCode: firstIssue.subcategoryCode,
-      subcategoryName: firstIssue.subcategoryName,
-    },
-    exercise: firstExercise,
+    issue: buildIssuePayload(initialLocator.issue),
+    exercise: initialLocator.exercise,
   };
 
   log.info(
-    "[language_lesson] Returning initial exercise",
+    "[language_lesson] Returning initial unfinished exercise",
     {},
     {
       returnPayload,

--- a/modules/vm-webrtc/src/toolkit_functions/language_lesson.ts
+++ b/modules/vm-webrtc/src/toolkit_functions/language_lesson.ts
@@ -68,11 +68,6 @@ interface ExerciseOverview {
 
 interface CompletedExercisePayload {
   exercise_id: string;
-  issue_error_id: string;
-  issue_title: string;
-  score: number;
-  notes: string | null;
-  finished_at: string | null;
 }
 
 interface FollowUpInputPayload {
@@ -106,7 +101,7 @@ interface LanguageExerciseToolResponse {
   progress: ProgressSummary | null;
   overview: ExerciseOverview | null;
   issue: LanguageIssuePayload | null;
-  exercise: LanguageExercise | null;
+  next_exercise: LanguageExercise | null;
   completed_exercise: CompletedExercisePayload | null;
   input: FollowUpInputPayload | null;
   validationErrors: string[];
@@ -243,7 +238,7 @@ function buildLanguageExerciseToolResponse(params: {
   progress?: ProgressSummary | null;
   overview?: ExerciseOverview | null;
   issue?: LanguageIssuePayload | null;
-  exercise?: LanguageExercise | null;
+  next_exercise?: LanguageExercise | null;
   completed_exercise?: CompletedExercisePayload | null;
   input?: FollowUpInputPayload | null;
   validationErrors?: string[];
@@ -262,7 +257,7 @@ function buildLanguageExerciseToolResponse(params: {
     progress: params.progress ?? null,
     overview: params.overview ?? null,
     issue: params.issue ?? null,
-    exercise: params.exercise ?? null,
+    next_exercise: params.next_exercise ?? null,
     completed_exercise: params.completed_exercise ?? null,
     input: params.input ?? null,
     validationErrors: params.validationErrors ?? [],
@@ -742,11 +737,6 @@ async function handleFollowUpCall(
       progress: progressAfter,
       completed_exercise: {
         exercise_id: previousExerciseLocator.exercise.exercise_id,
-        issue_error_id: previousExerciseLocator.issue.errorId,
-        issue_title: previousExerciseLocator.issue.title,
-        score: numericScore,
-        notes: normalizedPerformanceNotes,
-        finished_at: previousExerciseLocator.exercise.finished_at || null,
       },
     });
 
@@ -773,17 +763,12 @@ async function handleFollowUpCall(
     status: "next_exercise_ready",
     mode: "follow_up",
     message:
-      "Previous exercise was marked finished and persisted. Returning the next exercise to give to the user. The exercise details are in the exercise field, and see the issue field for more context.",
+      "Previous exercise was marked finished and persisted. Returning the next exercise to give to the user. The exercise details are in the next_exercise field, and see the issue field for more context.",
     config_hash: reloadOutcome.reloadedConfigResult.hash,
     summary: reloadOutcome.reloadedConfigResult.summary,
     progress: progressAfter,
     completed_exercise: {
       exercise_id: previousExerciseLocator.exercise.exercise_id,
-      issue_error_id: previousExerciseLocator.issue.errorId,
-      issue_title: previousExerciseLocator.issue.title,
-      score: numericScore,
-      notes: normalizedPerformanceNotes,
-      finished_at: previousExerciseLocator.exercise.finished_at || null,
     },
     overview: {
       issueIndex: nextLocator.issueIndex,
@@ -794,7 +779,7 @@ async function handleFollowUpCall(
       exerciseCountInIssue: nextLocator.issue.exercises.length,
     },
     issue: buildIssuePayload(nextLocator.issue),
-    exercise: nextLocator.exercise,
+    next_exercise: nextLocator.exercise,
   });
 
   log.info(
@@ -886,7 +871,7 @@ function handleInitialCall(
       exerciseCountInIssue: initialLocator.issue.exercises.length,
     },
     issue: buildIssuePayload(initialLocator.issue),
-    exercise: initialLocator.exercise,
+    next_exercise: initialLocator.exercise,
   });
 
   log.info(

--- a/modules/vm-webrtc/src/toolkit_functions/language_lesson.ts
+++ b/modules/vm-webrtc/src/toolkit_functions/language_lesson.ts
@@ -209,7 +209,7 @@ function buildIssuePayload(issue: LanguageIssue): LanguageIssuePayload {
 function buildNextActionSuggestion(status: LanguageExerciseToolStatus): string {
   switch (status) {
     case "next_exercise_ready":
-      return "Assume the user wants to keep going, so give the next exercise to the user. The next exercise details are in the next_exercise field.";
+      return "Assume the user wants to keep going. Give the next exercise to the user using next_exercise, then after the user responds call language_lesson__get_next_language_exercise again with previous_exercise_id, user_score, and performance_notes.";
     case "all_exercises_finished":
       return "Congratulate the user for finishing all exercises and ask if they want to practice a new issue.";
     case "no_exercises_available":
@@ -763,7 +763,7 @@ async function handleFollowUpCall(
     status: "next_exercise_ready",
     mode: "follow_up",
     message:
-      "Previous exercise was marked finished and persisted. Returning the next exercise to give to the user. The next exercise details are in the next_exercise field, and see the issue field for more context.",
+      "Previous exercise was marked finished and persisted. Returning the next exercise to give to the user. The next exercise details are in the next_exercise field, and see the issue field for more context. After the user answers, call language_lesson__get_next_language_exercise again.",
     config_hash: reloadOutcome.reloadedConfigResult.hash,
     summary: reloadOutcome.reloadedConfigResult.summary,
     progress: progressAfter,
@@ -859,7 +859,7 @@ function handleInitialCall(
     status: "next_exercise_ready",
     mode: "initial",
     message:
-      "Returning the next exercise to give to the user. The next exercise details are in the next_exercise field.",
+      "Returning the next exercise to give to the user. The next exercise details are in the next_exercise field. After the user answers, call language_lesson__get_next_language_exercise again.",
     config_hash: loadedConfigState.parsedConfigResult.hash,
     summary: loadedConfigState.parsedConfigResult.summary,
     progress: loadedConfigState.progressBefore,

--- a/modules/vm-webrtc/src/toolkit_functions/language_lesson.ts
+++ b/modules/vm-webrtc/src/toolkit_functions/language_lesson.ts
@@ -12,7 +12,7 @@ export interface GetNextLanguageExerciseParams {
  * Stub implementation for the language lesson exercise flow.
  * Step 1 implementation:
  * - First call (no previous exercise result): return first exercise in config.
- * - Follow-up calls with previous results: not implemented yet.
+ * - Follow-up calls: log previous result only (no progression/storage yet).
  */
 export async function get_next_language_exercise(
   params: GetNextLanguageExerciseParams = {},
@@ -36,29 +36,36 @@ export async function get_next_language_exercise(
     },
   );
 
-  const isInitialCall =
-    (!previous_exercise_id || previous_exercise_id.trim().length === 0) &&
-    user_score === null;
+  const normalizedPreviousExerciseId = (previous_exercise_id || "").trim();
+  const hasPreviousExerciseId = normalizedPreviousExerciseId.length > 0;
+  const hasUserScore = user_score !== null && user_score !== undefined;
+
+  const isInitialCall = !hasPreviousExerciseId && !hasUserScore;
 
   if (!isInitialCall) {
-    return {
-      result: JSON.stringify(
-        {
-          status: "not_implemented",
-          mode: "follow_up",
-          message:
-            "Step 2 is not implemented yet. Only initial exercise fetch is implemented.",
-          input: {
-            previous_exercise_id,
-            user_score,
-            performance_notes,
+    const hasValidUserScore =
+      typeof user_score === "number" && Number.isFinite(user_score);
+
+    if (!hasPreviousExerciseId || !hasValidUserScore) {
+      return {
+        result: JSON.stringify(
+          {
+            status: "invalid_follow_up_input",
+            mode: "follow_up",
+            message:
+              "Follow-up calls require both previous_exercise_id and numeric user_score.",
+            input: {
+              previous_exercise_id,
+              user_score,
+              performance_notes,
+            },
           },
-        },
-        null,
-        2,
-      ),
-      updatedToolSessionContext: toolSessionContext,
-    };
+          null,
+          2,
+        ),
+        updatedToolSessionContext: toolSessionContext,
+      };
+    }
   }
 
   const parsedConfigResult = await loadParsedLanguageLessonConfig();
@@ -71,12 +78,118 @@ export async function get_next_language_exercise(
       result: JSON.stringify(
         {
           status: "config_invalid",
-          mode: "initial",
+          mode: isInitialCall ? "initial" : "follow_up",
           message:
             "Language lesson config is invalid or missing. Update the JSON in Configure Tools.",
           config_hash: parsedConfigResult.hash,
           summary: parsedConfigResult.summary,
           validationErrors: parsedConfigResult.validationErrors,
+        },
+        null,
+        2,
+      ),
+      updatedToolSessionContext: toolSessionContext,
+    };
+  }
+
+  if (!isInitialCall) {
+    const languageIssues = parsedConfigResult.parsedConfig.language_issues;
+    let matchedIssueIndex = -1;
+    let matchedExerciseIndex = -1;
+    let matchedIssue:
+      | (typeof parsedConfigResult.parsedConfig.language_issues)[number]
+      | null = null;
+    let matchedExercise:
+      | (typeof parsedConfigResult.parsedConfig.language_issues)[number]["exercises"][number]
+      | null = null;
+
+    for (let issueIndex = 0; issueIndex < languageIssues.length; issueIndex++) {
+      const issue = languageIssues[issueIndex];
+      const exerciseIndex = issue.exercises.findIndex(
+        (exercise) => exercise.exercise_id === normalizedPreviousExerciseId,
+      );
+
+      if (exerciseIndex >= 0) {
+        matchedIssueIndex = issueIndex;
+        matchedExerciseIndex = exerciseIndex;
+        matchedIssue = issue;
+        matchedExercise = issue.exercises[exerciseIndex];
+        break;
+      }
+    }
+
+    if (!matchedIssue || !matchedExercise) {
+      return {
+        result: JSON.stringify(
+          {
+            status: "previous_exercise_not_found",
+            mode: "follow_up",
+            message:
+              "Could not find previous_exercise_id in current language lesson config.",
+            config_hash: parsedConfigResult.hash,
+            summary: parsedConfigResult.summary,
+            input: {
+              previous_exercise_id: normalizedPreviousExerciseId,
+              user_score,
+              performance_notes,
+            },
+          },
+          null,
+          2,
+        ),
+        updatedToolSessionContext: toolSessionContext,
+      };
+    }
+
+    const followUpLogPayload = {
+      previous_exercise_id: normalizedPreviousExerciseId,
+      user_score,
+      performance_notes,
+      config_hash: parsedConfigResult.hash,
+      matched_issue_index: matchedIssueIndex,
+      matched_exercise_index: matchedExerciseIndex,
+      matched_issue: {
+        errorId: matchedIssue.errorId,
+        title: matchedIssue.title,
+        area: matchedIssue.area,
+        impact: matchedIssue.impact,
+        description: matchedIssue.description,
+        theory: matchedIssue.theory,
+        categoryCode: matchedIssue.categoryCode,
+        subcategoryCode: matchedIssue.subcategoryCode,
+        subcategoryName: matchedIssue.subcategoryName,
+      },
+      matched_exercise: matchedExercise,
+      toolSessionContext,
+    };
+
+    log.info(
+      "[language_lesson] Logged previous exercise result (no progression yet)",
+      {},
+      followUpLogPayload,
+    );
+
+    return {
+      result: JSON.stringify(
+        {
+          status: "previous_result_logged",
+          mode: "follow_up",
+          message:
+            "Previous exercise result logged. Progression/selection is not enabled yet.",
+          config_hash: parsedConfigResult.hash,
+          summary: parsedConfigResult.summary,
+          logged_result: {
+            previous_exercise_id: normalizedPreviousExerciseId,
+            user_score,
+            performance_notes,
+            issue_index: matchedIssueIndex,
+            exercise_index: matchedExerciseIndex,
+            issue_error_id: matchedIssue.errorId,
+            issue_title: matchedIssue.title,
+            exercise_type: matchedExercise.type,
+            logged_at: new Date().toISOString(),
+          },
+          next_exercise: null,
         },
         null,
         2,

--- a/modules/vm-webrtc/src/toolkit_functions/language_lesson.ts
+++ b/modules/vm-webrtc/src/toolkit_functions/language_lesson.ts
@@ -2,6 +2,7 @@ import { log } from "../../../../lib/logger";
 import {
   loadParsedLanguageLessonConfig,
   saveParsedLanguageLessonConfig,
+  type LoadParsedLanguageLessonConfigResult,
 } from "../../../../lib/languageLessonConfig";
 import type { NormalizedLanguageLessonConfig } from "./language_lesson_schema";
 import type { ToolSessionContext, ToolkitResult } from "./types";
@@ -27,6 +28,22 @@ interface ProgressSummary {
   totalExerciseCount: number;
   finishedExerciseCount: number;
   pendingExerciseCount: number;
+}
+
+interface InvocationState {
+  previous_exercise_id: string | null;
+  user_score: number | null;
+  performance_notes: string | null;
+  normalizedPreviousExerciseId: string;
+  hasPreviousExerciseId: boolean;
+  hasUserScore: boolean;
+  isInitialCall: boolean;
+}
+
+interface LoadedConfigState {
+  parsedConfigResult: LoadParsedLanguageLessonConfigResult;
+  mutableConfig: NormalizedLanguageLessonConfig;
+  progressBefore: ProgressSummary;
 }
 
 function isExerciseFinished(exercise: LanguageExercise): boolean {
@@ -154,19 +171,20 @@ function buildUpdatedToolSessionContext(
   return updated;
 }
 
-/**
- * POC implementation:
- * - Initial call: return first unfinished exercise.
- * - Follow-up call: mark previous exercise finished in persisted JSON, save,
- *   then return next unfinished exercise.
- *
- * This intentionally mutates user lesson JSON in storage for rapid prototyping.
- */
-export async function get_next_language_exercise(
-  params: GetNextLanguageExerciseParams = {},
-  _context_params?: any,
-  toolSessionContext: ToolSessionContext = {},
-): Promise<ToolkitResult> {
+function buildToolkitResult(
+  payload: unknown,
+  updatedToolSessionContext: ToolSessionContext,
+): ToolkitResult {
+  return {
+    result: JSON.stringify(payload, null, 2),
+    updatedToolSessionContext,
+  };
+}
+
+function buildInvocationState(
+  params: GetNextLanguageExerciseParams,
+  toolSessionContext: ToolSessionContext,
+): InvocationState {
   const {
     previous_exercise_id = null,
     user_score = null,
@@ -189,68 +207,84 @@ export async function get_next_language_exercise(
   const hasUserScore = user_score !== null && user_score !== undefined;
   const isInitialCall = !hasPreviousExerciseId && !hasUserScore;
 
+  const invocationState: InvocationState = {
+    previous_exercise_id,
+    user_score,
+    performance_notes,
+    normalizedPreviousExerciseId,
+    hasPreviousExerciseId,
+    hasUserScore,
+    isInitialCall,
+  };
+
   log.info(
     "[language_lesson] Determined invocation mode",
     {},
     {
-      isInitialCall,
-      hasPreviousExerciseId,
-      hasUserScore,
-      normalizedPreviousExerciseId,
-      previous_exercise_id,
-      user_score,
-      performance_notes,
+      ...invocationState,
       toolSessionContext,
     },
   );
 
-  if (!isInitialCall) {
-    const hasValidUserScore =
-      typeof user_score === "number" && Number.isFinite(user_score);
+  return invocationState;
+}
 
-    if (!hasPreviousExerciseId || !hasValidUserScore) {
-      const returnPayload = {
-        status: "invalid_follow_up_input",
-        mode: "follow_up",
-        message:
-          "Follow-up calls require both previous_exercise_id and numeric user_score.",
-        input: {
-          previous_exercise_id,
-          user_score,
-          performance_notes,
-        },
-      };
-
-      log.warn(
-        "[language_lesson] Returning invalid follow-up input",
-        {},
-        {
-          hasPreviousExerciseId,
-          hasUserScore,
-          hasValidUserScore,
-          normalizedPreviousExerciseId,
-          previous_exercise_id,
-          user_score,
-          performance_notes,
-          toolSessionContext,
-          returnPayload,
-        },
-      );
-
-      return {
-        result: JSON.stringify(returnPayload, null, 2),
-        updatedToolSessionContext: toolSessionContext,
-      };
-    }
+function validateInvocationOrResult(
+  invocationState: InvocationState,
+  toolSessionContext: ToolSessionContext,
+): ToolkitResult | null {
+  if (invocationState.isInitialCall) {
+    return null;
   }
 
+  const hasValidUserScore =
+    typeof invocationState.user_score === "number" &&
+    Number.isFinite(invocationState.user_score);
+
+  if (invocationState.hasPreviousExerciseId && hasValidUserScore) {
+    return null;
+  }
+
+  const returnPayload = {
+    status: "invalid_follow_up_input",
+    mode: "follow_up",
+    message:
+      "Follow-up calls require both previous_exercise_id and numeric user_score.",
+    input: {
+      previous_exercise_id: invocationState.previous_exercise_id,
+      user_score: invocationState.user_score,
+      performance_notes: invocationState.performance_notes,
+    },
+  };
+
+  log.warn(
+    "[language_lesson] Returning invalid follow-up input",
+    {},
+    {
+      ...invocationState,
+      hasValidUserScore,
+      toolSessionContext,
+      returnPayload,
+    },
+  );
+
+  return buildToolkitResult(returnPayload, toolSessionContext);
+}
+
+async function loadValidatedConfigOrResult(
+  invocationState: InvocationState,
+  toolSessionContext: ToolSessionContext,
+): Promise<{
+  loadedConfigState: LoadedConfigState | null;
+  toolkitResult: ToolkitResult | null;
+}> {
   const parsedConfigResult = await loadParsedLanguageLessonConfig();
 
   log.info(
     "[language_lesson] Loaded parsed language lesson config",
     {},
     {
-      isInitialCall,
+      invocationState,
       parsedConfigResult,
       toolSessionContext,
     },
@@ -262,7 +296,7 @@ export async function get_next_language_exercise(
   ) {
     const returnPayload = {
       status: "config_invalid",
-      mode: isInitialCall ? "initial" : "follow_up",
+      mode: invocationState.isInitialCall ? "initial" : "follow_up",
       message:
         "Language lesson config is invalid or missing. Update the JSON in Configure Tools.",
       config_hash: parsedConfigResult.hash,
@@ -274,7 +308,7 @@ export async function get_next_language_exercise(
       "[language_lesson] Returning config_invalid",
       {},
       {
-        isInitialCall,
+        invocationState,
         parsedConfigResult,
         returnPayload,
         toolSessionContext,
@@ -282,8 +316,8 @@ export async function get_next_language_exercise(
     );
 
     return {
-      result: JSON.stringify(returnPayload, null, 2),
-      updatedToolSessionContext: toolSessionContext,
+      loadedConfigState: null,
+      toolkitResult: buildToolkitResult(returnPayload, toolSessionContext),
     };
   }
 
@@ -294,6 +328,7 @@ export async function get_next_language_exercise(
     "[language_lesson] Current progress before operation",
     {},
     {
+      invocationState,
       progressBefore,
       config_hash: parsedConfigResult.hash,
       summary: parsedConfigResult.summary,
@@ -301,236 +336,248 @@ export async function get_next_language_exercise(
     },
   );
 
-  if (!isInitialCall) {
-    const numericScore = user_score as number;
-    const normalizedPerformanceNotes =
-      performance_notes && performance_notes.trim().length > 0
-        ? performance_notes
-        : null;
-
-    const previousExerciseLocator = findExerciseById(
+  return {
+    loadedConfigState: {
+      parsedConfigResult,
       mutableConfig,
-      normalizedPreviousExerciseId,
-    );
+      progressBefore,
+    },
+    toolkitResult: null,
+  };
+}
 
-    if (!previousExerciseLocator) {
-      const returnPayload = {
-        status: "previous_exercise_not_found",
-        mode: "follow_up",
-        message:
-          "Could not find previous_exercise_id in current language lesson config.",
-        config_hash: parsedConfigResult.hash,
-        summary: parsedConfigResult.summary,
-        input: {
-          previous_exercise_id: normalizedPreviousExerciseId,
-          user_score: numericScore,
-          performance_notes: normalizedPerformanceNotes,
-        },
-      };
+function normalizePerformanceNotes(performanceNotes: string | null): string | null {
+  if (!performanceNotes || performanceNotes.trim().length === 0) {
+    return null;
+  }
 
-      log.warn(
-        "[language_lesson] Returning previous_exercise_not_found",
-        {},
-        {
-          normalizedPreviousExerciseId,
-          previous_exercise_id,
-          user_score: numericScore,
-          performance_notes: normalizedPerformanceNotes,
-          availableExerciseIds: mutableConfig.language_issues.flatMap((issue) =>
-            issue.exercises.map((exercise) => exercise.exercise_id),
-          ),
-          returnPayload,
-          toolSessionContext,
-        },
-      );
+  return performanceNotes;
+}
 
-      return {
-        result: JSON.stringify(returnPayload, null, 2),
-        updatedToolSessionContext: toolSessionContext,
-      };
-    }
+async function persistUpdatedConfigOrResult(
+  mutableConfig: NormalizedLanguageLessonConfig,
+  parsedConfigResult: LoadParsedLanguageLessonConfigResult,
+  previousExerciseId: string,
+  toolSessionContext: ToolSessionContext,
+): Promise<ToolkitResult | null> {
+  try {
+    await saveParsedLanguageLessonConfig(mutableConfig);
+  } catch (error) {
+    const errorMessage =
+      error instanceof Error ? error.message : String(error);
 
-    const previousExerciseBeforeUpdate = { ...previousExerciseLocator.exercise };
-    const existingAttempts =
-      typeof previousExerciseLocator.exercise.attempts === "number"
-        ? previousExerciseLocator.exercise.attempts
-        : 0;
+    const returnPayload = {
+      status: "persist_failed",
+      mode: "follow_up",
+      message: "Failed to persist updated language lesson progress.",
+      error: errorMessage,
+      config_hash: parsedConfigResult.hash,
+    };
 
-    previousExerciseLocator.exercise.attempts = existingAttempts + 1;
-    previousExerciseLocator.exercise.last_score = numericScore;
-    previousExerciseLocator.exercise.last_notes = normalizedPerformanceNotes;
-    previousExerciseLocator.exercise.status = "finished";
-    previousExerciseLocator.exercise.finished_at = new Date().toISOString();
-
-    log.info(
-      "[language_lesson] Updated previous exercise state before persistence",
+    log.error(
+      "[language_lesson] Failed to persist updated lesson progress",
       {},
       {
-        previous_exercise_id: normalizedPreviousExerciseId,
-        previousExerciseBeforeUpdate,
-        previousExerciseAfterUpdate: previousExerciseLocator.exercise,
-        issueIndex: previousExerciseLocator.issueIndex,
-        exerciseIndex: previousExerciseLocator.exerciseIndex,
-        config_hash_before_save: parsedConfigResult.hash,
-        progressBefore,
-        toolSessionContext,
-      },
-    );
-
-    try {
-      await saveParsedLanguageLessonConfig(mutableConfig);
-    } catch (error) {
-      const errorMessage =
-        error instanceof Error ? error.message : String(error);
-
-      const returnPayload = {
-        status: "persist_failed",
-        mode: "follow_up",
-        message: "Failed to persist updated language lesson progress.",
-        error: errorMessage,
-        config_hash: parsedConfigResult.hash,
-      };
-
-      log.error(
-        "[language_lesson] Failed to persist updated lesson progress",
-        {},
-        {
-          errorMessage,
-          returnPayload,
-          mutableConfig,
-          toolSessionContext,
-        },
-        error instanceof Error ? error : new Error(String(error)),
-      );
-
-      return {
-        result: JSON.stringify(returnPayload, null, 2),
-        updatedToolSessionContext: toolSessionContext,
-      };
-    }
-
-    log.info(
-      "[language_lesson] Persisted updated lesson progress",
-      {},
-      {
-        previous_exercise_id: normalizedPreviousExerciseId,
-        config_hash_before_save: parsedConfigResult.hash,
+        errorMessage,
+        returnPayload,
         mutableConfig,
         toolSessionContext,
       },
+      error instanceof Error ? error : new Error(String(error)),
     );
 
-    const reloadedConfigResult = await loadParsedLanguageLessonConfig();
+    return buildToolkitResult(returnPayload, toolSessionContext);
+  }
 
-    log.info(
-      "[language_lesson] Reloaded config after persistence",
+  log.info(
+    "[language_lesson] Persisted updated lesson progress",
+    {},
+    {
+      previous_exercise_id: previousExerciseId,
+      config_hash_before_save: parsedConfigResult.hash,
+      mutableConfig,
+      toolSessionContext,
+    },
+  );
+
+  return null;
+}
+
+async function reloadPersistedConfigOrResult(
+  toolSessionContext: ToolSessionContext,
+): Promise<{
+  reloadedConfigResult: LoadParsedLanguageLessonConfigResult | null;
+  reloadedConfig: NormalizedLanguageLessonConfig | null;
+  toolkitResult: ToolkitResult | null;
+}> {
+  const reloadedConfigResult = await loadParsedLanguageLessonConfig();
+
+  log.info(
+    "[language_lesson] Reloaded config after persistence",
+    {},
+    {
+      reloadedConfigResult,
+      toolSessionContext,
+    },
+  );
+
+  if (
+    reloadedConfigResult.validationErrors.length > 0 ||
+    !reloadedConfigResult.parsedConfig
+  ) {
+    const returnPayload = {
+      status: "persist_reload_invalid",
+      mode: "follow_up",
+      message:
+        "Progress was saved but reloading the updated config failed validation.",
+      config_hash: reloadedConfigResult.hash,
+      summary: reloadedConfigResult.summary,
+      validationErrors: reloadedConfigResult.validationErrors,
+    };
+
+    log.error(
+      "[language_lesson] Persisted config failed reload validation",
       {},
       {
+        returnPayload,
         reloadedConfigResult,
         toolSessionContext,
       },
     );
 
-    if (
-      reloadedConfigResult.validationErrors.length > 0 ||
-      !reloadedConfigResult.parsedConfig
-    ) {
-      const returnPayload = {
-        status: "persist_reload_invalid",
-        mode: "follow_up",
-        message:
-          "Progress was saved but reloading the updated config failed validation.",
-        config_hash: reloadedConfigResult.hash,
-        summary: reloadedConfigResult.summary,
-        validationErrors: reloadedConfigResult.validationErrors,
-      };
+    return {
+      reloadedConfigResult: null,
+      reloadedConfig: null,
+      toolkitResult: buildToolkitResult(returnPayload, toolSessionContext),
+    };
+  }
 
-      log.error(
-        "[language_lesson] Persisted config failed reload validation",
-        {},
-        {
-          returnPayload,
-          reloadedConfigResult,
-          toolSessionContext,
-        },
-      );
+  return {
+    reloadedConfigResult,
+    reloadedConfig: reloadedConfigResult.parsedConfig,
+    toolkitResult: null,
+  };
+}
 
-      return {
-        result: JSON.stringify(returnPayload, null, 2),
-        updatedToolSessionContext: toolSessionContext,
-      };
-    }
+async function handleFollowUpCall(
+  invocationState: InvocationState,
+  loadedConfigState: LoadedConfigState,
+  toolSessionContext: ToolSessionContext,
+): Promise<ToolkitResult> {
+  const numericScore = invocationState.user_score as number;
+  const normalizedPerformanceNotes = normalizePerformanceNotes(
+    invocationState.performance_notes,
+  );
 
-    const nextLocator = findFirstUnfinishedExercise(
-      reloadedConfigResult.parsedConfig,
-    );
-    const progressAfter = summarizeProgress(reloadedConfigResult.parsedConfig);
+  const previousExerciseLocator = findExerciseById(
+    loadedConfigState.mutableConfig,
+    invocationState.normalizedPreviousExerciseId,
+  );
 
-    log.info(
-      "[language_lesson] Selected next unfinished exercise after save",
+  if (!previousExerciseLocator) {
+    const returnPayload = {
+      status: "previous_exercise_not_found",
+      mode: "follow_up",
+      message:
+        "Could not find previous_exercise_id in current language lesson config.",
+      config_hash: loadedConfigState.parsedConfigResult.hash,
+      summary: loadedConfigState.parsedConfigResult.summary,
+      input: {
+        previous_exercise_id: invocationState.normalizedPreviousExerciseId,
+        user_score: numericScore,
+        performance_notes: normalizedPerformanceNotes,
+      },
+    };
+
+    log.warn(
+      "[language_lesson] Returning previous_exercise_not_found",
       {},
       {
-        nextLocator,
-        progressAfter,
-        config_hash_after_save: reloadedConfigResult.hash,
+        invocationState,
+        user_score: numericScore,
+        performance_notes: normalizedPerformanceNotes,
+        availableExerciseIds: loadedConfigState.mutableConfig.language_issues.flatMap(
+          (issue) => issue.exercises.map((exercise) => exercise.exercise_id),
+        ),
+        returnPayload,
         toolSessionContext,
       },
     );
 
-    if (!nextLocator) {
-      const updatedToolSessionContext = buildUpdatedToolSessionContext(
-        toolSessionContext,
-        null,
-        reloadedConfigResult.hash,
-        previousExerciseLocator.issue.errorId,
-      );
+    return buildToolkitResult(returnPayload, toolSessionContext);
+  }
 
-      const returnPayload = {
-        status: "all_exercises_finished",
-        mode: "follow_up",
-        message: "All exercises are finished.",
-        config_hash: reloadedConfigResult.hash,
-        summary: reloadedConfigResult.summary,
-        progress: progressAfter,
-        completed_exercise: {
-          exercise_id: previousExerciseLocator.exercise.exercise_id,
-          issue_error_id: previousExerciseLocator.issue.errorId,
-          issue_title: previousExerciseLocator.issue.title,
-          score: numericScore,
-          notes: normalizedPerformanceNotes,
-          finished_at: previousExerciseLocator.exercise.finished_at,
-        },
-      };
+  const previousExerciseBeforeUpdate = { ...previousExerciseLocator.exercise };
+  const existingAttempts =
+    typeof previousExerciseLocator.exercise.attempts === "number"
+      ? previousExerciseLocator.exercise.attempts
+      : 0;
 
-      log.info(
-        "[language_lesson] Returning all_exercises_finished",
-        {},
-        {
-          returnPayload,
-          updatedToolSessionContext,
-          toolSessionContext,
-        },
-      );
+  previousExerciseLocator.exercise.attempts = existingAttempts + 1;
+  previousExerciseLocator.exercise.last_score = numericScore;
+  previousExerciseLocator.exercise.last_notes = normalizedPerformanceNotes;
+  previousExerciseLocator.exercise.status = "finished";
+  previousExerciseLocator.exercise.finished_at = new Date().toISOString();
 
-      return {
-        result: JSON.stringify(returnPayload, null, 2),
-        updatedToolSessionContext,
-      };
-    }
+  log.info(
+    "[language_lesson] Updated previous exercise state before persistence",
+    {},
+    {
+      previous_exercise_id: invocationState.normalizedPreviousExerciseId,
+      previousExerciseBeforeUpdate,
+      previousExerciseAfterUpdate: previousExerciseLocator.exercise,
+      issueIndex: previousExerciseLocator.issueIndex,
+      exerciseIndex: previousExerciseLocator.exerciseIndex,
+      config_hash_before_save: loadedConfigState.parsedConfigResult.hash,
+      progressBefore: loadedConfigState.progressBefore,
+      toolSessionContext,
+    },
+  );
 
+  const persistResult = await persistUpdatedConfigOrResult(
+    loadedConfigState.mutableConfig,
+    loadedConfigState.parsedConfigResult,
+    invocationState.normalizedPreviousExerciseId,
+    toolSessionContext,
+  );
+
+  if (persistResult) {
+    return persistResult;
+  }
+
+  const reloadOutcome = await reloadPersistedConfigOrResult(toolSessionContext);
+  if (reloadOutcome.toolkitResult || !reloadOutcome.reloadedConfigResult) {
+    return reloadOutcome.toolkitResult as ToolkitResult;
+  }
+
+  const nextLocator = findFirstUnfinishedExercise(reloadOutcome.reloadedConfig!);
+  const progressAfter = summarizeProgress(reloadOutcome.reloadedConfig!);
+
+  log.info(
+    "[language_lesson] Selected next unfinished exercise after save",
+    {},
+    {
+      nextLocator,
+      progressAfter,
+      config_hash_after_save: reloadOutcome.reloadedConfigResult.hash,
+      toolSessionContext,
+    },
+  );
+
+  if (!nextLocator) {
     const updatedToolSessionContext = buildUpdatedToolSessionContext(
       toolSessionContext,
-      nextLocator,
-      reloadedConfigResult.hash,
+      null,
+      reloadOutcome.reloadedConfigResult.hash,
+      previousExerciseLocator.issue.errorId,
     );
 
     const returnPayload = {
-      status: "exercise_ready",
+      status: "all_exercises_finished",
       mode: "follow_up",
-      message:
-        "Previous exercise was marked finished and persisted. Returning next unfinished exercise.",
-      config_hash: reloadedConfigResult.hash,
-      summary: reloadedConfigResult.summary,
+      message: "All exercises are finished.",
+      config_hash: reloadOutcome.reloadedConfigResult.hash,
+      summary: reloadOutcome.reloadedConfigResult.summary,
       progress: progressAfter,
       completed_exercise: {
         exercise_id: previousExerciseLocator.exercise.exercise_id,
@@ -540,19 +587,10 @@ export async function get_next_language_exercise(
         notes: normalizedPerformanceNotes,
         finished_at: previousExerciseLocator.exercise.finished_at,
       },
-      overview: {
-        issueIndex: nextLocator.issueIndex,
-        exerciseIndex: nextLocator.exerciseIndex,
-        issueCount: reloadedConfigResult.summary.issueCount,
-        totalExerciseCount: reloadedConfigResult.summary.exerciseCount,
-        exerciseCountInIssue: nextLocator.issue.exercises.length,
-      },
-      issue: buildIssuePayload(nextLocator.issue),
-      exercise: nextLocator.exercise,
     };
 
     log.info(
-      "[language_lesson] Returning next unfinished exercise after follow-up",
+      "[language_lesson] Returning all_exercises_finished",
       {},
       {
         returnPayload,
@@ -561,44 +599,91 @@ export async function get_next_language_exercise(
       },
     );
 
-    return {
-      result: JSON.stringify(returnPayload, null, 2),
-      updatedToolSessionContext,
-    };
+    return buildToolkitResult(returnPayload, updatedToolSessionContext);
   }
 
-  const initialLocator = findFirstUnfinishedExercise(mutableConfig);
+  const updatedToolSessionContext = buildUpdatedToolSessionContext(
+    toolSessionContext,
+    nextLocator,
+    reloadOutcome.reloadedConfigResult.hash,
+  );
+
+  const returnPayload = {
+    status: "exercise_ready",
+    mode: "follow_up",
+    message:
+      "Previous exercise was marked finished and persisted. Returning next unfinished exercise.",
+    config_hash: reloadOutcome.reloadedConfigResult.hash,
+    summary: reloadOutcome.reloadedConfigResult.summary,
+    progress: progressAfter,
+    completed_exercise: {
+      exercise_id: previousExerciseLocator.exercise.exercise_id,
+      issue_error_id: previousExerciseLocator.issue.errorId,
+      issue_title: previousExerciseLocator.issue.title,
+      score: numericScore,
+      notes: normalizedPerformanceNotes,
+      finished_at: previousExerciseLocator.exercise.finished_at,
+    },
+    overview: {
+      issueIndex: nextLocator.issueIndex,
+      exerciseIndex: nextLocator.exerciseIndex,
+      issueCount: reloadOutcome.reloadedConfigResult.summary.issueCount,
+      totalExerciseCount: reloadOutcome.reloadedConfigResult.summary.exerciseCount,
+      exerciseCountInIssue: nextLocator.issue.exercises.length,
+    },
+    issue: buildIssuePayload(nextLocator.issue),
+    exercise: nextLocator.exercise,
+  };
+
+  log.info(
+    "[language_lesson] Returning next unfinished exercise after follow-up",
+    {},
+    {
+      returnPayload,
+      updatedToolSessionContext,
+      toolSessionContext,
+    },
+  );
+
+  return buildToolkitResult(returnPayload, updatedToolSessionContext);
+}
+
+function handleInitialCall(
+  loadedConfigState: LoadedConfigState,
+  toolSessionContext: ToolSessionContext,
+): ToolkitResult {
+  const initialLocator = findFirstUnfinishedExercise(loadedConfigState.mutableConfig);
 
   log.info(
     "[language_lesson] Selecting first unfinished exercise for initial call",
     {},
     {
       initialLocator,
-      progressBefore,
-      config_hash: parsedConfigResult.hash,
-      summary: parsedConfigResult.summary,
+      progressBefore: loadedConfigState.progressBefore,
+      config_hash: loadedConfigState.parsedConfigResult.hash,
+      summary: loadedConfigState.parsedConfigResult.summary,
       toolSessionContext,
     },
   );
 
   if (!initialLocator) {
     const returnPayload =
-      progressBefore.totalExerciseCount === 0
+      loadedConfigState.progressBefore.totalExerciseCount === 0
         ? {
             status: "no_exercises_available",
             mode: "initial",
             message: "No exercises were found in the language lesson config.",
-            config_hash: parsedConfigResult.hash,
-            summary: parsedConfigResult.summary,
-            progress: progressBefore,
+            config_hash: loadedConfigState.parsedConfigResult.hash,
+            summary: loadedConfigState.parsedConfigResult.summary,
+            progress: loadedConfigState.progressBefore,
           }
         : {
             status: "all_exercises_finished",
             mode: "initial",
             message: "All exercises are already finished.",
-            config_hash: parsedConfigResult.hash,
-            summary: parsedConfigResult.summary,
-            progress: progressBefore,
+            config_hash: loadedConfigState.parsedConfigResult.hash,
+            summary: loadedConfigState.parsedConfigResult.summary,
+            progress: loadedConfigState.progressBefore,
           };
 
     log.warn(
@@ -606,35 +691,32 @@ export async function get_next_language_exercise(
       {},
       {
         returnPayload,
-        progressBefore,
-        config_hash: parsedConfigResult.hash,
+        progressBefore: loadedConfigState.progressBefore,
+        config_hash: loadedConfigState.parsedConfigResult.hash,
         toolSessionContext,
       },
     );
 
-    return {
-      result: JSON.stringify(returnPayload, null, 2),
-      updatedToolSessionContext: toolSessionContext,
-    };
+    return buildToolkitResult(returnPayload, toolSessionContext);
   }
 
   const updatedToolSessionContext = buildUpdatedToolSessionContext(
     toolSessionContext,
     initialLocator,
-    parsedConfigResult.hash,
+    loadedConfigState.parsedConfigResult.hash,
   );
 
   const returnPayload = {
     status: "exercise_ready",
     mode: "initial",
-    config_hash: parsedConfigResult.hash,
-    summary: parsedConfigResult.summary,
-    progress: progressBefore,
+    config_hash: loadedConfigState.parsedConfigResult.hash,
+    summary: loadedConfigState.parsedConfigResult.summary,
+    progress: loadedConfigState.progressBefore,
     overview: {
       issueIndex: initialLocator.issueIndex,
       exerciseIndex: initialLocator.exerciseIndex,
-      issueCount: parsedConfigResult.summary.issueCount,
-      totalExerciseCount: parsedConfigResult.summary.exerciseCount,
+      issueCount: loadedConfigState.parsedConfigResult.summary.issueCount,
+      totalExerciseCount: loadedConfigState.parsedConfigResult.summary.exerciseCount,
       exerciseCountInIssue: initialLocator.issue.exercises.length,
     },
     issue: buildIssuePayload(initialLocator.issue),
@@ -651,8 +733,50 @@ export async function get_next_language_exercise(
     },
   );
 
-  return {
-    result: JSON.stringify(returnPayload, null, 2),
-    updatedToolSessionContext,
-  };
+  return buildToolkitResult(returnPayload, updatedToolSessionContext);
+}
+
+/**
+ * POC implementation:
+ * - Initial call: return first unfinished exercise.
+ * - Follow-up call: mark previous exercise finished in persisted JSON, save,
+ *   then return next unfinished exercise.
+ *
+ * This intentionally mutates user lesson JSON in storage for rapid prototyping.
+ */
+export async function get_next_language_exercise(
+  params: GetNextLanguageExerciseParams = {},
+  _context_params?: any,
+  toolSessionContext: ToolSessionContext = {},
+): Promise<ToolkitResult> {
+  const invocationState = buildInvocationState(params, toolSessionContext);
+
+  const invocationValidationResult = validateInvocationOrResult(
+    invocationState,
+    toolSessionContext,
+  );
+  if (invocationValidationResult) {
+    return invocationValidationResult;
+  }
+
+  const loadedConfigOutcome = await loadValidatedConfigOrResult(
+    invocationState,
+    toolSessionContext,
+  );
+  if (loadedConfigOutcome.toolkitResult || !loadedConfigOutcome.loadedConfigState) {
+    return loadedConfigOutcome.toolkitResult as ToolkitResult;
+  }
+
+  if (invocationState.isInitialCall) {
+    return handleInitialCall(
+      loadedConfigOutcome.loadedConfigState,
+      toolSessionContext,
+    );
+  }
+
+  return handleFollowUpCall(
+    invocationState,
+    loadedConfigOutcome.loadedConfigState,
+    toolSessionContext,
+  );
 }

--- a/modules/vm-webrtc/src/toolkit_functions/language_lesson.ts
+++ b/modules/vm-webrtc/src/toolkit_functions/language_lesson.ts
@@ -46,6 +46,73 @@ interface LoadedConfigState {
   progressBefore: ProgressSummary;
 }
 
+type LanguageExerciseToolMode = "initial" | "follow_up";
+
+type LanguageExerciseToolStatus =
+  | "next_exercise_ready"
+  | "all_exercises_finished"
+  | "no_exercises_available"
+  | "invalid_follow_up_input"
+  | "config_invalid"
+  | "persist_failed"
+  | "persist_reload_invalid"
+  | "previous_exercise_not_found";
+
+interface ExerciseOverview {
+  issueIndex: number;
+  exerciseIndex: number;
+  issueCount: number;
+  totalExerciseCount: number;
+  exerciseCountInIssue: number;
+}
+
+interface CompletedExercisePayload {
+  exercise_id: string;
+  issue_error_id: string;
+  issue_title: string;
+  score: number;
+  notes: string | null;
+  finished_at: string | null;
+}
+
+interface FollowUpInputPayload {
+  previous_exercise_id: string | null;
+  user_score: number | null;
+  performance_notes: string | null;
+}
+
+interface LanguageIssuePayload {
+  errorId: string;
+  title: string;
+  area?: string | null;
+  impact?: string | null;
+  description?: string | null;
+  theory?: string | null;
+  theory_voice?: LanguageIssue["theory_voice"];
+  categoryCode?: string | null;
+  subcategoryCode?: string | null;
+  subcategoryName?: string | null;
+}
+
+interface LanguageExerciseToolResponse {
+  type: "language_exercise_tool_response";
+  version: "1.0";
+  status: LanguageExerciseToolStatus;
+  mode: LanguageExerciseToolMode;
+  message: string;
+  next_action_suggestion: string;
+  config_hash: string | null;
+  summary: LoadParsedLanguageLessonConfigResult["summary"] | null;
+  progress: ProgressSummary | null;
+  overview: ExerciseOverview | null;
+  issue: LanguageIssuePayload | null;
+  exercise: LanguageExercise | null;
+  completed_exercise: CompletedExercisePayload | null;
+  input: FollowUpInputPayload | null;
+  validationErrors: string[];
+  error: string | null;
+}
+
 function isExerciseFinished(exercise: LanguageExercise): boolean {
   return exercise.status === "finished";
 }
@@ -129,7 +196,7 @@ function summarizeProgress(
   };
 }
 
-function buildIssuePayload(issue: LanguageIssue) {
+function buildIssuePayload(issue: LanguageIssue): LanguageIssuePayload {
   return {
     errorId: issue.errorId,
     title: issue.title,
@@ -141,6 +208,65 @@ function buildIssuePayload(issue: LanguageIssue) {
     categoryCode: issue.categoryCode,
     subcategoryCode: issue.subcategoryCode,
     subcategoryName: issue.subcategoryName,
+  };
+}
+
+function buildNextActionSuggestion(status: LanguageExerciseToolStatus): string {
+  switch (status) {
+    case "next_exercise_ready":
+      return "Ask the user if they want to continue to the next exercise or do something else. If they want to continue, present the returned exercise immediately.";
+    case "all_exercises_finished":
+      return "Congratulate the user for finishing all exercises and ask if they want to practice a new issue.";
+    case "no_exercises_available":
+      return "Tell the user no exercises are currently configured and ask them to add language lesson JSON in Configure Tools.";
+    case "invalid_follow_up_input":
+      return "Apologize to the user and tell them we hit an internal error that is not their fault.  Ask them what they want help with next.";
+    case "config_invalid":
+      return "Tell the user the lesson JSON is invalid or missing and ask them to fix it in Configure Tools.";
+    case "persist_failed":
+    case "persist_reload_invalid":
+      return "Tell the user progress could not be saved reliably and ask them to retry the exercise flow.";
+    case "previous_exercise_not_found":
+      return "Tell the user the previous exercise id was not found and tell them we hit an internal erorr that is not their fault.  Ask them what they want help with next..";
+    default:
+      return "Continue the lesson flow based on the returned status.";
+  }
+}
+
+function buildLanguageExerciseToolResponse(params: {
+  status: LanguageExerciseToolStatus;
+  mode: LanguageExerciseToolMode;
+  message: string;
+  next_action_suggestion?: string;
+  config_hash?: string | null;
+  summary?: LoadParsedLanguageLessonConfigResult["summary"] | null;
+  progress?: ProgressSummary | null;
+  overview?: ExerciseOverview | null;
+  issue?: LanguageIssuePayload | null;
+  exercise?: LanguageExercise | null;
+  completed_exercise?: CompletedExercisePayload | null;
+  input?: FollowUpInputPayload | null;
+  validationErrors?: string[];
+  error?: string | null;
+}): LanguageExerciseToolResponse {
+  return {
+    type: "language_exercise_tool_response",
+    version: "1.0",
+    status: params.status,
+    mode: params.mode,
+    message: params.message,
+    next_action_suggestion:
+      params.next_action_suggestion || buildNextActionSuggestion(params.status),
+    config_hash: params.config_hash ?? null,
+    summary: params.summary ?? null,
+    progress: params.progress ?? null,
+    overview: params.overview ?? null,
+    issue: params.issue ?? null,
+    exercise: params.exercise ?? null,
+    completed_exercise: params.completed_exercise ?? null,
+    input: params.input ?? null,
+    validationErrors: params.validationErrors ?? [],
+    error: params.error ?? null,
   };
 }
 
@@ -248,7 +374,7 @@ function validateInvocationOrResult(
     return null;
   }
 
-  const returnPayload = {
+  const returnPayload = buildLanguageExerciseToolResponse({
     status: "invalid_follow_up_input",
     mode: "follow_up",
     message:
@@ -258,7 +384,7 @@ function validateInvocationOrResult(
       user_score: invocationState.user_score,
       performance_notes: invocationState.performance_notes,
     },
-  };
+  });
 
   log.warn(
     "[language_lesson] Returning invalid follow-up input",
@@ -297,7 +423,7 @@ async function loadValidatedConfigOrResult(
     parsedConfigResult.validationErrors.length > 0 ||
     !parsedConfigResult.parsedConfig
   ) {
-    const returnPayload = {
+    const returnPayload = buildLanguageExerciseToolResponse({
       status: "config_invalid",
       mode: invocationState.isInitialCall ? "initial" : "follow_up",
       message:
@@ -305,7 +431,7 @@ async function loadValidatedConfigOrResult(
       config_hash: parsedConfigResult.hash,
       summary: parsedConfigResult.summary,
       validationErrors: parsedConfigResult.validationErrors,
-    };
+    });
 
     log.warn(
       "[language_lesson] Returning config_invalid",
@@ -370,13 +496,14 @@ async function persistUpdatedConfigOrErrorResult(
   } catch (error) {
     const errorMessage = error instanceof Error ? error.message : String(error);
 
-    const returnPayload = {
+    const returnPayload = buildLanguageExerciseToolResponse({
       status: "persist_failed",
       mode: "follow_up",
       message: "Failed to persist updated language lesson progress.",
       error: errorMessage,
       config_hash: parsedConfigResult.hash,
-    };
+      summary: parsedConfigResult.summary,
+    });
 
     log.error(
       "[language_lesson] Failed to persist updated lesson progress",
@@ -429,7 +556,7 @@ async function reloadPersistedConfigOrResult(
     reloadedConfigResult.validationErrors.length > 0 ||
     !reloadedConfigResult.parsedConfig
   ) {
-    const returnPayload = {
+    const returnPayload = buildLanguageExerciseToolResponse({
       status: "persist_reload_invalid",
       mode: "follow_up",
       message:
@@ -437,7 +564,7 @@ async function reloadPersistedConfigOrResult(
       config_hash: reloadedConfigResult.hash,
       summary: reloadedConfigResult.summary,
       validationErrors: reloadedConfigResult.validationErrors,
-    };
+    });
 
     log.error(
       "[language_lesson] Persisted config failed reload validation",
@@ -479,19 +606,20 @@ async function handleFollowUpCall(
   );
 
   if (!previousExerciseLocator) {
-    const returnPayload = {
+    const returnPayload = buildLanguageExerciseToolResponse({
       status: "previous_exercise_not_found",
       mode: "follow_up",
       message:
         "Could not find previous_exercise_id in current language lesson config.",
       config_hash: loadedConfigState.parsedConfigResult.hash,
       summary: loadedConfigState.parsedConfigResult.summary,
+      progress: loadedConfigState.progressBefore,
       input: {
         previous_exercise_id: invocationState.normalizedPreviousExerciseId,
         user_score: numericScore,
         performance_notes: normalizedPerformanceNotes,
       },
-    };
+    });
 
     log.warn(
       "[language_lesson] Returning previous_exercise_not_found",
@@ -596,7 +724,7 @@ async function handleFollowUpCall(
       previousExerciseLocator.issue.errorId,
     );
 
-    const returnPayload = {
+    const returnPayload = buildLanguageExerciseToolResponse({
       status: "all_exercises_finished",
       mode: "follow_up",
       message: "All exercises are finished.",
@@ -609,9 +737,9 @@ async function handleFollowUpCall(
         issue_title: previousExerciseLocator.issue.title,
         score: numericScore,
         notes: normalizedPerformanceNotes,
-        finished_at: previousExerciseLocator.exercise.finished_at,
+        finished_at: previousExerciseLocator.exercise.finished_at || null,
       },
-    };
+    });
 
     log.info(
       "[language_lesson] Returning all_exercises_finished",
@@ -632,8 +760,8 @@ async function handleFollowUpCall(
     reloadOutcome.reloadedConfigResult.hash,
   );
 
-  const returnPayload = {
-    status: "exercise_ready",
+  const returnPayload = buildLanguageExerciseToolResponse({
+    status: "next_exercise_ready",
     mode: "follow_up",
     message:
       "Previous exercise was marked finished and persisted. Returning next unfinished exercise.",
@@ -646,7 +774,7 @@ async function handleFollowUpCall(
       issue_title: previousExerciseLocator.issue.title,
       score: numericScore,
       notes: normalizedPerformanceNotes,
-      finished_at: previousExerciseLocator.exercise.finished_at,
+      finished_at: previousExerciseLocator.exercise.finished_at || null,
     },
     overview: {
       issueIndex: nextLocator.issueIndex,
@@ -658,7 +786,7 @@ async function handleFollowUpCall(
     },
     issue: buildIssuePayload(nextLocator.issue),
     exercise: nextLocator.exercise,
-  };
+  });
 
   log.info(
     "[language_lesson] Returning next unfinished exercise after follow-up",
@@ -696,22 +824,22 @@ function handleInitialCall(
   if (!initialLocator) {
     const returnPayload =
       loadedConfigState.progressBefore.totalExerciseCount === 0
-        ? {
+        ? buildLanguageExerciseToolResponse({
             status: "no_exercises_available",
             mode: "initial",
             message: "No exercises were found in the language lesson config.",
             config_hash: loadedConfigState.parsedConfigResult.hash,
             summary: loadedConfigState.parsedConfigResult.summary,
             progress: loadedConfigState.progressBefore,
-          }
-        : {
+          })
+        : buildLanguageExerciseToolResponse({
             status: "all_exercises_finished",
             mode: "initial",
             message: "All exercises are already finished.",
             config_hash: loadedConfigState.parsedConfigResult.hash,
             summary: loadedConfigState.parsedConfigResult.summary,
             progress: loadedConfigState.progressBefore,
-          };
+          });
 
     log.warn(
       "[language_lesson] No initial unfinished exercise available",
@@ -733,9 +861,10 @@ function handleInitialCall(
     loadedConfigState.parsedConfigResult.hash,
   );
 
-  const returnPayload = {
-    status: "exercise_ready",
+  const returnPayload = buildLanguageExerciseToolResponse({
+    status: "next_exercise_ready",
     mode: "initial",
+    message: "Returning next unfinished exercise.",
     config_hash: loadedConfigState.parsedConfigResult.hash,
     summary: loadedConfigState.parsedConfigResult.summary,
     progress: loadedConfigState.progressBefore,
@@ -749,7 +878,7 @@ function handleInitialCall(
     },
     issue: buildIssuePayload(initialLocator.issue),
     exercise: initialLocator.exercise,
-  };
+  });
 
   log.info(
     "[language_lesson] Returning initial unfinished exercise",

--- a/modules/vm-webrtc/src/toolkit_functions/language_lesson.ts
+++ b/modules/vm-webrtc/src/toolkit_functions/language_lesson.ts
@@ -71,6 +71,13 @@ interface CompletedExercisePayload {
   exercise_id: string;
 }
 
+interface GradingResultPayload {
+  user_score: number;
+  performance_notes: string | null;
+  passed: boolean;
+  passing_score_threshold: number;
+}
+
 interface FollowUpInputPayload {
   previous_exercise_id: string | null;
   user_score: number | null;
@@ -104,6 +111,7 @@ interface LanguageExerciseToolResponse {
   issue: LanguageIssuePayload | null;
   next_exercise: LanguageExercise | null;
   completed_exercise: CompletedExercisePayload | null;
+  grading_result: GradingResultPayload | null;
   input: FollowUpInputPayload | null;
   validationErrors: string[];
   error: string | null;
@@ -220,9 +228,9 @@ function buildNextActionSuggestion(status: LanguageExerciseToolStatus): string {
     case "next_exercise_ready":
       return "Present next_exercise to the user now. After the user responds, call language_lesson__grade_user_exercise with previous_exercise_id, user_score, and optional performance_notes.";
     case "ready_for_next_exercise":
-      return "Call language_lesson__start_next_exercise to fetch the next unfinished exercise.";
+      return "Tell the user their score and why using grading_result, then call language_lesson__start_next_exercise to fetch the next unfinished exercise.";
     case "retry_current_exercise":
-      return "Ask the user to retry the exercise in next_exercise, then call language_lesson__grade_user_exercise again with previous_exercise_id, user_score, and performance_notes.";
+      return "Tell the user their score and why using grading_result, ask them to retry the exercise in next_exercise, then call language_lesson__grade_user_exercise again with previous_exercise_id, user_score, and performance_notes.";
     case "all_exercises_finished":
       return "Congratulate the user for finishing all exercises and ask if they want to practice a new issue.";
     case "no_exercises_available":
@@ -253,6 +261,7 @@ function buildLanguageExerciseToolResponse(params: {
   issue?: LanguageIssuePayload | null;
   next_exercise?: LanguageExercise | null;
   completed_exercise?: CompletedExercisePayload | null;
+  grading_result?: GradingResultPayload | null;
   input?: FollowUpInputPayload | null;
   validationErrors?: string[];
   error?: string | null;
@@ -272,6 +281,7 @@ function buildLanguageExerciseToolResponse(params: {
     issue: params.issue ?? null,
     next_exercise: params.next_exercise ?? null,
     completed_exercise: params.completed_exercise ?? null,
+    grading_result: params.grading_result ?? null,
     input: params.input ?? null,
     validationErrors: params.validationErrors ?? [],
     error: params.error ?? null,
@@ -944,12 +954,18 @@ export async function grade_user_exercise(
       status: "ready_for_next_exercise",
       mode: "follow_up",
       message:
-        "Pending exercise was graded as passing and persisted. Call language_lesson__start_next_exercise to fetch the next unfinished exercise.",
+        "Pending exercise was graded as passing and persisted. Tell the user their score and why this score was assigned, then call language_lesson__start_next_exercise to fetch the next unfinished exercise.",
       config_hash: reloadOutcome.reloadedConfigResult.hash,
       summary: reloadOutcome.reloadedConfigResult.summary,
       progress: progressAfter,
       completed_exercise: {
         exercise_id: validatedInput.previousExerciseId,
+      },
+      grading_result: {
+        user_score: validatedInput.userScore,
+        performance_notes: validatedInput.performanceNotes,
+        passed,
+        passing_score_threshold: PASSING_SCORE_THRESHOLD,
       },
     });
 
@@ -1013,7 +1029,7 @@ export async function grade_user_exercise(
     status: "retry_current_exercise",
     mode: "follow_up",
     message:
-      "Pending exercise score was below passing threshold and was persisted. Ask the user to retry this same exercise.",
+      "Pending exercise score was below passing threshold and was persisted. Tell the user their score and why this score was assigned, then ask the user to retry this same exercise.",
     config_hash: reloadOutcome.reloadedConfigResult.hash,
     summary: reloadOutcome.reloadedConfigResult.summary,
     progress: progressAfter,
@@ -1027,6 +1043,12 @@ export async function grade_user_exercise(
     },
     issue: buildIssuePayload(retryLocator.issue),
     next_exercise: retryLocator.exercise,
+    grading_result: {
+      user_score: validatedInput.userScore,
+      performance_notes: validatedInput.performanceNotes,
+      passed,
+      passing_score_threshold: PASSING_SCORE_THRESHOLD,
+    },
     input: {
       previous_exercise_id: validatedInput.previousExerciseId,
       user_score: validatedInput.userScore,

--- a/modules/vm-webrtc/src/toolkit_functions/language_lesson.ts
+++ b/modules/vm-webrtc/src/toolkit_functions/language_lesson.ts
@@ -1,4 +1,5 @@
 import { log } from "../../../../lib/logger";
+import { loadParsedLanguageLessonConfig } from "../../../../lib/languageLessonConfig";
 import type { ToolSessionContext, ToolkitResult } from "./types";
 
 export interface GetNextLanguageExerciseParams {
@@ -9,8 +10,9 @@ export interface GetNextLanguageExerciseParams {
 
 /**
  * Stub implementation for the language lesson exercise flow.
- * Accepts optional score/update data from the previous exercise and
- * returns a placeholder response until persistence and drill logic are implemented.
+ * Step 1 implementation:
+ * - First call (no previous exercise result): return first exercise in config.
+ * - Follow-up calls with previous results: not implemented yet.
  */
 export async function get_next_language_exercise(
   params: GetNextLanguageExerciseParams = {},
@@ -34,21 +36,119 @@ export async function get_next_language_exercise(
     },
   );
 
+  const isInitialCall =
+    (!previous_exercise_id || previous_exercise_id.trim().length === 0) &&
+    user_score === null;
+
+  if (!isInitialCall) {
+    return {
+      result: JSON.stringify(
+        {
+          status: "not_implemented",
+          mode: "follow_up",
+          message:
+            "Step 2 is not implemented yet. Only initial exercise fetch is implemented.",
+          input: {
+            previous_exercise_id,
+            user_score,
+            performance_notes,
+          },
+        },
+        null,
+        2,
+      ),
+      updatedToolSessionContext: toolSessionContext,
+    };
+  }
+
+  const parsedConfigResult = await loadParsedLanguageLessonConfig();
+
+  if (
+    parsedConfigResult.validationErrors.length > 0 ||
+    !parsedConfigResult.parsedConfig
+  ) {
+    return {
+      result: JSON.stringify(
+        {
+          status: "config_invalid",
+          mode: "initial",
+          message:
+            "Language lesson config is invalid or missing. Update the JSON in Configure Tools.",
+          config_hash: parsedConfigResult.hash,
+          summary: parsedConfigResult.summary,
+          validationErrors: parsedConfigResult.validationErrors,
+        },
+        null,
+        2,
+      ),
+      updatedToolSessionContext: toolSessionContext,
+    };
+  }
+
+  const languageIssues = parsedConfigResult.parsedConfig.language_issues;
+  const firstIssue = languageIssues[0];
+
+  if (!firstIssue || firstIssue.exercises.length === 0) {
+    return {
+      result: JSON.stringify(
+        {
+          status: "no_exercises_available",
+          mode: "initial",
+          message: "No exercises were found in the language lesson config.",
+          config_hash: parsedConfigResult.hash,
+          summary: parsedConfigResult.summary,
+        },
+        null,
+        2,
+      ),
+      updatedToolSessionContext: toolSessionContext,
+    };
+  }
+
+  const firstExercise = firstIssue.exercises[0];
+
+  const updatedToolSessionContext: ToolSessionContext = {
+    ...toolSessionContext,
+    current_issue_error_id: firstIssue.errorId,
+    current_exercise_id: firstExercise.exercise_id,
+    current_issue_index: "0",
+    current_exercise_index: "0",
+  };
+
+  if (parsedConfigResult.hash) {
+    updatedToolSessionContext.language_lesson_config_hash =
+      parsedConfigResult.hash;
+  }
+
   return {
     result: JSON.stringify(
       {
-        status: "not_implemented",
-        message:
-          "Language lesson flow is not implemented yet. This is a stub tool response.",
-        input: {
-          previous_exercise_id,
-          user_score,
-          performance_notes,
+        status: "exercise_ready",
+        mode: "initial",
+        config_hash: parsedConfigResult.hash,
+        overview: {
+          issueIndex: 0,
+          exerciseIndex: 0,
+          issueCount: parsedConfigResult.summary.issueCount,
+          totalExerciseCount: parsedConfigResult.summary.exerciseCount,
+          exerciseCountInIssue: firstIssue.exercises.length,
         },
+        issue: {
+          errorId: firstIssue.errorId,
+          title: firstIssue.title,
+          area: firstIssue.area,
+          impact: firstIssue.impact,
+          description: firstIssue.description,
+          theory: firstIssue.theory,
+          categoryCode: firstIssue.categoryCode,
+          subcategoryCode: firstIssue.subcategoryCode,
+          subcategoryName: firstIssue.subcategoryName,
+        },
+        exercise: firstExercise,
       },
       null,
       2,
     ),
-    updatedToolSessionContext: toolSessionContext,
+    updatedToolSessionContext,
   };
 }

--- a/modules/vm-webrtc/src/toolkit_functions/language_lesson.ts
+++ b/modules/vm-webrtc/src/toolkit_functions/language_lesson.ts
@@ -7,11 +7,20 @@ import {
 import type { NormalizedLanguageLessonConfig } from "./language_lesson_schema";
 import type { ToolSessionContext, ToolkitResult } from "./types";
 
-export interface GetNextLanguageExerciseParams {
+export interface StartFirstExerciseParams {}
+
+export interface GradeUserExerciseParams {
   previous_exercise_id?: string | null;
   user_score?: number | null;
   performance_notes?: string | null;
 }
+
+export interface StartNextExerciseParams {
+  previous_exercise_id?: string | null;
+}
+
+// Backward-compat alias for legacy tool callers.
+export type GetNextLanguageExerciseParams = GradeUserExerciseParams;
 
 type LanguageIssue = NormalizedLanguageLessonConfig["language_issues"][number];
 type LanguageExercise = LanguageIssue["exercises"][number];
@@ -30,16 +39,6 @@ interface ProgressSummary {
   pendingExerciseCount: number;
 }
 
-interface InvocationState {
-  previous_exercise_id: string | null;
-  user_score: number | null;
-  performance_notes: string | null;
-  normalizedPreviousExerciseId: string;
-  hasPreviousExerciseId: boolean;
-  hasUserScore: boolean;
-  isInitialCall: boolean;
-}
-
 interface LoadedConfigState {
   parsedConfigResult: LoadParsedLanguageLessonConfigResult;
   mutableConfig: NormalizedLanguageLessonConfig;
@@ -50,6 +49,8 @@ type LanguageExerciseToolMode = "initial" | "follow_up";
 
 type LanguageExerciseToolStatus =
   | "next_exercise_ready"
+  | "ready_for_next_exercise"
+  | "retry_current_exercise"
   | "all_exercises_finished"
   | "no_exercises_available"
   | "invalid_follow_up_input"
@@ -107,6 +108,14 @@ interface LanguageExerciseToolResponse {
   validationErrors: string[];
   error: string | null;
 }
+
+interface ValidatedGradeInput {
+  previousExerciseId: string;
+  userScore: number;
+  performanceNotes: string | null;
+}
+
+const PASSING_SCORE_THRESHOLD = 8;
 
 function isExerciseFinished(exercise: LanguageExercise): boolean {
   return exercise.status === "finished";
@@ -209,20 +218,24 @@ function buildIssuePayload(issue: LanguageIssue): LanguageIssuePayload {
 function buildNextActionSuggestion(status: LanguageExerciseToolStatus): string {
   switch (status) {
     case "next_exercise_ready":
-      return "Assume the user wants to keep going. Give the next exercise to the user using next_exercise, then after the user responds call language_lesson__get_next_language_exercise again with previous_exercise_id, user_score, and performance_notes.";
+      return "Present next_exercise to the user now. After the user responds, call language_lesson__grade_user_exercise with previous_exercise_id, user_score, and optional performance_notes.";
+    case "ready_for_next_exercise":
+      return "Call language_lesson__start_next_exercise to fetch the next unfinished exercise.";
+    case "retry_current_exercise":
+      return "Ask the user to retry the exercise in next_exercise, then call language_lesson__grade_user_exercise again with previous_exercise_id, user_score, and performance_notes.";
     case "all_exercises_finished":
       return "Congratulate the user for finishing all exercises and ask if they want to practice a new issue.";
     case "no_exercises_available":
       return "Tell the user no exercises are currently configured and ask them to add language lesson JSON in Configure Tools.";
     case "invalid_follow_up_input":
-      return "Apologize to the user and tell them we hit an internal error that is not their fault.  Ask them what they want help with next.";
+      return "Apologize to the user and tell them we hit an internal error that is not their fault. Ask them what they want help with next.";
     case "config_invalid":
       return "Tell the user the lesson JSON is invalid or missing and ask them to fix it in Configure Tools.";
     case "persist_failed":
     case "persist_reload_invalid":
       return "Tell the user progress could not be saved reliably and ask them to retry the exercise flow.";
     case "previous_exercise_not_found":
-      return "Tell the user the previous exercise id was not found and tell them we hit an internal erorr that is not their fault.  Ask them what they want help with next..";
+      return "Tell the user the pending exercise id was not found and that this internal issue is not their fault. Ask what they want help with next.";
     default:
       return "Continue the lesson flow based on the returned status.";
   }
@@ -314,99 +327,20 @@ function buildToolkitResult(
   };
 }
 
-function buildInvocationState(
-  params: GetNextLanguageExerciseParams,
-  toolSessionContext: ToolSessionContext,
-): InvocationState {
-  const {
-    previous_exercise_id = null,
-    user_score = null,
-    performance_notes = null,
-  } = params;
-
-  log.info(
-    "[language_lesson] get_next_language_exercise called",
-    {},
-    {
-      previous_exercise_id,
-      user_score,
-      performance_notes,
-      toolSessionContext,
-    },
-  );
-
-  const normalizedPreviousExerciseId = (previous_exercise_id || "").trim();
-  const hasPreviousExerciseId = normalizedPreviousExerciseId.length > 0;
-  const hasUserScore = user_score !== null && user_score !== undefined;
-  const isInitialCall = !hasPreviousExerciseId && !hasUserScore;
-
-  const invocationState: InvocationState = {
-    previous_exercise_id,
-    user_score,
-    performance_notes,
-    normalizedPreviousExerciseId,
-    hasPreviousExerciseId,
-    hasUserScore,
-    isInitialCall,
-  };
-
-  log.info(
-    "[language_lesson] Determined invocation mode",
-    {},
-    {
-      ...invocationState,
-      toolSessionContext,
-    },
-  );
-
-  return invocationState;
-}
-
-function validateInvocationOrResult(
-  invocationState: InvocationState,
-  toolSessionContext: ToolSessionContext,
-): ToolkitResult | null {
-  if (invocationState.isInitialCall) {
+function normalizePerformanceNotes(
+  performanceNotes: string | null | undefined,
+): string | null {
+  if (!performanceNotes || performanceNotes.trim().length === 0) {
     return null;
   }
 
-  const hasValidUserScore =
-    typeof invocationState.user_score === "number" &&
-    Number.isFinite(invocationState.user_score);
-
-  if (invocationState.hasPreviousExerciseId && hasValidUserScore) {
-    return null;
-  }
-
-  const returnPayload = buildLanguageExerciseToolResponse({
-    status: "invalid_follow_up_input",
-    mode: "follow_up",
-    message:
-      "Follow-up calls require both previous_exercise_id and numeric user_score.",
-    input: {
-      previous_exercise_id: invocationState.previous_exercise_id,
-      user_score: invocationState.user_score,
-      performance_notes: invocationState.performance_notes,
-    },
-  });
-
-  log.warn(
-    "[language_lesson] Returning invalid follow-up input",
-    {},
-    {
-      ...invocationState,
-      hasValidUserScore,
-      toolSessionContext,
-      returnPayload,
-    },
-  );
-
-  return buildToolkitResult(returnPayload, toolSessionContext);
+  return performanceNotes;
 }
 
 async function loadValidatedConfigOrResult(
-  invocationState: InvocationState,
+  mode: LanguageExerciseToolMode,
   toolSessionContext: ToolSessionContext,
+  logContext: Record<string, unknown>,
 ): Promise<{
   loadedConfigState: LoadedConfigState | null;
   toolkitResult: ToolkitResult | null;
@@ -417,7 +351,8 @@ async function loadValidatedConfigOrResult(
     "[language_lesson] Loaded parsed language lesson config",
     {},
     {
-      invocationState,
+      mode,
+      logContext,
       parsedConfigResult,
       toolSessionContext,
     },
@@ -429,7 +364,7 @@ async function loadValidatedConfigOrResult(
   ) {
     const returnPayload = buildLanguageExerciseToolResponse({
       status: "config_invalid",
-      mode: invocationState.isInitialCall ? "initial" : "follow_up",
+      mode,
       message:
         "Language lesson config is invalid or missing. Update the JSON in Configure Tools.",
       config_hash: parsedConfigResult.hash,
@@ -441,7 +376,8 @@ async function loadValidatedConfigOrResult(
       "[language_lesson] Returning config_invalid",
       {},
       {
-        invocationState,
+        mode,
+        logContext,
         parsedConfigResult,
         returnPayload,
         toolSessionContext,
@@ -461,7 +397,8 @@ async function loadValidatedConfigOrResult(
     "[language_lesson] Current progress before operation",
     {},
     {
-      invocationState,
+      mode,
+      logContext,
       progressBefore,
       config_hash: parsedConfigResult.hash,
       summary: parsedConfigResult.summary,
@@ -479,21 +416,12 @@ async function loadValidatedConfigOrResult(
   };
 }
 
-function normalizePerformanceNotes(
-  performanceNotes: string | null,
-): string | null {
-  if (!performanceNotes || performanceNotes.trim().length === 0) {
-    return null;
-  }
-
-  return performanceNotes;
-}
-
 async function persistUpdatedConfigOrErrorResult(
   mutableConfig: NormalizedLanguageLessonConfig,
   parsedConfigResult: LoadParsedLanguageLessonConfigResult,
-  previousExerciseId: string,
+  mode: LanguageExerciseToolMode,
   toolSessionContext: ToolSessionContext,
+  logContext: Record<string, unknown>,
 ): Promise<ToolkitResult | null> {
   try {
     await saveParsedLanguageLessonConfig(mutableConfig);
@@ -502,7 +430,7 @@ async function persistUpdatedConfigOrErrorResult(
 
     const returnPayload = buildLanguageExerciseToolResponse({
       status: "persist_failed",
-      mode: "follow_up",
+      mode,
       message: "Failed to persist updated language lesson progress.",
       error: errorMessage,
       config_hash: parsedConfigResult.hash,
@@ -513,6 +441,8 @@ async function persistUpdatedConfigOrErrorResult(
       "[language_lesson] Failed to persist updated lesson progress",
       {},
       {
+        mode,
+        logContext,
         errorMessage,
         returnPayload,
         mutableConfig,
@@ -528,7 +458,8 @@ async function persistUpdatedConfigOrErrorResult(
     "[language_lesson] Persisted updated lesson progress",
     {},
     {
-      previous_exercise_id: previousExerciseId,
+      mode,
+      logContext,
       config_hash_before_save: parsedConfigResult.hash,
       mutableConfig,
       toolSessionContext,
@@ -539,7 +470,9 @@ async function persistUpdatedConfigOrErrorResult(
 }
 
 async function reloadPersistedConfigOrResult(
+  mode: LanguageExerciseToolMode,
   toolSessionContext: ToolSessionContext,
+  logContext: Record<string, unknown>,
 ): Promise<{
   reloadedConfigResult: LoadParsedLanguageLessonConfigResult | null;
   reloadedConfig: NormalizedLanguageLessonConfig | null;
@@ -551,6 +484,8 @@ async function reloadPersistedConfigOrResult(
     "[language_lesson] Reloaded config after persistence",
     {},
     {
+      mode,
+      logContext,
       reloadedConfigResult,
       toolSessionContext,
     },
@@ -562,7 +497,7 @@ async function reloadPersistedConfigOrResult(
   ) {
     const returnPayload = buildLanguageExerciseToolResponse({
       status: "persist_reload_invalid",
-      mode: "follow_up",
+      mode,
       message:
         "Progress was saved but reloading the updated config failed validation.",
       config_hash: reloadedConfigResult.hash,
@@ -574,6 +509,8 @@ async function reloadPersistedConfigOrResult(
       "[language_lesson] Persisted config failed reload validation",
       {},
       {
+        mode,
+        logContext,
         returnPayload,
         reloadedConfigResult,
         toolSessionContext,
@@ -594,22 +531,316 @@ async function reloadPersistedConfigOrResult(
   };
 }
 
-async function handleFollowUpCall(
-  invocationState: InvocationState,
-  loadedConfigState: LoadedConfigState,
+function updateExerciseAttemptState(params: {
+  exercise: LanguageExercise;
+  userScore: number;
+  performanceNotes: string | null;
+  passed: boolean;
+}): void {
+  const existingAttempts =
+    typeof params.exercise.attempts === "number" ? params.exercise.attempts : 0;
+
+  params.exercise.attempts = existingAttempts + 1;
+  params.exercise.last_score = params.userScore;
+  params.exercise.last_notes = params.performanceNotes;
+
+  if (params.passed) {
+    params.exercise.status = "finished";
+    params.exercise.finished_at = new Date().toISOString();
+    return;
+  }
+
+  params.exercise.status = "pending";
+  params.exercise.finished_at = null;
+}
+
+function buildSelectionResult(params: {
+  mode: LanguageExerciseToolMode;
+  parsedConfigResult: LoadParsedLanguageLessonConfigResult;
+  config: NormalizedLanguageLessonConfig;
+  progress: ProgressSummary;
+  toolSessionContext: ToolSessionContext;
+  completedExerciseId?: string;
+}): ToolkitResult {
+  const nextLocator = findFirstUnfinishedExercise(params.config);
+
+  log.info(
+    "[language_lesson] Selecting next unfinished exercise",
+    {},
+    {
+      mode: params.mode,
+      nextLocator,
+      progress: params.progress,
+      config_hash: params.parsedConfigResult.hash,
+      summary: params.parsedConfigResult.summary,
+      completedExerciseId: params.completedExerciseId ?? null,
+      toolSessionContext: params.toolSessionContext,
+    },
+  );
+
+  if (!nextLocator) {
+    const status: LanguageExerciseToolStatus =
+      params.progress.totalExerciseCount === 0
+        ? "no_exercises_available"
+        : "all_exercises_finished";
+
+    const message =
+      status === "no_exercises_available"
+        ? "No exercises were found in the language lesson config."
+        : "All exercises are finished.";
+
+    const updatedToolSessionContext = buildUpdatedToolSessionContext(
+      params.toolSessionContext,
+      null,
+      params.parsedConfigResult.hash,
+      params.toolSessionContext.current_issue_error_id,
+    );
+
+    const returnPayload = buildLanguageExerciseToolResponse({
+      status,
+      mode: params.mode,
+      message,
+      config_hash: params.parsedConfigResult.hash,
+      summary: params.parsedConfigResult.summary,
+      progress: params.progress,
+      completed_exercise: params.completedExerciseId
+        ? { exercise_id: params.completedExerciseId }
+        : null,
+    });
+
+    log.info(
+      "[language_lesson] Returning selection result with no unfinished exercises",
+      {},
+      {
+        mode: params.mode,
+        returnPayload,
+        updatedToolSessionContext,
+        toolSessionContext: params.toolSessionContext,
+      },
+    );
+
+    return buildToolkitResult(returnPayload, updatedToolSessionContext);
+  }
+
+  const updatedToolSessionContext = buildUpdatedToolSessionContext(
+    params.toolSessionContext,
+    nextLocator,
+    params.parsedConfigResult.hash,
+  );
+
+  const returnPayload = buildLanguageExerciseToolResponse({
+    status: "next_exercise_ready",
+    mode: params.mode,
+    message:
+      "Returning the next exercise to give to the user. The next exercise details are in the next_exercise field.",
+    config_hash: params.parsedConfigResult.hash,
+    summary: params.parsedConfigResult.summary,
+    progress: params.progress,
+    completed_exercise: params.completedExerciseId
+      ? { exercise_id: params.completedExerciseId }
+      : null,
+    overview: {
+      issueIndex: nextLocator.issueIndex,
+      exerciseIndex: nextLocator.exerciseIndex,
+      issueCount: params.parsedConfigResult.summary.issueCount,
+      totalExerciseCount: params.parsedConfigResult.summary.exerciseCount,
+      exerciseCountInIssue: nextLocator.issue.exercises.length,
+    },
+    issue: buildIssuePayload(nextLocator.issue),
+    next_exercise: nextLocator.exercise,
+  });
+
+  log.info(
+    "[language_lesson] Returning next_exercise_ready",
+    {},
+    {
+      mode: params.mode,
+      returnPayload,
+      updatedToolSessionContext,
+      toolSessionContext: params.toolSessionContext,
+    },
+  );
+
+  return buildToolkitResult(returnPayload, updatedToolSessionContext);
+}
+
+function validateGradeInputOrResult(
+  params: GradeUserExerciseParams,
   toolSessionContext: ToolSessionContext,
+): {
+  validatedInput: ValidatedGradeInput | null;
+  toolkitResult: ToolkitResult | null;
+} {
+  const normalizedPreviousExerciseId = (
+    params.previous_exercise_id || ""
+  ).trim();
+  const hasPreviousExerciseId = normalizedPreviousExerciseId.length > 0;
+  const hasValidUserScore =
+    typeof params.user_score === "number" && Number.isFinite(params.user_score);
+
+  log.info(
+    "[language_lesson] Validating grade_user_exercise input",
+    {},
+    {
+      params,
+      normalizedPreviousExerciseId,
+      hasPreviousExerciseId,
+      hasValidUserScore,
+      toolSessionContext,
+    },
+  );
+
+  if (!hasPreviousExerciseId || !hasValidUserScore) {
+    const returnPayload = buildLanguageExerciseToolResponse({
+      status: "invalid_follow_up_input",
+      mode: "follow_up",
+      message:
+        "grade_user_exercise requires both previous_exercise_id and numeric user_score.",
+      input: {
+        previous_exercise_id: params.previous_exercise_id ?? null,
+        user_score: params.user_score ?? null,
+        performance_notes: params.performance_notes ?? null,
+      },
+    });
+
+    log.warn(
+      "[language_lesson] Returning invalid follow-up input for grade_user_exercise",
+      {},
+      {
+        params,
+        normalizedPreviousExerciseId,
+        hasPreviousExerciseId,
+        hasValidUserScore,
+        returnPayload,
+        toolSessionContext,
+      },
+    );
+
+    return {
+      validatedInput: null,
+      toolkitResult: buildToolkitResult(returnPayload, toolSessionContext),
+    };
+  }
+
+  return {
+    validatedInput: {
+      previousExerciseId: normalizedPreviousExerciseId,
+      userScore: params.user_score as number,
+      performanceNotes: normalizePerformanceNotes(params.performance_notes),
+    },
+    toolkitResult: null,
+  };
+}
+
+function parseToolResponse(
+  result: ToolkitResult,
+): LanguageExerciseToolResponse | null {
+  try {
+    const parsed = JSON.parse(result.result);
+    if (parsed && parsed.type === "language_exercise_tool_response") {
+      return parsed as LanguageExerciseToolResponse;
+    }
+  } catch (error) {
+    log.warn(
+      "[language_lesson] Failed to parse toolkit result payload",
+      {},
+      {
+        result,
+        error: error instanceof Error ? error.message : String(error),
+      },
+    );
+  }
+
+  return null;
+}
+
+export async function start_first_exercise(
+  _params: StartFirstExerciseParams = {},
+  _context_params?: any,
+  toolSessionContext: ToolSessionContext = {},
 ): Promise<ToolkitResult> {
-  const numericScore = invocationState.user_score as number;
-  const normalizedPerformanceNotes = normalizePerformanceNotes(
-    invocationState.performance_notes,
+  log.info(
+    "[language_lesson] start_first_exercise called",
+    {},
+    {
+      toolSessionContext,
+    },
   );
 
-  const previousExerciseLocator = findExerciseById(
+  const loadedConfigOutcome = await loadValidatedConfigOrResult(
+    "initial",
+    toolSessionContext,
+    {
+      tool: "start_first_exercise",
+    },
+  );
+
+  if (
+    loadedConfigOutcome.toolkitResult ||
+    !loadedConfigOutcome.loadedConfigState
+  ) {
+    return loadedConfigOutcome.toolkitResult as ToolkitResult;
+  }
+
+  return buildSelectionResult({
+    mode: "initial",
+    parsedConfigResult:
+      loadedConfigOutcome.loadedConfigState.parsedConfigResult,
+    config: loadedConfigOutcome.loadedConfigState.mutableConfig,
+    progress: loadedConfigOutcome.loadedConfigState.progressBefore,
+    toolSessionContext,
+  });
+}
+
+export async function grade_user_exercise(
+  params: GradeUserExerciseParams = {},
+  _context_params?: any,
+  toolSessionContext: ToolSessionContext = {},
+): Promise<ToolkitResult> {
+  log.info(
+    "[language_lesson] grade_user_exercise called",
+    {},
+    {
+      params,
+      toolSessionContext,
+      passingScoreThreshold: PASSING_SCORE_THRESHOLD,
+    },
+  );
+
+  const gradeValidation = validateGradeInputOrResult(
+    params,
+    toolSessionContext,
+  );
+  if (gradeValidation.toolkitResult || !gradeValidation.validatedInput) {
+    return gradeValidation.toolkitResult as ToolkitResult;
+  }
+
+  const validatedInput = gradeValidation.validatedInput;
+
+  const loadedConfigOutcome = await loadValidatedConfigOrResult(
+    "follow_up",
+    toolSessionContext,
+    {
+      tool: "grade_user_exercise",
+      validatedInput,
+    },
+  );
+
+  if (
+    loadedConfigOutcome.toolkitResult ||
+    !loadedConfigOutcome.loadedConfigState
+  ) {
+    return loadedConfigOutcome.toolkitResult as ToolkitResult;
+  }
+
+  const loadedConfigState = loadedConfigOutcome.loadedConfigState;
+
+  const pendingExerciseLocator = findExerciseById(
     loadedConfigState.mutableConfig,
-    invocationState.normalizedPreviousExerciseId,
+    validatedInput.previousExerciseId,
   );
 
-  if (!previousExerciseLocator) {
+  if (!pendingExerciseLocator) {
     const returnPayload = buildLanguageExerciseToolResponse({
       status: "previous_exercise_not_found",
       mode: "follow_up",
@@ -619,19 +850,17 @@ async function handleFollowUpCall(
       summary: loadedConfigState.parsedConfigResult.summary,
       progress: loadedConfigState.progressBefore,
       input: {
-        previous_exercise_id: invocationState.normalizedPreviousExerciseId,
-        user_score: numericScore,
-        performance_notes: normalizedPerformanceNotes,
+        previous_exercise_id: validatedInput.previousExerciseId,
+        user_score: validatedInput.userScore,
+        performance_notes: validatedInput.performanceNotes,
       },
     });
 
     log.warn(
-      "[language_lesson] Returning previous_exercise_not_found",
+      "[language_lesson] Returning previous_exercise_not_found from grade_user_exercise",
       {},
       {
-        invocationState,
-        user_score: numericScore,
-        performance_notes: normalizedPerformanceNotes,
+        validatedInput,
         availableExerciseIds:
           loadedConfigState.mutableConfig.language_issues.flatMap((issue) =>
             issue.exercises.map((exercise) => exercise.exercise_id),
@@ -644,29 +873,29 @@ async function handleFollowUpCall(
     return buildToolkitResult(returnPayload, toolSessionContext);
   }
 
-  const previousExerciseBeforeUpdate = { ...previousExerciseLocator.exercise };
-  const existingAttempts =
-    typeof previousExerciseLocator.exercise.attempts === "number"
-      ? previousExerciseLocator.exercise.attempts
-      : 0;
+  const passed = validatedInput.userScore >= PASSING_SCORE_THRESHOLD;
+  const pendingExerciseBeforeUpdate = { ...pendingExerciseLocator.exercise };
 
-  previousExerciseLocator.exercise.attempts = existingAttempts + 1;
-  previousExerciseLocator.exercise.last_score = numericScore;
-  previousExerciseLocator.exercise.last_notes = normalizedPerformanceNotes;
-  previousExerciseLocator.exercise.status = "finished";
-  previousExerciseLocator.exercise.finished_at = new Date().toISOString();
+  updateExerciseAttemptState({
+    exercise: pendingExerciseLocator.exercise,
+    userScore: validatedInput.userScore,
+    performanceNotes: validatedInput.performanceNotes,
+    passed,
+  });
 
   log.info(
-    "[language_lesson] Updated previous exercise state before persistence",
+    "[language_lesson] Updated pending exercise state before persistence",
     {},
     {
-      previous_exercise_id: invocationState.normalizedPreviousExerciseId,
-      previousExerciseBeforeUpdate,
-      previousExerciseAfterUpdate: previousExerciseLocator.exercise,
-      issueIndex: previousExerciseLocator.issueIndex,
-      exerciseIndex: previousExerciseLocator.exerciseIndex,
-      config_hash_before_save: loadedConfigState.parsedConfigResult.hash,
+      validatedInput,
+      passed,
+      passingScoreThreshold: PASSING_SCORE_THRESHOLD,
+      pendingExerciseBeforeUpdate,
+      pendingExerciseAfterUpdate: pendingExerciseLocator.exercise,
+      issueIndex: pendingExerciseLocator.issueIndex,
+      exerciseIndex: pendingExerciseLocator.exerciseIndex,
       progressBefore: loadedConfigState.progressBefore,
+      config_hash_before_save: loadedConfigState.parsedConfigResult.hash,
       toolSessionContext,
     },
   );
@@ -674,76 +903,62 @@ async function handleFollowUpCall(
   const persistErrorResult = await persistUpdatedConfigOrErrorResult(
     loadedConfigState.mutableConfig,
     loadedConfigState.parsedConfigResult,
-    invocationState.normalizedPreviousExerciseId,
+    "follow_up",
     toolSessionContext,
-  );
-
-  if (persistErrorResult) {
-    log.warn(
-      "[language_lesson] Persistence step returned an error result; ending follow-up flow early",
-      {},
-      {
-        previous_exercise_id: invocationState.normalizedPreviousExerciseId,
-        toolSessionContext,
-      },
-    );
-    return persistErrorResult;
-  }
-
-  log.info(
-    "[language_lesson] Previous exercise progress persisted; continuing to select next exercise",
-    {},
     {
-      previous_exercise_id: invocationState.normalizedPreviousExerciseId,
-      toolSessionContext,
+      tool: "grade_user_exercise",
+      validatedInput,
+      passed,
     },
   );
 
-  const reloadOutcome = await reloadPersistedConfigOrResult(toolSessionContext);
+  if (persistErrorResult) {
+    return persistErrorResult;
+  }
+
+  const reloadOutcome = await reloadPersistedConfigOrResult(
+    "follow_up",
+    toolSessionContext,
+    {
+      tool: "grade_user_exercise",
+      validatedInput,
+      passed,
+    },
+  );
+
   if (reloadOutcome.toolkitResult || !reloadOutcome.reloadedConfigResult) {
     return reloadOutcome.toolkitResult as ToolkitResult;
   }
 
-  const nextLocator = findFirstUnfinishedExercise(
-    reloadOutcome.reloadedConfig!,
-  );
   const progressAfter = summarizeProgress(reloadOutcome.reloadedConfig!);
 
-  log.info(
-    "[language_lesson] Selected next unfinished exercise after save",
-    {},
-    {
-      nextLocator,
-      progressAfter,
-      config_hash_after_save: reloadOutcome.reloadedConfigResult.hash,
-      toolSessionContext,
-    },
-  );
-
-  if (!nextLocator) {
+  if (passed) {
     const updatedToolSessionContext = buildUpdatedToolSessionContext(
       toolSessionContext,
       null,
       reloadOutcome.reloadedConfigResult.hash,
-      previousExerciseLocator.issue.errorId,
+      pendingExerciseLocator.issue.errorId,
     );
 
     const returnPayload = buildLanguageExerciseToolResponse({
-      status: "all_exercises_finished",
+      status: "ready_for_next_exercise",
       mode: "follow_up",
-      message: "All exercises are finished.",
+      message:
+        "Pending exercise was graded as passing and persisted. Call language_lesson__start_next_exercise to fetch the next unfinished exercise.",
       config_hash: reloadOutcome.reloadedConfigResult.hash,
       summary: reloadOutcome.reloadedConfigResult.summary,
       progress: progressAfter,
       completed_exercise: {
-        exercise_id: previousExerciseLocator.exercise.exercise_id,
+        exercise_id: validatedInput.previousExerciseId,
       },
     });
 
     log.info(
-      "[language_lesson] Returning all_exercises_finished",
+      "[language_lesson] Returning ready_for_next_exercise",
       {},
       {
+        validatedInput,
+        passed,
         returnPayload,
         updatedToolSessionContext,
         toolSessionContext,
@@ -753,95 +968,34 @@ async function handleFollowUpCall(
     return buildToolkitResult(returnPayload, updatedToolSessionContext);
   }
 
-  const updatedToolSessionContext = buildUpdatedToolSessionContext(
-    toolSessionContext,
-    nextLocator,
-    reloadOutcome.reloadedConfigResult.hash,
+  const retryLocator = findExerciseById(
+    reloadOutcome.reloadedConfig!,
+    validatedInput.previousExerciseId,
   );
 
-  const returnPayload = buildLanguageExerciseToolResponse({
-    status: "next_exercise_ready",
-    mode: "follow_up",
-    message:
-      "Previous exercise was marked finished and persisted. Returning the next exercise to give to the user. The next exercise details are in the next_exercise field, and see the issue field for more context. After the user answers, call language_lesson__get_next_language_exercise again.",
-    config_hash: reloadOutcome.reloadedConfigResult.hash,
-    summary: reloadOutcome.reloadedConfigResult.summary,
-    progress: progressAfter,
-    completed_exercise: {
-      exercise_id: previousExerciseLocator.exercise.exercise_id,
-    },
-    overview: {
-      issueIndex: nextLocator.issueIndex,
-      exerciseIndex: nextLocator.exerciseIndex,
-      issueCount: reloadOutcome.reloadedConfigResult.summary.issueCount,
-      totalExerciseCount:
-        reloadOutcome.reloadedConfigResult.summary.exerciseCount,
-      exerciseCountInIssue: nextLocator.issue.exercises.length,
-    },
-    issue: buildIssuePayload(nextLocator.issue),
-    next_exercise: nextLocator.exercise,
-  });
+  if (!retryLocator) {
+    const returnPayload = buildLanguageExerciseToolResponse({
+      status: "previous_exercise_not_found",
+      mode: "follow_up",
+      message:
+        "Could not find previous_exercise_id after persistence while preparing retry guidance.",
+      config_hash: reloadOutcome.reloadedConfigResult.hash,
+      summary: reloadOutcome.reloadedConfigResult.summary,
+      progress: progressAfter,
+      input: {
+        previous_exercise_id: validatedInput.previousExerciseId,
+        user_score: validatedInput.userScore,
+        performance_notes: validatedInput.performanceNotes,
+      },
+    });
 
-  log.info(
-    "[language_lesson] Returning next unfinished exercise after follow-up",
-    {},
-    {
-      returnPayload,
-      updatedToolSessionContext,
-      toolSessionContext,
-    },
-  );
-
-  return buildToolkitResult(returnPayload, updatedToolSessionContext);
-}
-
-function handleInitialCall(
-  loadedConfigState: LoadedConfigState,
-  toolSessionContext: ToolSessionContext,
-): ToolkitResult {
-  const initialLocator = findFirstUnfinishedExercise(
-    loadedConfigState.mutableConfig,
-  );
-
-  log.info(
-    "[language_lesson] Selecting first unfinished exercise for initial call",
-    {},
-    {
-      initialLocator,
-      progressBefore: loadedConfigState.progressBefore,
-      config_hash: loadedConfigState.parsedConfigResult.hash,
-      summary: loadedConfigState.parsedConfigResult.summary,
-      toolSessionContext,
-    },
-  );
-
-  if (!initialLocator) {
-    const returnPayload =
-      loadedConfigState.progressBefore.totalExerciseCount === 0
-        ? buildLanguageExerciseToolResponse({
-            status: "no_exercises_available",
-            mode: "initial",
-            message: "No exercises were found in the language lesson config.",
-            config_hash: loadedConfigState.parsedConfigResult.hash,
-            summary: loadedConfigState.parsedConfigResult.summary,
-            progress: loadedConfigState.progressBefore,
-          })
-        : buildLanguageExerciseToolResponse({
-            status: "all_exercises_finished",
-            mode: "initial",
-            message: "All exercises are already finished.",
-            config_hash: loadedConfigState.parsedConfigResult.hash,
-            summary: loadedConfigState.parsedConfigResult.summary,
-            progress: loadedConfigState.progressBefore,
-          });
-
-    log.warn(
-      "[language_lesson] No initial unfinished exercise available",
+    log.error(
+      "[language_lesson] Retry locator missing after persisted fail grading",
       {},
       {
+        validatedInput,
+        progressAfter,
         returnPayload,
-        progressBefore: loadedConfigState.progressBefore,
-        config_hash: loadedConfigState.parsedConfigResult.hash,
         toolSessionContext,
       },
     );
@@ -851,34 +1005,42 @@ function handleInitialCall(
 
   const updatedToolSessionContext = buildUpdatedToolSessionContext(
     toolSessionContext,
-    initialLocator,
-    loadedConfigState.parsedConfigResult.hash,
+    retryLocator,
+    reloadOutcome.reloadedConfigResult.hash,
   );
 
   const returnPayload = buildLanguageExerciseToolResponse({
-    status: "next_exercise_ready",
-    mode: "initial",
+    status: "retry_current_exercise",
+    mode: "follow_up",
     message:
-      "Returning the next exercise to give to the user. The next exercise details are in the next_exercise field. After the user answers, call language_lesson__get_next_language_exercise again.",
-    config_hash: loadedConfigState.parsedConfigResult.hash,
-    summary: loadedConfigState.parsedConfigResult.summary,
-    progress: loadedConfigState.progressBefore,
+      "Pending exercise score was below passing threshold and was persisted. Ask the user to retry this same exercise.",
+    config_hash: reloadOutcome.reloadedConfigResult.hash,
+    summary: reloadOutcome.reloadedConfigResult.summary,
+    progress: progressAfter,
     overview: {
-      issueIndex: initialLocator.issueIndex,
-      exerciseIndex: initialLocator.exerciseIndex,
-      issueCount: loadedConfigState.parsedConfigResult.summary.issueCount,
+      issueIndex: retryLocator.issueIndex,
+      exerciseIndex: retryLocator.exerciseIndex,
+      issueCount: reloadOutcome.reloadedConfigResult.summary.issueCount,
       totalExerciseCount:
-        loadedConfigState.parsedConfigResult.summary.exerciseCount,
-      exerciseCountInIssue: initialLocator.issue.exercises.length,
+        reloadOutcome.reloadedConfigResult.summary.exerciseCount,
+      exerciseCountInIssue: retryLocator.issue.exercises.length,
     },
-    issue: buildIssuePayload(initialLocator.issue),
-    next_exercise: initialLocator.exercise,
+    issue: buildIssuePayload(retryLocator.issue),
+    next_exercise: retryLocator.exercise,
+    input: {
+      previous_exercise_id: validatedInput.previousExerciseId,
+      user_score: validatedInput.userScore,
+      performance_notes: validatedInput.performanceNotes,
+    },
   });
 
   log.info(
-    "[language_lesson] Returning initial unfinished exercise",
+    "[language_lesson] Returning retry_current_exercise",
     {},
     {
+      validatedInput,
+      passed,
+      passingScoreThreshold: PASSING_SCORE_THRESHOLD,
       returnPayload,
       updatedToolSessionContext,
       toolSessionContext,
@@ -888,33 +1050,35 @@ function handleInitialCall(
   return buildToolkitResult(returnPayload, updatedToolSessionContext);
 }
 
-/**
- * POC implementation:
- * - Initial call: return first unfinished exercise.
- * - Follow-up call: mark previous exercise finished in persisted JSON, save,
- *   then return next unfinished exercise.
- *
- * This intentionally mutates user lesson JSON in storage for rapid prototyping.
- */
-export async function get_next_language_exercise(
-  params: GetNextLanguageExerciseParams = {},
+export async function start_next_exercise(
+  params: StartNextExerciseParams = {},
   _context_params?: any,
   toolSessionContext: ToolSessionContext = {},
 ): Promise<ToolkitResult> {
-  const invocationState = buildInvocationState(params, toolSessionContext);
+  const normalizedPreviousExerciseId = (
+    params.previous_exercise_id || ""
+  ).trim();
 
-  const invocationValidationResult = validateInvocationOrResult(
-    invocationState,
-    toolSessionContext,
+  log.info(
+    "[language_lesson] start_next_exercise called",
+    {},
+    {
+      params,
+      normalizedPreviousExerciseId,
+      hasPreviousExerciseId: normalizedPreviousExerciseId.length > 0,
+      toolSessionContext,
+    },
   );
-  if (invocationValidationResult) {
-    return invocationValidationResult;
-  }
 
   const loadedConfigOutcome = await loadValidatedConfigOrResult(
-    invocationState,
+    "follow_up",
     toolSessionContext,
+    {
+      tool: "start_next_exercise",
+      previous_exercise_id: normalizedPreviousExerciseId || null,
+    },
   );
+
   if (
     loadedConfigOutcome.toolkitResult ||
     !loadedConfigOutcome.loadedConfigState
@@ -922,16 +1086,70 @@ export async function get_next_language_exercise(
     return loadedConfigOutcome.toolkitResult as ToolkitResult;
   }
 
-  if (invocationState.isInitialCall) {
-    return handleInitialCall(
-      loadedConfigOutcome.loadedConfigState,
+  return buildSelectionResult({
+    mode: "follow_up",
+    parsedConfigResult:
+      loadedConfigOutcome.loadedConfigState.parsedConfigResult,
+    config: loadedConfigOutcome.loadedConfigState.mutableConfig,
+    progress: loadedConfigOutcome.loadedConfigState.progressBefore,
+    toolSessionContext,
+    completedExerciseId: normalizedPreviousExerciseId || undefined,
+  });
+}
+
+/**
+ * Backward-compat shim for legacy callers.
+ *
+ * New flow:
+ * - language_lesson__start_first_exercise
+ * - language_lesson__grade_user_exercise
+ * - language_lesson__start_next_exercise
+ */
+export async function get_next_language_exercise(
+  params: GetNextLanguageExerciseParams = {},
+  _context_params?: any,
+  toolSessionContext: ToolSessionContext = {},
+): Promise<ToolkitResult> {
+  log.warn(
+    "[language_lesson] get_next_language_exercise is deprecated; use start_first_exercise/grade_user_exercise/start_next_exercise",
+    {},
+    {
+      params,
       toolSessionContext,
-    );
+    },
+  );
+
+  const normalizedPreviousExerciseId = (
+    params.previous_exercise_id || ""
+  ).trim();
+  const hasPreviousExerciseId = normalizedPreviousExerciseId.length > 0;
+  const hasUserScore =
+    params.user_score !== null && params.user_score !== undefined;
+
+  if (!hasPreviousExerciseId && !hasUserScore) {
+    return start_first_exercise({}, _context_params, toolSessionContext);
   }
 
-  return handleFollowUpCall(
-    invocationState,
-    loadedConfigOutcome.loadedConfigState,
+  const gradeResult = await grade_user_exercise(
+    {
+      previous_exercise_id: params.previous_exercise_id,
+      user_score: params.user_score,
+      performance_notes: params.performance_notes,
+    },
+    _context_params,
     toolSessionContext,
+  );
+
+  const parsedGradeResult = parseToolResponse(gradeResult);
+  if (parsedGradeResult?.status !== "ready_for_next_exercise") {
+    return gradeResult;
+  }
+
+  return start_next_exercise(
+    {
+      previous_exercise_id: normalizedPreviousExerciseId || null,
+    },
+    _context_params,
+    gradeResult.updatedToolSessionContext,
   );
 }

--- a/modules/vm-webrtc/src/toolkit_functions/language_lesson.ts
+++ b/modules/vm-webrtc/src/toolkit_functions/language_lesson.ts
@@ -1,0 +1,54 @@
+import { log } from "../../../../lib/logger";
+import type { ToolSessionContext, ToolkitResult } from "./types";
+
+export interface GetNextLanguageExerciseParams {
+  previous_exercise_id?: string | null;
+  user_score?: number | null;
+  performance_notes?: string | null;
+}
+
+/**
+ * Stub implementation for the language lesson exercise flow.
+ * Accepts optional score/update data from the previous exercise and
+ * returns a placeholder response until persistence and drill logic are implemented.
+ */
+export async function get_next_language_exercise(
+  params: GetNextLanguageExerciseParams = {},
+  _context_params?: any,
+  toolSessionContext: ToolSessionContext = {},
+): Promise<ToolkitResult> {
+  const {
+    previous_exercise_id = null,
+    user_score = null,
+    performance_notes = null,
+  } = params;
+
+  log.info(
+    "[language_lesson] get_next_language_exercise called",
+    {},
+    {
+      previous_exercise_id,
+      user_score,
+      performance_notes,
+      toolSessionContext,
+    },
+  );
+
+  return {
+    result: JSON.stringify(
+      {
+        status: "not_implemented",
+        message:
+          "Language lesson flow is not implemented yet. This is a stub tool response.",
+        input: {
+          previous_exercise_id,
+          user_score,
+          performance_notes,
+        },
+      },
+      null,
+      2,
+    ),
+    updatedToolSessionContext: toolSessionContext,
+  };
+}

--- a/modules/vm-webrtc/src/toolkit_functions/language_lesson.ts
+++ b/modules/vm-webrtc/src/toolkit_functions/language_lesson.ts
@@ -214,7 +214,7 @@ function buildIssuePayload(issue: LanguageIssue): LanguageIssuePayload {
 function buildNextActionSuggestion(status: LanguageExerciseToolStatus): string {
   switch (status) {
     case "next_exercise_ready":
-      return "Ask the user if they want to continue to the next exercise or do something else. If they want to continue, present the returned exercise immediately.";
+      return "Assume the user wants to keep going, so give the next exercise to the user.";
     case "all_exercises_finished":
       return "Congratulate the user for finishing all exercises and ask if they want to practice a new issue.";
     case "no_exercises_available":
@@ -773,7 +773,7 @@ async function handleFollowUpCall(
     status: "next_exercise_ready",
     mode: "follow_up",
     message:
-      "Previous exercise was marked finished and persisted. Returning next unfinished exercise.",
+      "Previous exercise was marked finished and persisted. Returning the next exercise to give to the user. The exercise details are in the exercise field, and see the issue field for more context.",
     config_hash: reloadOutcome.reloadedConfigResult.hash,
     summary: reloadOutcome.reloadedConfigResult.summary,
     progress: progressAfter,

--- a/modules/vm-webrtc/src/toolkit_functions/language_lesson.ts
+++ b/modules/vm-webrtc/src/toolkit_functions/language_lesson.ts
@@ -57,7 +57,8 @@ type LanguageExerciseToolStatus =
   | "config_invalid"
   | "persist_failed"
   | "persist_reload_invalid"
-  | "previous_exercise_not_found";
+  | "previous_exercise_not_found"
+  | "exercise_already_finished";
 
 interface ExerciseOverview {
   issueIndex: number;
@@ -123,6 +124,8 @@ interface ValidatedGradeInput {
   performanceNotes: string | null;
 }
 
+const MIN_USER_SCORE = 0;
+const MAX_USER_SCORE = 10;
 const PASSING_SCORE_THRESHOLD = 8;
 
 function isExerciseFinished(exercise: LanguageExercise): boolean {
@@ -244,6 +247,8 @@ function buildNextActionSuggestion(status: LanguageExerciseToolStatus): string {
       return "Tell the user progress could not be saved reliably and ask them to retry the exercise flow.";
     case "previous_exercise_not_found":
       return "Tell the user the pending exercise id was not found and that this internal issue is not their fault. Ask what they want help with next.";
+    case "exercise_already_finished":
+      return "Tell the user this exercise was already finished. If they want to continue the lesson, call language_lesson__start_next_exercise with the same previous_exercise_id.";
     default:
       return "Continue the lesson flow based on the returned status.";
   }
@@ -337,10 +342,26 @@ function buildToolkitResult(
   };
 }
 
+function normalizeOptionalTrimmedString(value: unknown): string {
+  return typeof value === "string" ? value.trim() : "";
+}
+
+function isValidUserScore(value: unknown): value is number {
+  return (
+    typeof value === "number" &&
+    Number.isFinite(value) &&
+    value >= MIN_USER_SCORE &&
+    value <= MAX_USER_SCORE
+  );
+}
+
 function normalizePerformanceNotes(
   performanceNotes: string | null | undefined,
 ): string | null {
-  if (!performanceNotes || performanceNotes.trim().length === 0) {
+  if (
+    typeof performanceNotes !== "string" ||
+    performanceNotes.trim().length === 0
+  ) {
     return null;
   }
 
@@ -681,12 +702,11 @@ function validateGradeInputOrResult(
   validatedInput: ValidatedGradeInput | null;
   toolkitResult: ToolkitResult | null;
 } {
-  const normalizedPreviousExerciseId = (
-    params.previous_exercise_id || ""
-  ).trim();
+  const normalizedPreviousExerciseId = normalizeOptionalTrimmedString(
+    params.previous_exercise_id,
+  );
   const hasPreviousExerciseId = normalizedPreviousExerciseId.length > 0;
-  const hasValidUserScore =
-    typeof params.user_score === "number" && Number.isFinite(params.user_score);
+  const hasValidUserScore = isValidUserScore(params.user_score);
 
   log.info(
     "[language_lesson] Validating grade_user_exercise input",
@@ -705,7 +725,7 @@ function validateGradeInputOrResult(
       status: "invalid_follow_up_input",
       mode: "follow_up",
       message:
-        "grade_user_exercise requires both previous_exercise_id and numeric user_score.",
+        "grade_user_exercise requires both previous_exercise_id and numeric user_score between 0 and 10.",
       input: {
         previous_exercise_id: params.previous_exercise_id ?? null,
         user_score: params.user_score ?? null,
@@ -881,6 +901,48 @@ export async function grade_user_exercise(
     );
 
     return buildToolkitResult(returnPayload, toolSessionContext);
+  }
+
+  if (isExerciseFinished(pendingExerciseLocator.exercise)) {
+    const updatedToolSessionContext = buildUpdatedToolSessionContext(
+      toolSessionContext,
+      pendingExerciseLocator,
+      loadedConfigState.parsedConfigResult.hash,
+      pendingExerciseLocator.issue.errorId,
+    );
+
+    const returnPayload = buildLanguageExerciseToolResponse({
+      status: "exercise_already_finished",
+      mode: "follow_up",
+      message:
+        "previous_exercise_id already refers to a finished exercise. Progress was not changed.",
+      config_hash: loadedConfigState.parsedConfigResult.hash,
+      summary: loadedConfigState.parsedConfigResult.summary,
+      progress: loadedConfigState.progressBefore,
+      completed_exercise: {
+        exercise_id: validatedInput.previousExerciseId,
+      },
+      input: {
+        previous_exercise_id: validatedInput.previousExerciseId,
+        user_score: validatedInput.userScore,
+        performance_notes: validatedInput.performanceNotes,
+      },
+    });
+
+    log.warn(
+      "[language_lesson] Refusing to re-grade an already finished exercise",
+      {},
+      {
+        validatedInput,
+        pendingExercise: pendingExerciseLocator.exercise,
+        progressBefore: loadedConfigState.progressBefore,
+        returnPayload,
+        updatedToolSessionContext,
+        toolSessionContext,
+      },
+    );
+
+    return buildToolkitResult(returnPayload, updatedToolSessionContext);
   }
 
   const passed = validatedInput.userScore >= PASSING_SCORE_THRESHOLD;
@@ -1077,9 +1139,9 @@ export async function start_next_exercise(
   _context_params?: any,
   toolSessionContext: ToolSessionContext = {},
 ): Promise<ToolkitResult> {
-  const normalizedPreviousExerciseId = (
-    params.previous_exercise_id || ""
-  ).trim();
+  const normalizedPreviousExerciseId = normalizeOptionalTrimmedString(
+    params.previous_exercise_id,
+  );
 
   log.info(
     "[language_lesson] start_next_exercise called",
@@ -1141,9 +1203,9 @@ export async function get_next_language_exercise(
     },
   );
 
-  const normalizedPreviousExerciseId = (
-    params.previous_exercise_id || ""
-  ).trim();
+  const normalizedPreviousExerciseId = normalizeOptionalTrimmedString(
+    params.previous_exercise_id,
+  );
   const hasPreviousExerciseId = normalizedPreviousExerciseId.length > 0;
   const hasUserScore =
     params.user_score !== null && params.user_score !== undefined;

--- a/modules/vm-webrtc/src/toolkit_functions/language_lesson.ts
+++ b/modules/vm-webrtc/src/toolkit_functions/language_lesson.ts
@@ -42,27 +42,56 @@ export async function get_next_language_exercise(
 
   const isInitialCall = !hasPreviousExerciseId && !hasUserScore;
 
+  log.info(
+    "[language_lesson] Determined invocation mode",
+    {},
+    {
+      isInitialCall,
+      hasPreviousExerciseId,
+      hasUserScore,
+      normalizedPreviousExerciseId,
+      previous_exercise_id,
+      user_score,
+      performance_notes,
+      toolSessionContext,
+    },
+  );
+
   if (!isInitialCall) {
     const hasValidUserScore =
       typeof user_score === "number" && Number.isFinite(user_score);
 
     if (!hasPreviousExerciseId || !hasValidUserScore) {
+      const returnPayload = {
+        status: "invalid_follow_up_input",
+        mode: "follow_up",
+        message:
+          "Follow-up calls require both previous_exercise_id and numeric user_score.",
+        input: {
+          previous_exercise_id,
+          user_score,
+          performance_notes,
+        },
+      };
+
+      log.warn(
+        "[language_lesson] Returning invalid follow-up input",
+        {},
+        {
+          hasPreviousExerciseId,
+          hasUserScore,
+          hasValidUserScore,
+          normalizedPreviousExerciseId,
+          previous_exercise_id,
+          user_score,
+          performance_notes,
+          toolSessionContext,
+          returnPayload,
+        },
+      );
+
       return {
-        result: JSON.stringify(
-          {
-            status: "invalid_follow_up_input",
-            mode: "follow_up",
-            message:
-              "Follow-up calls require both previous_exercise_id and numeric user_score.",
-            input: {
-              previous_exercise_id,
-              user_score,
-              performance_notes,
-            },
-          },
-          null,
-          2,
-        ),
+        result: JSON.stringify(returnPayload, null, 2),
         updatedToolSessionContext: toolSessionContext,
       };
     }
@@ -70,30 +99,69 @@ export async function get_next_language_exercise(
 
   const parsedConfigResult = await loadParsedLanguageLessonConfig();
 
+  log.info(
+    "[language_lesson] Loaded parsed language lesson config",
+    {},
+    {
+      isInitialCall,
+      parsedConfigResult,
+      toolSessionContext,
+    },
+  );
+
   if (
     parsedConfigResult.validationErrors.length > 0 ||
     !parsedConfigResult.parsedConfig
   ) {
+    const returnPayload = {
+      status: "config_invalid",
+      mode: isInitialCall ? "initial" : "follow_up",
+      message:
+        "Language lesson config is invalid or missing. Update the JSON in Configure Tools.",
+      config_hash: parsedConfigResult.hash,
+      summary: parsedConfigResult.summary,
+      validationErrors: parsedConfigResult.validationErrors,
+    };
+
+    log.warn(
+      "[language_lesson] Returning config_invalid",
+      {},
+      {
+        isInitialCall,
+        parsedConfigResult,
+        returnPayload,
+        toolSessionContext,
+      },
+    );
+
     return {
-      result: JSON.stringify(
-        {
-          status: "config_invalid",
-          mode: isInitialCall ? "initial" : "follow_up",
-          message:
-            "Language lesson config is invalid or missing. Update the JSON in Configure Tools.",
-          config_hash: parsedConfigResult.hash,
-          summary: parsedConfigResult.summary,
-          validationErrors: parsedConfigResult.validationErrors,
-        },
-        null,
-        2,
-      ),
+      result: JSON.stringify(returnPayload, null, 2),
       updatedToolSessionContext: toolSessionContext,
     };
   }
 
   if (!isInitialCall) {
     const languageIssues = parsedConfigResult.parsedConfig.language_issues;
+
+    log.info(
+      "[language_lesson] Resolving follow-up previous_exercise_id",
+      {},
+      {
+        normalizedPreviousExerciseId,
+        previous_exercise_id,
+        user_score,
+        performance_notes,
+        issueCount: languageIssues.length,
+        searchableExercises: languageIssues.map((issue, issueIndex) => ({
+          issueIndex,
+          errorId: issue.errorId,
+          title: issue.title,
+          exerciseIds: issue.exercises.map((exercise) => exercise.exercise_id),
+        })),
+        toolSessionContext,
+      },
+    );
+
     let matchedIssueIndex = -1;
     let matchedExerciseIndex = -1;
     let matchedIssue:
@@ -119,24 +187,38 @@ export async function get_next_language_exercise(
     }
 
     if (!matchedIssue || !matchedExercise) {
+      const returnPayload = {
+        status: "previous_exercise_not_found",
+        mode: "follow_up",
+        message:
+          "Could not find previous_exercise_id in current language lesson config.",
+        config_hash: parsedConfigResult.hash,
+        summary: parsedConfigResult.summary,
+        input: {
+          previous_exercise_id: normalizedPreviousExerciseId,
+          user_score,
+          performance_notes,
+        },
+      };
+
+      log.warn(
+        "[language_lesson] Returning previous_exercise_not_found",
+        {},
+        {
+          normalizedPreviousExerciseId,
+          previous_exercise_id,
+          user_score,
+          performance_notes,
+          availableExerciseIds: languageIssues.flatMap((issue) =>
+            issue.exercises.map((exercise) => exercise.exercise_id),
+          ),
+          returnPayload,
+          toolSessionContext,
+        },
+      );
+
       return {
-        result: JSON.stringify(
-          {
-            status: "previous_exercise_not_found",
-            mode: "follow_up",
-            message:
-              "Could not find previous_exercise_id in current language lesson config.",
-            config_hash: parsedConfigResult.hash,
-            summary: parsedConfigResult.summary,
-            input: {
-              previous_exercise_id: normalizedPreviousExerciseId,
-              user_score,
-              performance_notes,
-            },
-          },
-          null,
-          2,
-        ),
+        result: JSON.stringify(returnPayload, null, 2),
         updatedToolSessionContext: toolSessionContext,
       };
     }
@@ -169,31 +251,38 @@ export async function get_next_language_exercise(
       followUpLogPayload,
     );
 
+    const returnPayload = {
+      status: "previous_result_logged",
+      mode: "follow_up",
+      message:
+        "Previous exercise result logged. Progression/selection is not enabled yet.",
+      config_hash: parsedConfigResult.hash,
+      summary: parsedConfigResult.summary,
+      logged_result: {
+        previous_exercise_id: normalizedPreviousExerciseId,
+        user_score,
+        performance_notes,
+        issue_index: matchedIssueIndex,
+        exercise_index: matchedExerciseIndex,
+        issue_error_id: matchedIssue.errorId,
+        issue_title: matchedIssue.title,
+        exercise_type: matchedExercise.type,
+        logged_at: new Date().toISOString(),
+      },
+      next_exercise: null,
+    };
+
+    log.info(
+      "[language_lesson] Returning follow-up result (log-only mode)",
+      {},
+      {
+        returnPayload,
+        toolSessionContext,
+      },
+    );
+
     return {
-      result: JSON.stringify(
-        {
-          status: "previous_result_logged",
-          mode: "follow_up",
-          message:
-            "Previous exercise result logged. Progression/selection is not enabled yet.",
-          config_hash: parsedConfigResult.hash,
-          summary: parsedConfigResult.summary,
-          logged_result: {
-            previous_exercise_id: normalizedPreviousExerciseId,
-            user_score,
-            performance_notes,
-            issue_index: matchedIssueIndex,
-            exercise_index: matchedExerciseIndex,
-            issue_error_id: matchedIssue.errorId,
-            issue_title: matchedIssue.title,
-            exercise_type: matchedExercise.type,
-            logged_at: new Date().toISOString(),
-          },
-          next_exercise: null,
-        },
-        null,
-        2,
-      ),
+      result: JSON.stringify(returnPayload, null, 2),
       updatedToolSessionContext: toolSessionContext,
     };
   }
@@ -201,19 +290,43 @@ export async function get_next_language_exercise(
   const languageIssues = parsedConfigResult.parsedConfig.language_issues;
   const firstIssue = languageIssues[0];
 
-  if (!firstIssue || firstIssue.exercises.length === 0) {
-    return {
-      result: JSON.stringify(
-        {
-          status: "no_exercises_available",
-          mode: "initial",
-          message: "No exercises were found in the language lesson config.",
-          config_hash: parsedConfigResult.hash,
-          summary: parsedConfigResult.summary,
-        },
-        null,
-        2,
+  log.info(
+    "[language_lesson] Selecting first exercise for initial call",
+    {},
+    {
+      issueCount: languageIssues.length,
+      firstIssue,
+      firstIssueExerciseIds: firstIssue?.exercises?.map(
+        (exercise) => exercise.exercise_id,
       ),
+      config_hash: parsedConfigResult.hash,
+      summary: parsedConfigResult.summary,
+      toolSessionContext,
+    },
+  );
+
+  if (!firstIssue || firstIssue.exercises.length === 0) {
+    const returnPayload = {
+      status: "no_exercises_available",
+      mode: "initial",
+      message: "No exercises were found in the language lesson config.",
+      config_hash: parsedConfigResult.hash,
+      summary: parsedConfigResult.summary,
+    };
+
+    log.warn(
+      "[language_lesson] Returning no_exercises_available",
+      {},
+      {
+        firstIssue,
+        languageIssues,
+        returnPayload,
+        toolSessionContext,
+      },
+    );
+
+    return {
+      result: JSON.stringify(returnPayload, null, 2),
       updatedToolSessionContext: toolSessionContext,
     };
   }
@@ -233,35 +346,43 @@ export async function get_next_language_exercise(
       parsedConfigResult.hash;
   }
 
+  const returnPayload = {
+    status: "exercise_ready",
+    mode: "initial",
+    config_hash: parsedConfigResult.hash,
+    overview: {
+      issueIndex: 0,
+      exerciseIndex: 0,
+      issueCount: parsedConfigResult.summary.issueCount,
+      totalExerciseCount: parsedConfigResult.summary.exerciseCount,
+      exerciseCountInIssue: firstIssue.exercises.length,
+    },
+    issue: {
+      errorId: firstIssue.errorId,
+      title: firstIssue.title,
+      area: firstIssue.area,
+      impact: firstIssue.impact,
+      description: firstIssue.description,
+      theory: firstIssue.theory,
+      categoryCode: firstIssue.categoryCode,
+      subcategoryCode: firstIssue.subcategoryCode,
+      subcategoryName: firstIssue.subcategoryName,
+    },
+    exercise: firstExercise,
+  };
+
+  log.info(
+    "[language_lesson] Returning initial exercise",
+    {},
+    {
+      returnPayload,
+      updatedToolSessionContext,
+      toolSessionContext,
+    },
+  );
+
   return {
-    result: JSON.stringify(
-      {
-        status: "exercise_ready",
-        mode: "initial",
-        config_hash: parsedConfigResult.hash,
-        overview: {
-          issueIndex: 0,
-          exerciseIndex: 0,
-          issueCount: parsedConfigResult.summary.issueCount,
-          totalExerciseCount: parsedConfigResult.summary.exerciseCount,
-          exerciseCountInIssue: firstIssue.exercises.length,
-        },
-        issue: {
-          errorId: firstIssue.errorId,
-          title: firstIssue.title,
-          area: firstIssue.area,
-          impact: firstIssue.impact,
-          description: firstIssue.description,
-          theory: firstIssue.theory,
-          categoryCode: firstIssue.categoryCode,
-          subcategoryCode: firstIssue.subcategoryCode,
-          subcategoryName: firstIssue.subcategoryName,
-        },
-        exercise: firstExercise,
-      },
-      null,
-      2,
-    ),
+    result: JSON.stringify(returnPayload, null, 2),
     updatedToolSessionContext,
   };
 }

--- a/modules/vm-webrtc/src/toolkit_functions/language_lesson.ts
+++ b/modules/vm-webrtc/src/toolkit_functions/language_lesson.ts
@@ -106,7 +106,9 @@ function findFirstUnfinishedExercise(
   return null;
 }
 
-function summarizeProgress(config: NormalizedLanguageLessonConfig): ProgressSummary {
+function summarizeProgress(
+  config: NormalizedLanguageLessonConfig,
+): ProgressSummary {
   const issueCount = config.language_issues.length;
   const totalExerciseCount = config.language_issues.reduce(
     (count, issue) => count + issue.exercises.length,
@@ -114,7 +116,8 @@ function summarizeProgress(config: NormalizedLanguageLessonConfig): ProgressSumm
   );
   const finishedExerciseCount = config.language_issues.reduce(
     (count, issue) =>
-      count + issue.exercises.filter((exercise) => isExerciseFinished(exercise)).length,
+      count +
+      issue.exercises.filter((exercise) => isExerciseFinished(exercise)).length,
     0,
   );
 
@@ -346,7 +349,9 @@ async function loadValidatedConfigOrResult(
   };
 }
 
-function normalizePerformanceNotes(performanceNotes: string | null): string | null {
+function normalizePerformanceNotes(
+  performanceNotes: string | null,
+): string | null {
   if (!performanceNotes || performanceNotes.trim().length === 0) {
     return null;
   }
@@ -354,7 +359,7 @@ function normalizePerformanceNotes(performanceNotes: string | null): string | nu
   return performanceNotes;
 }
 
-async function persistUpdatedConfigOrResult(
+async function persistUpdatedConfigOrErrorResult(
   mutableConfig: NormalizedLanguageLessonConfig,
   parsedConfigResult: LoadParsedLanguageLessonConfigResult,
   previousExerciseId: string,
@@ -363,8 +368,7 @@ async function persistUpdatedConfigOrResult(
   try {
     await saveParsedLanguageLessonConfig(mutableConfig);
   } catch (error) {
-    const errorMessage =
-      error instanceof Error ? error.message : String(error);
+    const errorMessage = error instanceof Error ? error.message : String(error);
 
     const returnPayload = {
       status: "persist_failed",
@@ -496,9 +500,10 @@ async function handleFollowUpCall(
         invocationState,
         user_score: numericScore,
         performance_notes: normalizedPerformanceNotes,
-        availableExerciseIds: loadedConfigState.mutableConfig.language_issues.flatMap(
-          (issue) => issue.exercises.map((exercise) => exercise.exercise_id),
-        ),
+        availableExerciseIds:
+          loadedConfigState.mutableConfig.language_issues.flatMap((issue) =>
+            issue.exercises.map((exercise) => exercise.exercise_id),
+          ),
         returnPayload,
         toolSessionContext,
       },
@@ -534,23 +539,42 @@ async function handleFollowUpCall(
     },
   );
 
-  const persistResult = await persistUpdatedConfigOrResult(
+  const persistErrorResult = await persistUpdatedConfigOrErrorResult(
     loadedConfigState.mutableConfig,
     loadedConfigState.parsedConfigResult,
     invocationState.normalizedPreviousExerciseId,
     toolSessionContext,
   );
 
-  if (persistResult) {
-    return persistResult;
+  if (persistErrorResult) {
+    log.warn(
+      "[language_lesson] Persistence step returned an error result; ending follow-up flow early",
+      {},
+      {
+        previous_exercise_id: invocationState.normalizedPreviousExerciseId,
+        toolSessionContext,
+      },
+    );
+    return persistErrorResult;
   }
+
+  log.info(
+    "[language_lesson] Previous exercise progress persisted; continuing to select next exercise",
+    {},
+    {
+      previous_exercise_id: invocationState.normalizedPreviousExerciseId,
+      toolSessionContext,
+    },
+  );
 
   const reloadOutcome = await reloadPersistedConfigOrResult(toolSessionContext);
   if (reloadOutcome.toolkitResult || !reloadOutcome.reloadedConfigResult) {
     return reloadOutcome.toolkitResult as ToolkitResult;
   }
 
-  const nextLocator = findFirstUnfinishedExercise(reloadOutcome.reloadedConfig!);
+  const nextLocator = findFirstUnfinishedExercise(
+    reloadOutcome.reloadedConfig!,
+  );
   const progressAfter = summarizeProgress(reloadOutcome.reloadedConfig!);
 
   log.info(
@@ -628,7 +652,8 @@ async function handleFollowUpCall(
       issueIndex: nextLocator.issueIndex,
       exerciseIndex: nextLocator.exerciseIndex,
       issueCount: reloadOutcome.reloadedConfigResult.summary.issueCount,
-      totalExerciseCount: reloadOutcome.reloadedConfigResult.summary.exerciseCount,
+      totalExerciseCount:
+        reloadOutcome.reloadedConfigResult.summary.exerciseCount,
       exerciseCountInIssue: nextLocator.issue.exercises.length,
     },
     issue: buildIssuePayload(nextLocator.issue),
@@ -652,7 +677,9 @@ function handleInitialCall(
   loadedConfigState: LoadedConfigState,
   toolSessionContext: ToolSessionContext,
 ): ToolkitResult {
-  const initialLocator = findFirstUnfinishedExercise(loadedConfigState.mutableConfig);
+  const initialLocator = findFirstUnfinishedExercise(
+    loadedConfigState.mutableConfig,
+  );
 
   log.info(
     "[language_lesson] Selecting first unfinished exercise for initial call",
@@ -716,7 +743,8 @@ function handleInitialCall(
       issueIndex: initialLocator.issueIndex,
       exerciseIndex: initialLocator.exerciseIndex,
       issueCount: loadedConfigState.parsedConfigResult.summary.issueCount,
-      totalExerciseCount: loadedConfigState.parsedConfigResult.summary.exerciseCount,
+      totalExerciseCount:
+        loadedConfigState.parsedConfigResult.summary.exerciseCount,
       exerciseCountInIssue: initialLocator.issue.exercises.length,
     },
     issue: buildIssuePayload(initialLocator.issue),
@@ -763,7 +791,10 @@ export async function get_next_language_exercise(
     invocationState,
     toolSessionContext,
   );
-  if (loadedConfigOutcome.toolkitResult || !loadedConfigOutcome.loadedConfigState) {
+  if (
+    loadedConfigOutcome.toolkitResult ||
+    !loadedConfigOutcome.loadedConfigState
+  ) {
     return loadedConfigOutcome.toolkitResult as ToolkitResult;
   }
 

--- a/modules/vm-webrtc/src/toolkit_functions/language_lesson.ts
+++ b/modules/vm-webrtc/src/toolkit_functions/language_lesson.ts
@@ -304,6 +304,15 @@ function buildToolkitResult(
   payload: unknown,
   updatedToolSessionContext: ToolSessionContext,
 ): ToolkitResult {
+  log.info(
+    "[language_lesson] Emitting normalized tool response",
+    {},
+    {
+      payload,
+      updatedToolSessionContext,
+    },
+  );
+
   return {
     result: JSON.stringify(payload, null, 2),
     updatedToolSessionContext,

--- a/modules/vm-webrtc/src/toolkit_functions/language_lesson_schema.ts
+++ b/modules/vm-webrtc/src/toolkit_functions/language_lesson_schema.ts
@@ -19,6 +19,14 @@ const DEFAULT_EXERCISE_FEEDBACK = {
   hint_levels: [] as string[],
 };
 
+const DEFAULT_SPOKEN_FEEDBACK = {
+  on_fail: undefined as
+    | string
+    | { level: number; text: string }[]
+    | undefined,
+  on_pass: undefined as string | undefined,
+};
+
 const DEFAULT_EXERCISE_METADATA = {
   difficulty: undefined as number | undefined,
   tags: [] as string[],
@@ -27,8 +35,9 @@ const DEFAULT_EXERCISE_METADATA = {
 const DEFAULT_EXERCISE_PRESENTATION_RULES = {
   max_hint_level: 2,
   shuffle_exercises: true,
-  show_theory_before_first_exercise: true,
-  show_corrections_after_each_attempt: true,
+  speak_theory_before_first_exercise: true,
+  spoken_corrections_after_each_attempt: true,
+  allow_self_correction_window_seconds: 2.0,
 };
 
 const DEFAULT_EXERCISES_SPEC = {
@@ -43,6 +52,23 @@ const languageIssueExampleSchema = z
     nativeTarget: nonEmptyString,
     tsStart: z.number(),
     tsEnd: z.number(),
+  })
+  .strict();
+
+const theoryVoiceExamplePairSchema = z
+  .object({
+    incorrect: nonEmptyString,
+    correct: nonEmptyString,
+  })
+  .strict();
+
+const theoryVoiceSchema = z
+  .object({
+    spoken_explanation: nonEmptyString,
+    example_pairs_audio: z
+      .array(theoryVoiceExamplePairSchema)
+      .optional()
+      .default([]),
   })
   .strict();
 
@@ -97,6 +123,27 @@ const exerciseFeedbackSchema = z
   .transform((value) => ({
     on_fail: value?.on_fail ?? DEFAULT_EXERCISE_FEEDBACK.on_fail,
     hint_levels: value?.hint_levels ?? DEFAULT_EXERCISE_FEEDBACK.hint_levels,
+  }));
+
+const spokenOnFailLevelSchema = z
+  .object({
+    level: z.number().int().min(1),
+    text: nonEmptyString,
+  })
+  .strict();
+
+const spokenFeedbackSchema = z
+  .object({
+    on_fail: z
+      .union([nonEmptyString, z.array(spokenOnFailLevelSchema).min(1)])
+      .optional(),
+    on_pass: nonEmptyString.optional(),
+  })
+  .strict()
+  .optional()
+  .transform((value) => ({
+    on_fail: value?.on_fail ?? DEFAULT_SPOKEN_FEEDBACK.on_fail,
+    on_pass: value?.on_pass ?? DEFAULT_SPOKEN_FEEDBACK.on_pass,
   }));
 
 const exerciseMetadataSchema = z
@@ -172,35 +219,169 @@ const correctTheSentenceExerciseSchema = z
   })
   .strict();
 
+const speechLearnerResponseSchema = z
+  .object({
+    mode: z.literal("speech"),
+  })
+  .strict();
+
+const firstSecondEnumSchema = z.enum(["first", "second"]);
+
+const listenLearnerResponseSchema = z
+  .object({
+    mode: z.literal("speech"),
+    expected: z.array(firstSecondEnumSchema).min(1).optional(),
+  })
+  .strict();
+
+const spokenCommonErrorPatternSchema = z
+  .object({
+    pattern: nonEmptyString,
+    diagnosis: nonEmptyString,
+  })
+  .strict();
+
+const spokenToleranceSchema = z
+  .object({
+    allow_minor_disfluencies: z.boolean().optional(),
+    allow_article_variation: z.boolean().optional(),
+  })
+  .strict();
+
+const spokenTranslationExerciseSchema = z
+  .object({
+    exercise_id: nonEmptyString,
+    type: z.literal("spoken_translation"),
+    agent_prompt_spoken: nonEmptyString,
+    learner_response: speechLearnerResponseSchema,
+    grading: z
+      .object({
+        semantic_target: nonEmptyString,
+        must_include_concepts: z.array(nonEmptyString).optional(),
+        common_error_patterns: z
+          .array(spokenCommonErrorPatternSchema)
+          .optional(),
+        tolerance: spokenToleranceSchema.optional(),
+      })
+      .strict(),
+    spoken_feedback: spokenFeedbackSchema,
+    metadata: exerciseMetadataSchema,
+  })
+  .strict();
+
+const listenAndDiscriminateExerciseSchema = z
+  .object({
+    exercise_id: nonEmptyString,
+    type: z.literal("listen_and_discriminate"),
+    agent_prompt_spoken: nonEmptyString,
+    audio_pairs: z
+      .array(
+        z
+          .object({
+            first: nonEmptyString,
+            second: nonEmptyString,
+          })
+          .strict(),
+      )
+      .min(1),
+    learner_response: listenLearnerResponseSchema,
+    grading: z
+      .object({
+        correct_answer: z.union([
+          firstSecondEnumSchema,
+          z.array(firstSecondEnumSchema).min(1),
+        ]),
+      })
+      .strict(),
+    spoken_feedback: spokenFeedbackSchema,
+    metadata: exerciseMetadataSchema,
+  })
+  .strict();
+
+const spokenCorrectionExerciseSchema = z
+  .object({
+    exercise_id: nonEmptyString,
+    type: z.literal("spoken_correction"),
+    agent_prompt_spoken: nonEmptyString,
+    learner_response: speechLearnerResponseSchema,
+    grading: z
+      .object({
+        required_fix: nonEmptyString,
+        target_structure: nonEmptyString,
+      })
+      .strict(),
+    spoken_feedback: spokenFeedbackSchema,
+    metadata: exerciseMetadataSchema,
+  })
+  .strict();
+
+const spokenPatternCompletionExerciseSchema = z
+  .object({
+    exercise_id: nonEmptyString,
+    type: z.literal("spoken_pattern_completion"),
+    agent_prompt_spoken: nonEmptyString,
+    learner_response: speechLearnerResponseSchema,
+    grading: z
+      .object({
+        expected_word: nonEmptyString,
+        forbidden_patterns: z.array(nonEmptyString).optional(),
+      })
+      .strict(),
+    spoken_feedback: spokenFeedbackSchema,
+    metadata: exerciseMetadataSchema,
+  })
+  .strict();
+
 export const languageExerciseSchema = z.discriminatedUnion("type", [
   translateExerciseSchema,
   chooseOneExerciseSchema,
   correctTheSentenceExerciseSchema,
+  spokenTranslationExerciseSchema,
+  listenAndDiscriminateExerciseSchema,
+  spokenCorrectionExerciseSchema,
+  spokenPatternCompletionExerciseSchema,
 ]);
 
 const exercisePresentationRulesSchema = z
   .object({
     max_hint_level: z.number().int().min(0).optional(),
     shuffle_exercises: z.boolean().optional(),
+    speak_theory_before_first_exercise: z.boolean().optional(),
+    spoken_corrections_after_each_attempt: z.boolean().optional(),
+    allow_self_correction_window_seconds: z.number().min(0).optional(),
     show_theory_before_first_exercise: z.boolean().optional(),
     show_corrections_after_each_attempt: z.boolean().optional(),
   })
   .strict()
   .optional()
-  .transform((value) => ({
-    max_hint_level:
-      value?.max_hint_level ??
-      DEFAULT_EXERCISE_PRESENTATION_RULES.max_hint_level,
-    shuffle_exercises:
-      value?.shuffle_exercises ??
-      DEFAULT_EXERCISE_PRESENTATION_RULES.shuffle_exercises,
-    show_theory_before_first_exercise:
+  .transform((value) => {
+    const speakTheoryBeforeFirstExercise =
+      value?.speak_theory_before_first_exercise ??
       value?.show_theory_before_first_exercise ??
-      DEFAULT_EXERCISE_PRESENTATION_RULES.show_theory_before_first_exercise,
-    show_corrections_after_each_attempt:
+      DEFAULT_EXERCISE_PRESENTATION_RULES.speak_theory_before_first_exercise;
+
+    const spokenCorrectionsAfterEachAttempt =
+      value?.spoken_corrections_after_each_attempt ??
       value?.show_corrections_after_each_attempt ??
-      DEFAULT_EXERCISE_PRESENTATION_RULES.show_corrections_after_each_attempt,
-  }));
+      DEFAULT_EXERCISE_PRESENTATION_RULES.spoken_corrections_after_each_attempt;
+
+    return {
+      max_hint_level:
+        value?.max_hint_level ??
+        DEFAULT_EXERCISE_PRESENTATION_RULES.max_hint_level,
+      shuffle_exercises:
+        value?.shuffle_exercises ??
+        DEFAULT_EXERCISE_PRESENTATION_RULES.shuffle_exercises,
+      speak_theory_before_first_exercise: speakTheoryBeforeFirstExercise,
+      spoken_corrections_after_each_attempt:
+        spokenCorrectionsAfterEachAttempt,
+      allow_self_correction_window_seconds:
+        value?.allow_self_correction_window_seconds ??
+        DEFAULT_EXERCISE_PRESENTATION_RULES.allow_self_correction_window_seconds,
+      show_theory_before_first_exercise: speakTheoryBeforeFirstExercise,
+      show_corrections_after_each_attempt: spokenCorrectionsAfterEachAttempt,
+    };
+  });
 
 const exercisesSpecSchema = z
   .object({
@@ -228,6 +409,7 @@ const languageIssueSchema = z
     impact: z.string().optional(),
     description: z.string().optional(),
     theory: z.string().optional(),
+    theory_voice: theoryVoiceSchema.optional(),
     examples: z.array(languageIssueExampleSchema).optional(),
     categoryCode: z.string().optional(),
     subcategoryCode: z.string().optional(),

--- a/modules/vm-webrtc/src/toolkit_functions/language_lesson_schema.ts
+++ b/modules/vm-webrtc/src/toolkit_functions/language_lesson_schema.ts
@@ -1,0 +1,347 @@
+import { z } from "zod";
+
+const nonEmptyString = z.string().trim().min(1);
+
+const DEFAULT_EXERCISE_NORMALIZATION = {
+  casefold: true,
+  strip_punctuation: true,
+  trim_whitespace: true,
+};
+
+const DEFAULT_EXERCISE_CHECKS = {
+  must_contain: [] as string[],
+  must_match_regex_all: [] as string[],
+  forbid_regex_any: [] as string[],
+};
+
+const DEFAULT_EXERCISE_FEEDBACK = {
+  on_fail: undefined as string | undefined,
+  hint_levels: [] as string[],
+};
+
+const DEFAULT_EXERCISE_METADATA = {
+  difficulty: undefined as number | undefined,
+  tags: [] as string[],
+};
+
+const DEFAULT_EXERCISE_PRESENTATION_RULES = {
+  max_hint_level: 2,
+  shuffle_exercises: true,
+  show_theory_before_first_exercise: true,
+  show_corrections_after_each_attempt: true,
+};
+
+const DEFAULT_EXERCISES_SPEC = {
+  num_times_repeat_on_fail: 3,
+  num_exercises_required_for_pass: 0.2,
+  presentation_rules: DEFAULT_EXERCISE_PRESENTATION_RULES,
+};
+
+const languageIssueExampleSchema = z
+  .object({
+    userSaid: nonEmptyString,
+    nativeTarget: nonEmptyString,
+    tsStart: z.number(),
+    tsEnd: z.number(),
+  })
+  .strict();
+
+const exerciseNormalizationSchema = z
+  .object({
+    casefold: z.boolean().optional(),
+    strip_punctuation: z.boolean().optional(),
+    trim_whitespace: z.boolean().optional(),
+  })
+  .strict()
+  .optional()
+  .transform((value) => ({
+    casefold: value?.casefold ?? DEFAULT_EXERCISE_NORMALIZATION.casefold,
+    strip_punctuation:
+      value?.strip_punctuation ??
+      DEFAULT_EXERCISE_NORMALIZATION.strip_punctuation,
+    trim_whitespace:
+      value?.trim_whitespace ?? DEFAULT_EXERCISE_NORMALIZATION.trim_whitespace,
+  }));
+
+const exerciseExpectedAnswersSchema = z
+  .object({
+    accepted_answers: z.array(nonEmptyString).min(1),
+    normalize: exerciseNormalizationSchema,
+  })
+  .strict();
+
+const exerciseChecksSchema = z
+  .object({
+    must_contain: z.array(nonEmptyString).optional(),
+    must_match_regex_all: z.array(nonEmptyString).optional(),
+    forbid_regex_any: z.array(nonEmptyString).optional(),
+  })
+  .strict()
+  .optional()
+  .transform((value) => ({
+    must_contain: value?.must_contain ?? DEFAULT_EXERCISE_CHECKS.must_contain,
+    must_match_regex_all:
+      value?.must_match_regex_all ??
+      DEFAULT_EXERCISE_CHECKS.must_match_regex_all,
+    forbid_regex_any:
+      value?.forbid_regex_any ?? DEFAULT_EXERCISE_CHECKS.forbid_regex_any,
+  }));
+
+const exerciseFeedbackSchema = z
+  .object({
+    on_fail: nonEmptyString.optional(),
+    hint_levels: z.array(nonEmptyString).optional(),
+  })
+  .strict()
+  .optional()
+  .transform((value) => ({
+    on_fail: value?.on_fail ?? DEFAULT_EXERCISE_FEEDBACK.on_fail,
+    hint_levels: value?.hint_levels ?? DEFAULT_EXERCISE_FEEDBACK.hint_levels,
+  }));
+
+const exerciseMetadataSchema = z
+  .object({
+    difficulty: z.number().optional(),
+    tags: z.array(nonEmptyString).optional(),
+  })
+  .strict()
+  .optional()
+  .transform((value) => ({
+    difficulty: value?.difficulty ?? DEFAULT_EXERCISE_METADATA.difficulty,
+    tags: value?.tags ?? DEFAULT_EXERCISE_METADATA.tags,
+  }));
+
+const translateExerciseSchema = z
+  .object({
+    exercise_id: nonEmptyString,
+    type: z.literal("translate"),
+    prompt: nonEmptyString,
+    expected: exerciseExpectedAnswersSchema,
+    checks: exerciseChecksSchema,
+    feedback: exerciseFeedbackSchema,
+    metadata: exerciseMetadataSchema,
+  })
+  .strict();
+
+const chooseOneOptionSchema = z
+  .object({
+    id: nonEmptyString,
+    text: nonEmptyString,
+  })
+  .strict();
+
+const chooseOneExerciseSchema = z
+  .object({
+    exercise_id: nonEmptyString,
+    type: z.literal("choose_one"),
+    prompt: nonEmptyString,
+    stem: nonEmptyString.optional(),
+    options: z.array(chooseOneOptionSchema).min(2),
+    answer: z
+      .object({
+        correct_option_id: nonEmptyString,
+      })
+      .strict(),
+    rationale: nonEmptyString.optional(),
+    feedback: exerciseFeedbackSchema,
+    metadata: exerciseMetadataSchema,
+  })
+  .strict()
+  .superRefine((exercise, ctx) => {
+    const optionIds = new Set(exercise.options.map((option) => option.id));
+    if (!optionIds.has(exercise.answer.correct_option_id)) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message:
+          "answer.correct_option_id must match one of the provided option ids",
+        path: ["answer", "correct_option_id"],
+      });
+    }
+  });
+
+const correctTheSentenceExerciseSchema = z
+  .object({
+    exercise_id: nonEmptyString,
+    type: z.literal("correct_the_sentence"),
+    prompt: nonEmptyString,
+    sentence: nonEmptyString,
+    expected: exerciseExpectedAnswersSchema,
+    checks: exerciseChecksSchema,
+    feedback: exerciseFeedbackSchema,
+    metadata: exerciseMetadataSchema,
+  })
+  .strict();
+
+export const languageExerciseSchema = z.discriminatedUnion("type", [
+  translateExerciseSchema,
+  chooseOneExerciseSchema,
+  correctTheSentenceExerciseSchema,
+]);
+
+const exercisePresentationRulesSchema = z
+  .object({
+    max_hint_level: z.number().int().min(0).optional(),
+    shuffle_exercises: z.boolean().optional(),
+    show_theory_before_first_exercise: z.boolean().optional(),
+    show_corrections_after_each_attempt: z.boolean().optional(),
+  })
+  .strict()
+  .optional()
+  .transform((value) => ({
+    max_hint_level:
+      value?.max_hint_level ?? DEFAULT_EXERCISE_PRESENTATION_RULES.max_hint_level,
+    shuffle_exercises:
+      value?.shuffle_exercises ??
+      DEFAULT_EXERCISE_PRESENTATION_RULES.shuffle_exercises,
+    show_theory_before_first_exercise:
+      value?.show_theory_before_first_exercise ??
+      DEFAULT_EXERCISE_PRESENTATION_RULES.show_theory_before_first_exercise,
+    show_corrections_after_each_attempt:
+      value?.show_corrections_after_each_attempt ??
+      DEFAULT_EXERCISE_PRESENTATION_RULES.show_corrections_after_each_attempt,
+  }));
+
+const exercisesSpecSchema = z
+  .object({
+    num_times_repeat_on_fail: z.number().int().min(0).optional(),
+    num_exercises_required_for_pass: z.number().min(0).max(100).optional(),
+    presentation_rules: exercisePresentationRulesSchema.optional(),
+  })
+  .strict()
+  .optional()
+  .transform((value) => ({
+    num_times_repeat_on_fail:
+      value?.num_times_repeat_on_fail ??
+      DEFAULT_EXERCISES_SPEC.num_times_repeat_on_fail,
+    num_exercises_required_for_pass:
+      value?.num_exercises_required_for_pass ??
+      DEFAULT_EXERCISES_SPEC.num_exercises_required_for_pass,
+    presentation_rules:
+      value?.presentation_rules ?? DEFAULT_EXERCISES_SPEC.presentation_rules,
+  }));
+
+const languageIssueSchema = z
+  .object({
+    title: nonEmptyString,
+    area: nonEmptyString,
+    impact: nonEmptyString,
+    description: nonEmptyString,
+    theory: nonEmptyString,
+    examples: z.array(languageIssueExampleSchema).optional().default([]),
+    categoryCode: nonEmptyString,
+    subcategoryCode: nonEmptyString,
+    subcategoryName: nonEmptyString,
+    errorId: nonEmptyString,
+    exercises_spec: exercisesSpecSchema,
+    exercises: z.array(languageExerciseSchema).min(1),
+  })
+  .strict();
+
+export const languageLessonConfigSchema = z
+  .object({
+    language_issues: z.array(languageIssueSchema).min(1),
+  })
+  .strict()
+  .superRefine((config, ctx) => {
+    const seenErrorIds = new Map<string, number>();
+    const seenExerciseIds = new Map<
+      string,
+      { issueIndex: number; exerciseIndex: number }
+    >();
+
+    config.language_issues.forEach((issue, issueIndex) => {
+      const priorErrorIssueIndex = seenErrorIds.get(issue.errorId);
+      if (priorErrorIssueIndex !== undefined) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: `Duplicate errorId '${issue.errorId}' first seen at language_issues[${priorErrorIssueIndex}]`,
+          path: ["language_issues", issueIndex, "errorId"],
+        });
+      } else {
+        seenErrorIds.set(issue.errorId, issueIndex);
+      }
+
+      issue.exercises.forEach((exercise, exerciseIndex) => {
+        const priorExerciseLocation = seenExerciseIds.get(exercise.exercise_id);
+        if (priorExerciseLocation) {
+          ctx.addIssue({
+            code: z.ZodIssueCode.custom,
+            message: `Duplicate exercise_id '${exercise.exercise_id}' first seen at language_issues[${priorExerciseLocation.issueIndex}].exercises[${priorExerciseLocation.exerciseIndex}]`,
+            path: [
+              "language_issues",
+              issueIndex,
+              "exercises",
+              exerciseIndex,
+              "exercise_id",
+            ],
+          });
+        } else {
+          seenExerciseIds.set(exercise.exercise_id, {
+            issueIndex,
+            exerciseIndex,
+          });
+        }
+      });
+    });
+  });
+
+export type NormalizedLanguageLessonConfig = z.infer<
+  typeof languageLessonConfigSchema
+>;
+export type NormalizedLanguageIssue = z.infer<typeof languageIssueSchema>;
+export type NormalizedLanguageExercise = z.infer<typeof languageExerciseSchema>;
+
+export interface ParseLanguageLessonConfigResult {
+  success: boolean;
+  data: NormalizedLanguageLessonConfig | null;
+  errors: string[];
+}
+
+function formatZodIssues(issues: z.ZodIssue[]): string[] {
+  return issues.map((issue) => {
+    const path = issue.path.length > 0 ? issue.path.join(".") : "root";
+    return `${path}: ${issue.message}`;
+  });
+}
+
+export function parseAndNormalizeLanguageLessonConfig(
+  raw: string,
+): ParseLanguageLessonConfigResult {
+  const trimmed = raw.trim();
+
+  if (trimmed.length === 0) {
+    return {
+      success: false,
+      data: null,
+      errors: ["root: Language lesson config is empty"],
+    };
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(trimmed);
+  } catch (error) {
+    return {
+      success: false,
+      data: null,
+      errors: [
+        `root: Invalid JSON - ${error instanceof Error ? error.message : String(error)}`,
+      ],
+    };
+  }
+
+  const normalizedResult = languageLessonConfigSchema.safeParse(parsed);
+  if (!normalizedResult.success) {
+    return {
+      success: false,
+      data: null,
+      errors: formatZodIssues(normalizedResult.error.issues),
+    };
+  }
+
+  return {
+    success: true,
+    data: normalizedResult.data,
+    errors: [],
+  };
+}

--- a/modules/vm-webrtc/src/toolkit_functions/language_lesson_schema.ts
+++ b/modules/vm-webrtc/src/toolkit_functions/language_lesson_schema.ts
@@ -20,16 +20,21 @@ const DEFAULT_EXERCISE_FEEDBACK = {
 };
 
 const DEFAULT_SPOKEN_FEEDBACK = {
-  on_fail: undefined as
-    | string
-    | { level: number; text: string }[]
-    | undefined,
+  on_fail: undefined as string | { level: number; text: string }[] | undefined,
   on_pass: undefined as string | undefined,
 };
 
 const DEFAULT_EXERCISE_METADATA = {
   difficulty: undefined as number | undefined,
   tags: [] as string[],
+};
+
+const exerciseProgressStateFields = {
+  status: z.enum(["pending", "finished"]).optional(),
+  attempts: z.number().int().min(0).optional(),
+  last_score: z.number().nullable().optional(),
+  last_notes: z.string().nullable().optional(),
+  finished_at: z.string().nullable().optional(),
 };
 
 const DEFAULT_EXERCISE_PRESENTATION_RULES = {
@@ -167,6 +172,7 @@ const translateExerciseSchema = z
     checks: exerciseChecksSchema,
     feedback: exerciseFeedbackSchema,
     metadata: exerciseMetadataSchema,
+    ...exerciseProgressStateFields,
   })
   .strict();
 
@@ -192,6 +198,7 @@ const chooseOneExerciseSchema = z
     rationale: nonEmptyString.optional(),
     feedback: exerciseFeedbackSchema,
     metadata: exerciseMetadataSchema,
+    ...exerciseProgressStateFields,
   })
   .strict()
   .superRefine((exercise, ctx) => {
@@ -216,6 +223,7 @@ const correctTheSentenceExerciseSchema = z
     checks: exerciseChecksSchema,
     feedback: exerciseFeedbackSchema,
     metadata: exerciseMetadataSchema,
+    ...exerciseProgressStateFields,
   })
   .strict();
 
@@ -266,6 +274,7 @@ const spokenTranslationExerciseSchema = z
       .strict(),
     spoken_feedback: spokenFeedbackSchema,
     metadata: exerciseMetadataSchema,
+    ...exerciseProgressStateFields,
   })
   .strict();
 
@@ -295,6 +304,7 @@ const listenAndDiscriminateExerciseSchema = z
       .strict(),
     spoken_feedback: spokenFeedbackSchema,
     metadata: exerciseMetadataSchema,
+    ...exerciseProgressStateFields,
   })
   .strict();
 
@@ -312,6 +322,7 @@ const spokenCorrectionExerciseSchema = z
       .strict(),
     spoken_feedback: spokenFeedbackSchema,
     metadata: exerciseMetadataSchema,
+    ...exerciseProgressStateFields,
   })
   .strict();
 
@@ -329,6 +340,7 @@ const spokenPatternCompletionExerciseSchema = z
       .strict(),
     spoken_feedback: spokenFeedbackSchema,
     metadata: exerciseMetadataSchema,
+    ...exerciseProgressStateFields,
   })
   .strict();
 
@@ -373,8 +385,7 @@ const exercisePresentationRulesSchema = z
         value?.shuffle_exercises ??
         DEFAULT_EXERCISE_PRESENTATION_RULES.shuffle_exercises,
       speak_theory_before_first_exercise: speakTheoryBeforeFirstExercise,
-      spoken_corrections_after_each_attempt:
-        spokenCorrectionsAfterEachAttempt,
+      spoken_corrections_after_each_attempt: spokenCorrectionsAfterEachAttempt,
       allow_self_correction_window_seconds:
         value?.allow_self_correction_window_seconds ??
         DEFAULT_EXERCISE_PRESENTATION_RULES.allow_self_correction_window_seconds,

--- a/modules/vm-webrtc/src/toolkit_functions/language_lesson_schema.ts
+++ b/modules/vm-webrtc/src/toolkit_functions/language_lesson_schema.ts
@@ -189,7 +189,8 @@ const exercisePresentationRulesSchema = z
   .optional()
   .transform((value) => ({
     max_hint_level:
-      value?.max_hint_level ?? DEFAULT_EXERCISE_PRESENTATION_RULES.max_hint_level,
+      value?.max_hint_level ??
+      DEFAULT_EXERCISE_PRESENTATION_RULES.max_hint_level,
     shuffle_exercises:
       value?.shuffle_exercises ??
       DEFAULT_EXERCISE_PRESENTATION_RULES.shuffle_exercises,
@@ -223,14 +224,14 @@ const exercisesSpecSchema = z
 const languageIssueSchema = z
   .object({
     title: nonEmptyString,
-    area: nonEmptyString,
-    impact: nonEmptyString,
-    description: nonEmptyString,
-    theory: nonEmptyString,
-    examples: z.array(languageIssueExampleSchema).optional().default([]),
-    categoryCode: nonEmptyString,
-    subcategoryCode: nonEmptyString,
-    subcategoryName: nonEmptyString,
+    area: z.string().optional(),
+    impact: z.string().optional(),
+    description: z.string().optional(),
+    theory: z.string().optional(),
+    examples: z.array(languageIssueExampleSchema).optional(),
+    categoryCode: z.string().optional(),
+    subcategoryCode: z.string().optional(),
+    subcategoryName: z.string().optional(),
     errorId: nonEmptyString,
     exercises_spec: exercisesSpecSchema,
     exercises: z.array(languageExerciseSchema).min(1),

--- a/modules/vm-webrtc/src/toolkit_functions/toolkit_functions.ts
+++ b/modules/vm-webrtc/src/toolkit_functions/toolkit_functions.ts
@@ -5,6 +5,7 @@ import * as dailyPapers from "./daily_papers";
 import * as github from "./github_helper";
 import * as googleDrive from "./google_drive";
 import * as hackerNews from "./hacker_news";
+import * as languageLesson from "./language_lesson";
 import * as web from "./web";
 
 // MARK: - Types
@@ -39,6 +40,7 @@ const toolkitModules = {
   web: web,
   google_drive: googleDrive,
   github: github,
+  language_lesson: languageLesson,
 };
 
 /**
@@ -185,4 +187,4 @@ export async function executeToolkitFunction(
 
 // MARK: - Exports
 
-export { dailyPapers, github, googleDrive, hackerNews, web };
+export { dailyPapers, github, googleDrive, hackerNews, languageLesson, web };

--- a/modules/vm-webrtc/toolkits/sample_language_lesson.json
+++ b/modules/vm-webrtc/toolkits/sample_language_lesson.json
@@ -1,0 +1,185 @@
+{
+  "language_issues": [
+    {
+      "title": "Verb 'Gustar' Structure with Indirect Object",
+      "area": "Syntax / Spoken Word Order",
+      "impact": "high",
+      "description": "Learner uses English-like subject patterns with 'gustar' instead of the Spanish indirect-object structure.",
+      "theory_voice": {
+        "spoken_explanation": "In Spanish, with 'gustar', the person is not the subject. You say 'a' plus the person, and you repeat it with 'me', 'te', 'le', or 'les'. The thing you like is the subject.",
+        "example_pairs_audio": [
+          {
+            "incorrect": "Creo que ella le gustará.",
+            "correct": "Creo que a ella le gustará."
+          }
+        ]
+      },
+      "categoryCode": "G",
+      "subcategoryCode": "G-SYN",
+      "subcategoryName": "Syntax / Word Order",
+      "errorId": "priority-gustar-1",
+      "exercises_spec": {
+        "num_times_repeat_on_fail": 3,
+        "num_exercises_required_for_pass": 0.2,
+        "presentation_rules": {
+          "max_hint_level": 2,
+          "shuffle_exercises": true,
+          "speak_theory_before_first_exercise": true,
+          "spoken_corrections_after_each_attempt": true,
+          "allow_self_correction_window_seconds": 2.0
+        }
+      },
+      "exercises": [
+        {
+          "exercise_id": "ex-gustar-voice-1",
+          "type": "spoken_translation",
+          "agent_prompt_spoken": "Say in Spanish: I think she will like the game design book.",
+          "learner_response": {
+            "mode": "speech"
+          },
+          "grading": {
+            "semantic_target": "Creo que a ella le gustará el libro de diseño de juegos",
+            "must_include_concepts": [
+              "indirect_object_a_ella",
+              "indirect_object_pronoun_le",
+              "future_gustar"
+            ],
+            "common_error_patterns": [
+              {
+                "pattern": "ella le gustará",
+                "diagnosis": "missing a + person"
+              }
+            ],
+            "tolerance": {
+              "allow_minor_disfluencies": true,
+              "allow_article_variation": true
+            }
+          },
+          "spoken_feedback": {
+            "on_fail": [
+              {
+                "level": 1,
+                "text": "Listen carefully. With 'gustar', you need 'a ella' before 'le gustará'. Try again."
+              },
+              {
+                "level": 2,
+                "text": "Repeat after me: Creo que a ella le gustará el libro."
+              }
+            ],
+            "on_pass": "Good. You used 'a ella' and 'le' correctly."
+          },
+          "metadata": {
+            "difficulty": 2,
+            "tags": ["gustar", "future", "spoken-grammar"]
+          }
+        },
+        {
+          "exercise_id": "ex-gustar-voice-2",
+          "type": "listen_and_discriminate",
+          "agent_prompt_spoken": "I will say two sentences. Say which one sounds correct: first or second.",
+          "audio_pairs": [
+            {
+              "first": "Creo que ella le gustará la app.",
+              "second": "Creo que a ella le gustará la app."
+            }
+          ],
+          "learner_response": {
+            "mode": "speech",
+            "expected": ["first", "second"]
+          },
+          "grading": {
+            "correct_answer": "second"
+          },
+          "spoken_feedback": {
+            "on_fail": "The correct one includes 'a ella'. Let's say it together.",
+            "on_pass": "Exactly. Spanish needs 'a ella le'."
+          },
+          "metadata": {
+            "difficulty": 1,
+            "tags": ["gustar", "ear-training"]
+          }
+        },
+        {
+          "exercise_id": "ex-gustar-voice-3",
+          "type": "spoken_correction",
+          "agent_prompt_spoken": "Correct this sentence out loud, keeping the same meaning: Creo que ella le gustará esta herramienta.",
+          "learner_response": {
+            "mode": "speech"
+          },
+          "grading": {
+            "required_fix": "insert_indirect_object_phrase",
+            "target_structure": "a ella le gustará"
+          },
+          "spoken_feedback": {
+            "on_fail": "You only need one change. Add 'a ella' before 'le gustará'.",
+            "on_pass": "Perfect correction."
+          },
+          "metadata": {
+            "difficulty": 2,
+            "tags": ["self-repair", "gustar"]
+          }
+        },
+        {
+          "exercise_id": "ex-gustar-voice-4",
+          "type": "spoken_pattern_completion",
+          "agent_prompt_spoken": "Complete the sentence out loud: A mí ___ gusta esta idea de startup.",
+          "learner_response": {
+            "mode": "speech"
+          },
+          "grading": {
+            "expected_word": "me",
+            "forbidden_patterns": ["yo me gusta"]
+          },
+          "spoken_feedback": {
+            "on_fail": "Remember, it's 'a mí me gusta', not 'yo me gusta'.",
+            "on_pass": "Yes. 'A mí me gusta.'"
+          },
+          "metadata": {
+            "difficulty": 1,
+            "tags": ["gustar", "pronouns"]
+          }
+        },
+        {
+          "exercise_id": "ex-gustar-voice-5",
+          "type": "spoken_translation",
+          "agent_prompt_spoken": "Say in Spanish: I don't think they will like these notes.",
+          "learner_response": {
+            "mode": "speech"
+          },
+          "grading": {
+            "semantic_target": "No creo que a ellos les gusten estas notas",
+            "must_include_concepts": [
+              "a_ellos",
+              "les",
+              "plural_gustar",
+              "subjunctive"
+            ],
+            "common_error_patterns": [
+              {
+                "pattern": "ellos les gusten",
+                "diagnosis": "subject used instead of indirect object"
+              }
+            ]
+          },
+          "spoken_feedback": {
+            "on_fail": [
+              {
+                "level": 1,
+                "text": "You need 'a ellos les' and the plural verb 'gusten'. Try again."
+              },
+              {
+                "level": 2,
+                "text": "Repeat after me: No creo que a ellos les gusten estas notas."
+              }
+            ],
+            "on_pass": "Excellent. You used 'les gusten' correctly."
+          },
+          "metadata": {
+            "difficulty": 3,
+            "tags": ["gustar", "subjunctive", "plural"]
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/modules/vm-webrtc/toolkits/sample_language_lesson.schema.json
+++ b/modules/vm-webrtc/toolkits/sample_language_lesson.schema.json
@@ -1,0 +1,875 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://arty.local/modules/vm-webrtc/toolkits/sample_language_lesson.schema.json",
+  "title": "Language Lesson Config",
+  "description": "Shareable schema for the language lesson JSON consumed by the language_lesson toolkit. Canonical runtime validation lives in modules/vm-webrtc/src/toolkit_functions/language_lesson_schema.ts. Note: cross-record uniqueness of errorId and exercise_id is enforced by the tool at runtime and is not fully expressible here.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["language_issues"],
+  "properties": {
+    "language_issues": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "$ref": "#/$defs/languageIssue"
+      }
+    }
+  },
+  "$defs": {
+    "nonEmptyTrimmedString": {
+      "type": "string",
+      "minLength": 1,
+      "pattern": ".*\\S.*",
+      "description": "String must contain at least one non-whitespace character."
+    },
+    "nullableString": {
+      "type": ["string", "null"]
+    },
+    "exerciseProgressStateFields": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "status": {
+          "type": "string",
+          "enum": ["pending", "finished"]
+        },
+        "attempts": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "last_score": {
+          "type": ["number", "null"]
+        },
+        "last_notes": {
+          "$ref": "#/$defs/nullableString"
+        },
+        "finished_at": {
+          "$ref": "#/$defs/nullableString"
+        }
+      }
+    },
+    "languageIssueExample": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["userSaid", "nativeTarget", "tsStart", "tsEnd"],
+      "properties": {
+        "userSaid": {
+          "$ref": "#/$defs/nonEmptyTrimmedString"
+        },
+        "nativeTarget": {
+          "$ref": "#/$defs/nonEmptyTrimmedString"
+        },
+        "tsStart": {
+          "type": "number"
+        },
+        "tsEnd": {
+          "type": "number"
+        }
+      }
+    },
+    "theoryVoiceExamplePair": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["incorrect", "correct"],
+      "properties": {
+        "incorrect": {
+          "$ref": "#/$defs/nonEmptyTrimmedString"
+        },
+        "correct": {
+          "$ref": "#/$defs/nonEmptyTrimmedString"
+        }
+      }
+    },
+    "theoryVoice": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["spoken_explanation"],
+      "properties": {
+        "spoken_explanation": {
+          "$ref": "#/$defs/nonEmptyTrimmedString"
+        },
+        "example_pairs_audio": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/theoryVoiceExamplePair"
+          },
+          "default": []
+        }
+      }
+    },
+    "exerciseNormalization": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "casefold": {
+          "type": "boolean",
+          "default": true
+        },
+        "strip_punctuation": {
+          "type": "boolean",
+          "default": true
+        },
+        "trim_whitespace": {
+          "type": "boolean",
+          "default": true
+        }
+      }
+    },
+    "exerciseExpectedAnswers": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["accepted_answers"],
+      "properties": {
+        "accepted_answers": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "$ref": "#/$defs/nonEmptyTrimmedString"
+          }
+        },
+        "normalize": {
+          "$ref": "#/$defs/exerciseNormalization"
+        }
+      }
+    },
+    "exerciseChecks": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "must_contain": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/nonEmptyTrimmedString"
+          },
+          "default": []
+        },
+        "must_match_regex_all": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/nonEmptyTrimmedString"
+          },
+          "default": []
+        },
+        "forbid_regex_any": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/nonEmptyTrimmedString"
+          },
+          "default": []
+        }
+      }
+    },
+    "exerciseFeedback": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "on_fail": {
+          "$ref": "#/$defs/nonEmptyTrimmedString"
+        },
+        "hint_levels": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/nonEmptyTrimmedString"
+          },
+          "default": []
+        }
+      }
+    },
+    "spokenOnFailLevel": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["level", "text"],
+      "properties": {
+        "level": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "text": {
+          "$ref": "#/$defs/nonEmptyTrimmedString"
+        }
+      }
+    },
+    "spokenFeedback": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "on_fail": {
+          "oneOf": [
+            {
+              "$ref": "#/$defs/nonEmptyTrimmedString"
+            },
+            {
+              "type": "array",
+              "minItems": 1,
+              "items": {
+                "$ref": "#/$defs/spokenOnFailLevel"
+              }
+            }
+          ]
+        },
+        "on_pass": {
+          "$ref": "#/$defs/nonEmptyTrimmedString"
+        }
+      }
+    },
+    "exerciseMetadata": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "difficulty": {
+          "type": "number"
+        },
+        "tags": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/nonEmptyTrimmedString"
+          },
+          "default": []
+        }
+      }
+    },
+    "chooseOneOption": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "text"],
+      "properties": {
+        "id": {
+          "$ref": "#/$defs/nonEmptyTrimmedString"
+        },
+        "text": {
+          "$ref": "#/$defs/nonEmptyTrimmedString"
+        }
+      }
+    },
+    "speechLearnerResponse": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["mode"],
+      "properties": {
+        "mode": {
+          "const": "speech"
+        }
+      }
+    },
+    "listenLearnerResponse": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["mode"],
+      "properties": {
+        "mode": {
+          "const": "speech"
+        },
+        "expected": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "string",
+            "enum": ["first", "second"]
+          }
+        }
+      }
+    },
+    "spokenCommonErrorPattern": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["pattern", "diagnosis"],
+      "properties": {
+        "pattern": {
+          "$ref": "#/$defs/nonEmptyTrimmedString"
+        },
+        "diagnosis": {
+          "$ref": "#/$defs/nonEmptyTrimmedString"
+        }
+      }
+    },
+    "spokenTolerance": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "allow_minor_disfluencies": {
+          "type": "boolean"
+        },
+        "allow_article_variation": {
+          "type": "boolean"
+        }
+      }
+    },
+    "translateExercise": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["exercise_id", "type", "prompt", "expected"],
+      "properties": {
+        "exercise_id": {
+          "$ref": "#/$defs/nonEmptyTrimmedString"
+        },
+        "type": {
+          "const": "translate"
+        },
+        "prompt": {
+          "$ref": "#/$defs/nonEmptyTrimmedString"
+        },
+        "expected": {
+          "$ref": "#/$defs/exerciseExpectedAnswers"
+        },
+        "checks": {
+          "$ref": "#/$defs/exerciseChecks"
+        },
+        "feedback": {
+          "$ref": "#/$defs/exerciseFeedback"
+        },
+        "metadata": {
+          "$ref": "#/$defs/exerciseMetadata"
+        },
+        "status": {
+          "type": "string",
+          "enum": ["pending", "finished"]
+        },
+        "attempts": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "last_score": {
+          "type": ["number", "null"]
+        },
+        "last_notes": {
+          "$ref": "#/$defs/nullableString"
+        },
+        "finished_at": {
+          "$ref": "#/$defs/nullableString"
+        }
+      }
+    },
+    "chooseOneExercise": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["exercise_id", "type", "prompt", "options", "answer"],
+      "properties": {
+        "exercise_id": {
+          "$ref": "#/$defs/nonEmptyTrimmedString"
+        },
+        "type": {
+          "const": "choose_one"
+        },
+        "prompt": {
+          "$ref": "#/$defs/nonEmptyTrimmedString"
+        },
+        "stem": {
+          "$ref": "#/$defs/nonEmptyTrimmedString"
+        },
+        "options": {
+          "type": "array",
+          "minItems": 2,
+          "items": {
+            "$ref": "#/$defs/chooseOneOption"
+          }
+        },
+        "answer": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["correct_option_id"],
+          "properties": {
+            "correct_option_id": {
+              "$ref": "#/$defs/nonEmptyTrimmedString"
+            }
+          },
+          "description": "Tool runtime also requires correct_option_id to match one of the option ids."
+        },
+        "rationale": {
+          "$ref": "#/$defs/nonEmptyTrimmedString"
+        },
+        "feedback": {
+          "$ref": "#/$defs/exerciseFeedback"
+        },
+        "metadata": {
+          "$ref": "#/$defs/exerciseMetadata"
+        },
+        "status": {
+          "type": "string",
+          "enum": ["pending", "finished"]
+        },
+        "attempts": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "last_score": {
+          "type": ["number", "null"]
+        },
+        "last_notes": {
+          "$ref": "#/$defs/nullableString"
+        },
+        "finished_at": {
+          "$ref": "#/$defs/nullableString"
+        }
+      }
+    },
+    "correctTheSentenceExercise": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["exercise_id", "type", "prompt", "sentence", "expected"],
+      "properties": {
+        "exercise_id": {
+          "$ref": "#/$defs/nonEmptyTrimmedString"
+        },
+        "type": {
+          "const": "correct_the_sentence"
+        },
+        "prompt": {
+          "$ref": "#/$defs/nonEmptyTrimmedString"
+        },
+        "sentence": {
+          "$ref": "#/$defs/nonEmptyTrimmedString"
+        },
+        "expected": {
+          "$ref": "#/$defs/exerciseExpectedAnswers"
+        },
+        "checks": {
+          "$ref": "#/$defs/exerciseChecks"
+        },
+        "feedback": {
+          "$ref": "#/$defs/exerciseFeedback"
+        },
+        "metadata": {
+          "$ref": "#/$defs/exerciseMetadata"
+        },
+        "status": {
+          "type": "string",
+          "enum": ["pending", "finished"]
+        },
+        "attempts": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "last_score": {
+          "type": ["number", "null"]
+        },
+        "last_notes": {
+          "$ref": "#/$defs/nullableString"
+        },
+        "finished_at": {
+          "$ref": "#/$defs/nullableString"
+        }
+      }
+    },
+    "spokenTranslationExercise": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "exercise_id",
+        "type",
+        "agent_prompt_spoken",
+        "learner_response",
+        "grading"
+      ],
+      "properties": {
+        "exercise_id": {
+          "$ref": "#/$defs/nonEmptyTrimmedString"
+        },
+        "type": {
+          "const": "spoken_translation"
+        },
+        "agent_prompt_spoken": {
+          "$ref": "#/$defs/nonEmptyTrimmedString"
+        },
+        "learner_response": {
+          "$ref": "#/$defs/speechLearnerResponse"
+        },
+        "grading": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["semantic_target"],
+          "properties": {
+            "semantic_target": {
+              "$ref": "#/$defs/nonEmptyTrimmedString"
+            },
+            "must_include_concepts": {
+              "type": "array",
+              "items": {
+                "$ref": "#/$defs/nonEmptyTrimmedString"
+              }
+            },
+            "common_error_patterns": {
+              "type": "array",
+              "items": {
+                "$ref": "#/$defs/spokenCommonErrorPattern"
+              }
+            },
+            "tolerance": {
+              "$ref": "#/$defs/spokenTolerance"
+            }
+          }
+        },
+        "spoken_feedback": {
+          "$ref": "#/$defs/spokenFeedback"
+        },
+        "metadata": {
+          "$ref": "#/$defs/exerciseMetadata"
+        },
+        "status": {
+          "type": "string",
+          "enum": ["pending", "finished"]
+        },
+        "attempts": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "last_score": {
+          "type": ["number", "null"]
+        },
+        "last_notes": {
+          "$ref": "#/$defs/nullableString"
+        },
+        "finished_at": {
+          "$ref": "#/$defs/nullableString"
+        }
+      }
+    },
+    "listenAndDiscriminateExercise": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "exercise_id",
+        "type",
+        "agent_prompt_spoken",
+        "audio_pairs",
+        "learner_response",
+        "grading"
+      ],
+      "properties": {
+        "exercise_id": {
+          "$ref": "#/$defs/nonEmptyTrimmedString"
+        },
+        "type": {
+          "const": "listen_and_discriminate"
+        },
+        "agent_prompt_spoken": {
+          "$ref": "#/$defs/nonEmptyTrimmedString"
+        },
+        "audio_pairs": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["first", "second"],
+            "properties": {
+              "first": {
+                "$ref": "#/$defs/nonEmptyTrimmedString"
+              },
+              "second": {
+                "$ref": "#/$defs/nonEmptyTrimmedString"
+              }
+            }
+          }
+        },
+        "learner_response": {
+          "$ref": "#/$defs/listenLearnerResponse"
+        },
+        "grading": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["correct_answer"],
+          "properties": {
+            "correct_answer": {
+              "oneOf": [
+                {
+                  "type": "string",
+                  "enum": ["first", "second"]
+                },
+                {
+                  "type": "array",
+                  "minItems": 1,
+                  "items": {
+                    "type": "string",
+                    "enum": ["first", "second"]
+                  }
+                }
+              ]
+            }
+          }
+        },
+        "spoken_feedback": {
+          "$ref": "#/$defs/spokenFeedback"
+        },
+        "metadata": {
+          "$ref": "#/$defs/exerciseMetadata"
+        },
+        "status": {
+          "type": "string",
+          "enum": ["pending", "finished"]
+        },
+        "attempts": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "last_score": {
+          "type": ["number", "null"]
+        },
+        "last_notes": {
+          "$ref": "#/$defs/nullableString"
+        },
+        "finished_at": {
+          "$ref": "#/$defs/nullableString"
+        }
+      }
+    },
+    "spokenCorrectionExercise": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "exercise_id",
+        "type",
+        "agent_prompt_spoken",
+        "learner_response",
+        "grading"
+      ],
+      "properties": {
+        "exercise_id": {
+          "$ref": "#/$defs/nonEmptyTrimmedString"
+        },
+        "type": {
+          "const": "spoken_correction"
+        },
+        "agent_prompt_spoken": {
+          "$ref": "#/$defs/nonEmptyTrimmedString"
+        },
+        "learner_response": {
+          "$ref": "#/$defs/speechLearnerResponse"
+        },
+        "grading": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["required_fix", "target_structure"],
+          "properties": {
+            "required_fix": {
+              "$ref": "#/$defs/nonEmptyTrimmedString"
+            },
+            "target_structure": {
+              "$ref": "#/$defs/nonEmptyTrimmedString"
+            }
+          }
+        },
+        "spoken_feedback": {
+          "$ref": "#/$defs/spokenFeedback"
+        },
+        "metadata": {
+          "$ref": "#/$defs/exerciseMetadata"
+        },
+        "status": {
+          "type": "string",
+          "enum": ["pending", "finished"]
+        },
+        "attempts": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "last_score": {
+          "type": ["number", "null"]
+        },
+        "last_notes": {
+          "$ref": "#/$defs/nullableString"
+        },
+        "finished_at": {
+          "$ref": "#/$defs/nullableString"
+        }
+      }
+    },
+    "spokenPatternCompletionExercise": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "exercise_id",
+        "type",
+        "agent_prompt_spoken",
+        "learner_response",
+        "grading"
+      ],
+      "properties": {
+        "exercise_id": {
+          "$ref": "#/$defs/nonEmptyTrimmedString"
+        },
+        "type": {
+          "const": "spoken_pattern_completion"
+        },
+        "agent_prompt_spoken": {
+          "$ref": "#/$defs/nonEmptyTrimmedString"
+        },
+        "learner_response": {
+          "$ref": "#/$defs/speechLearnerResponse"
+        },
+        "grading": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["expected_word"],
+          "properties": {
+            "expected_word": {
+              "$ref": "#/$defs/nonEmptyTrimmedString"
+            },
+            "forbidden_patterns": {
+              "type": "array",
+              "items": {
+                "$ref": "#/$defs/nonEmptyTrimmedString"
+              }
+            }
+          }
+        },
+        "spoken_feedback": {
+          "$ref": "#/$defs/spokenFeedback"
+        },
+        "metadata": {
+          "$ref": "#/$defs/exerciseMetadata"
+        },
+        "status": {
+          "type": "string",
+          "enum": ["pending", "finished"]
+        },
+        "attempts": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "last_score": {
+          "type": ["number", "null"]
+        },
+        "last_notes": {
+          "$ref": "#/$defs/nullableString"
+        },
+        "finished_at": {
+          "$ref": "#/$defs/nullableString"
+        }
+      }
+    },
+    "languageExercise": {
+      "oneOf": [
+        {
+          "$ref": "#/$defs/translateExercise"
+        },
+        {
+          "$ref": "#/$defs/chooseOneExercise"
+        },
+        {
+          "$ref": "#/$defs/correctTheSentenceExercise"
+        },
+        {
+          "$ref": "#/$defs/spokenTranslationExercise"
+        },
+        {
+          "$ref": "#/$defs/listenAndDiscriminateExercise"
+        },
+        {
+          "$ref": "#/$defs/spokenCorrectionExercise"
+        },
+        {
+          "$ref": "#/$defs/spokenPatternCompletionExercise"
+        }
+      ]
+    },
+    "exercisePresentationRules": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "max_hint_level": {
+          "type": "integer",
+          "minimum": 0,
+          "default": 2
+        },
+        "shuffle_exercises": {
+          "type": "boolean",
+          "default": true
+        },
+        "speak_theory_before_first_exercise": {
+          "type": "boolean",
+          "default": true
+        },
+        "spoken_corrections_after_each_attempt": {
+          "type": "boolean",
+          "default": true
+        },
+        "allow_self_correction_window_seconds": {
+          "type": "number",
+          "minimum": 0,
+          "default": 2.0
+        },
+        "show_theory_before_first_exercise": {
+          "type": "boolean",
+          "description": "Backward-compatible alias for speak_theory_before_first_exercise."
+        },
+        "show_corrections_after_each_attempt": {
+          "type": "boolean",
+          "description": "Backward-compatible alias for spoken_corrections_after_each_attempt."
+        }
+      }
+    },
+    "exercisesSpec": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "num_times_repeat_on_fail": {
+          "type": "integer",
+          "minimum": 0,
+          "default": 3
+        },
+        "num_exercises_required_for_pass": {
+          "type": "number",
+          "minimum": 0,
+          "maximum": 100,
+          "default": 0.2
+        },
+        "presentation_rules": {
+          "$ref": "#/$defs/exercisePresentationRules"
+        }
+      }
+    },
+    "languageIssue": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["title", "errorId", "exercises"],
+      "properties": {
+        "title": {
+          "$ref": "#/$defs/nonEmptyTrimmedString"
+        },
+        "area": {
+          "type": "string"
+        },
+        "impact": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "theory": {
+          "type": "string"
+        },
+        "theory_voice": {
+          "$ref": "#/$defs/theoryVoice"
+        },
+        "examples": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/languageIssueExample"
+          }
+        },
+        "categoryCode": {
+          "type": "string"
+        },
+        "subcategoryCode": {
+          "type": "string"
+        },
+        "subcategoryName": {
+          "type": "string"
+        },
+        "errorId": {
+          "$ref": "#/$defs/nonEmptyTrimmedString"
+        },
+        "exercises_spec": {
+          "$ref": "#/$defs/exercisesSpec"
+        },
+        "exercises": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "$ref": "#/$defs/languageExercise"
+          }
+        }
+      }
+    }
+  }
+}

--- a/modules/vm-webrtc/toolkits/toolkitGroups.json
+++ b/modules/vm-webrtc/toolkits/toolkitGroups.json
@@ -488,6 +488,40 @@
         }
       ]
     },
+    "language_lesson": {
+      "name": "language_lesson",
+      "description": "Run interactive language drills from predefined issue exercise sets.",
+      "toolkits": [
+        {
+          "type": "function",
+          "name": "get_next_language_exercise",
+          "group": "language_lesson",
+          "description": "Get the next language exercise and optionally score/update the previous exercise attempt. To start a session, call with empty params. For follow-up calls, provide previous_exercise_id, user_score (0-10), and optional performance_notes.",
+          "supported_auth": "no_auth_required",
+          "extra": {},
+          "parameters": {
+            "type": "object",
+            "properties": {
+              "previous_exercise_id": {
+                "type": "string",
+                "description": "The exercise ID that the user just completed. Omit on first call."
+              },
+              "user_score": {
+                "type": "number",
+                "description": "Assistant-estimated score for the previous exercise attempt on a 0-10 scale.",
+                "minimum": 0,
+                "maximum": 10
+              },
+              "performance_notes": {
+                "type": "string",
+                "description": "Optional notes on why the score was assigned and what the learner should improve."
+              }
+            },
+            "required": []
+          }
+        }
+      ]
+    },
     "github_legacy": {
       "name": "github_legacy",
       "description": "Legacy GitHub connector (disabled by default).",

--- a/modules/vm-webrtc/toolkits/toolkitGroups.json
+++ b/modules/vm-webrtc/toolkits/toolkitGroups.json
@@ -490,13 +490,26 @@
     },
     "language_lesson": {
       "name": "language_lesson",
-      "description": "When the user asks for a language lesson or language exercise, run interactive language drills from predefined issue exercise sets. This is a stateful tool flow: after each learner attempt, call language_lesson__get_next_language_exercise again to score/update progress and fetch the next exercise until completion or user exit.",
+      "description": "When the user asks for a language lesson or language exercise, run interactive language drills from predefined issue exercise sets. Use a 3-step stateful flow: (1) call language_lesson__start_first_exercise, (2) after each learner response call language_lesson__grade_user_exercise, (3) if grading passes call language_lesson__start_next_exercise. Repeat until completion or user exit.",
       "toolkits": [
         {
           "type": "function",
-          "name": "get_next_language_exercise",
+          "name": "start_first_exercise",
           "group": "language_lesson",
-          "description": "Get the first or next language exercise and score/update the previous attempt. To start a session, call with empty params. For follow-up calls, provide previous_exercise_id, user_score (0-10), and optional performance_notes. Important: when status is next_exercise_ready, do not just narrate progression; call this tool again after the user answers to continue the drill loop.",
+          "description": "Start the language lesson and return the first unfinished exercise. This tool takes no input. Present the returned exercise to the user. After the user answers, grade the attempt and call language_lesson__grade_user_exercise with previous_exercise_id, user_score (0-10), and optional performance_notes.",
+          "supported_auth": "no_auth_required",
+          "extra": {},
+          "parameters": {
+            "type": "object",
+            "properties": {},
+            "required": []
+          }
+        },
+        {
+          "type": "function",
+          "name": "grade_user_exercise",
+          "group": "language_lesson",
+          "description": "Grade the user's attempt for the pending exercise and update persistent lesson progress. If the score is good enough, call language_lesson__start_next_exercise to fetch the next exercise. If the score is not good enough, this tool returns retry guidance and current-exercise context so the user can retry before moving on.",
           "supported_auth": "no_auth_required",
           "extra": {},
           "parameters": {
@@ -504,17 +517,35 @@
             "properties": {
               "previous_exercise_id": {
                 "type": "string",
-                "description": "The exercise ID that the user just completed. Omit on first call."
+                "description": "The pending exercise ID that the user just attempted and that still needs grading."
               },
               "user_score": {
                 "type": "number",
-                "description": "Assistant-estimated score for the previous exercise attempt on a 0-10 scale.",
+                "description": "Assistant-estimated score for the user's attempt on a 0-10 scale.",
                 "minimum": 0,
                 "maximum": 10
               },
               "performance_notes": {
                 "type": "string",
                 "description": "Optional notes on why the score was assigned and what the learner should improve."
+              }
+            },
+            "required": ["previous_exercise_id", "user_score"]
+          }
+        },
+        {
+          "type": "function",
+          "name": "start_next_exercise",
+          "group": "language_lesson",
+          "description": "Start the next unfinished exercise after language_lesson__grade_user_exercise reports a passing result and indicates to continue. Include previous_exercise_id so the tool can log which pending exercise was just completed. If there are no exercises left, this tool returns completion status so you can congratulate the user.",
+          "supported_auth": "no_auth_required",
+          "extra": {},
+          "parameters": {
+            "type": "object",
+            "properties": {
+              "previous_exercise_id": {
+                "type": "string",
+                "description": "The exercise ID that was just successfully graded and completed."
               }
             },
             "required": []

--- a/modules/vm-webrtc/toolkits/toolkitGroups.json
+++ b/modules/vm-webrtc/toolkits/toolkitGroups.json
@@ -490,7 +490,7 @@
     },
     "language_lesson": {
       "name": "language_lesson",
-      "description": "Run interactive language drills from predefined issue exercise sets.",
+      "description": "When the user asks for a language lesson or language exercise, run interactive language drills from predefined issue exercise sets.",
       "toolkits": [
         {
           "type": "function",

--- a/modules/vm-webrtc/toolkits/toolkitGroups.json
+++ b/modules/vm-webrtc/toolkits/toolkitGroups.json
@@ -496,7 +496,7 @@
           "type": "function",
           "name": "get_next_language_exercise",
           "group": "language_lesson",
-          "description": "Get the next language exercise and optionally score/update the previous exercise attempt. To start a session, call with empty params. For follow-up calls, provide previous_exercise_id, user_score (0-10), and optional performance_notes.",
+          "description": "Get the first or the next language exercise and optionally score/update the previous exercise attempt. To start a session, call with empty params. For follow-up calls, provide previous_exercise_id, user_score (0-10), and optional performance_notes.",
           "supported_auth": "no_auth_required",
           "extra": {},
           "parameters": {

--- a/modules/vm-webrtc/toolkits/toolkitGroups.json
+++ b/modules/vm-webrtc/toolkits/toolkitGroups.json
@@ -509,7 +509,7 @@
           "type": "function",
           "name": "grade_user_exercise",
           "group": "language_lesson",
-          "description": "Grade the user's attempt for the pending exercise and update persistent lesson progress. If the score is good enough, call language_lesson__start_next_exercise to fetch the next exercise. If the score is not good enough, this tool returns retry guidance and current-exercise context so the user can retry before moving on.",
+          "description": "Grade the user's attempt for the pending exercise and update persistent lesson progress. Always tell the user their score and why that score was assigned (use the returned grading_result fields). If the score is good enough, then call language_lesson__start_next_exercise to fetch and present the next exercise. If the score is not good enough, this tool returns retry guidance and current-exercise context so the user can retry before moving on.",
           "supported_auth": "no_auth_required",
           "extra": {},
           "parameters": {

--- a/modules/vm-webrtc/toolkits/toolkitGroups.json
+++ b/modules/vm-webrtc/toolkits/toolkitGroups.json
@@ -490,7 +490,7 @@
     },
     "language_lesson": {
       "name": "language_lesson",
-      "description": "When the user asks for a language lesson or language exercise, run interactive language drills from predefined issue exercise sets. Use a 3-step stateful flow: (1) call language_lesson__start_first_exercise, (2) after each learner response call language_lesson__grade_user_exercise, (3) if grading passes call language_lesson__start_next_exercise. Repeat until completion or user exit.",
+      "description": "When the user asks for a language lesson or language exercise, run interactive language drills from predefined issue exercise sets. Use a 3-step stateful flow: (1) call language_lesson__start_first_exercise, (2) after each learner response call language_lesson__grade_user_exercise, (3) if grading passes call language_lesson__start_next_exercise. Repeat until completion or user exit.  Do not give the user any hints unless they ask, otherwise they won't learn anything.",
       "toolkits": [
         {
           "type": "function",

--- a/modules/vm-webrtc/toolkits/toolkitGroups.json
+++ b/modules/vm-webrtc/toolkits/toolkitGroups.json
@@ -490,13 +490,13 @@
     },
     "language_lesson": {
       "name": "language_lesson",
-      "description": "When the user asks for a language lesson or language exercise, run interactive language drills from predefined issue exercise sets.",
+      "description": "When the user asks for a language lesson or language exercise, run interactive language drills from predefined issue exercise sets. This is a stateful tool flow: after each learner attempt, call language_lesson__get_next_language_exercise again to score/update progress and fetch the next exercise until completion or user exit.",
       "toolkits": [
         {
           "type": "function",
           "name": "get_next_language_exercise",
           "group": "language_lesson",
-          "description": "Get the first or the next language exercise and optionally score/update the previous exercise attempt. To start a session, call with empty params. For follow-up calls, provide previous_exercise_id, user_score (0-10), and optional performance_notes.",
+          "description": "Get the first or next language exercise and score/update the previous attempt. To start a session, call with empty params. For follow-up calls, provide previous_exercise_id, user_score (0-10), and optional performance_notes. Important: when status is next_exercise_ready, do not just narrate progression; call this tool again after the user answers to continue the drill loop.",
           "supported_auth": "no_auth_required",
           "extra": {},
           "parameters": {

--- a/package.json
+++ b/package.json
@@ -60,7 +60,8 @@
     "react-native-svg": "15.12.1",
     "react-native-web": "~0.21.0",
     "react-native-worklets": "0.5.1",
-    "striptags": "^3.2.0"
+    "striptags": "^3.2.0",
+    "zod": "^4.3.6"
   },
   "devDependencies": {
     "@types/bun": "latest",


### PR DESCRIPTION
This adds the ability to add a tool that takes a JSON language lesson, and the voice agent will walk the user through all the exercises in the lesson.  This is prototyping an integration with https://fluensy.app/.

## AI Summary
This PR introduces a full `language_lesson` toolkit flow with persistent lesson state, schema validation, and iOS settings UX for managing lesson JSON.

## What Changed

### 1) New Language Lesson toolkit group + 3-tool flow
- Added `language_lesson` group in `toolkitGroups.json`.
- Added tools:
1. `start_first_exercise`
2. `grade_user_exercise`
3. `start_next_exercise`
- Updated tool descriptions to enforce stateful sequencing and explicit grading behavior.

### 2) New language lesson runtime implementation
- Added `modules/vm-webrtc/src/toolkit_functions/language_lesson.ts`.
- Implements:
1. Exercise selection (`first` and `next unfinished`)
2. Grading and score persistence
3. Retry-vs-pass branching
4. Progress summaries and normalized tool responses
5. Session context updates for issue/exercise tracking
- Includes backward-compat shim for `get_next_language_exercise` that routes through the new flow.

### 3) New schema + normalization layer
- Added `modules/vm-webrtc/src/toolkit_functions/language_lesson_schema.ts` using `zod`.
- Supports multiple exercise types and normalizes defaults.
- Includes progress state fields on exercises (`status`, `attempts`, `last_score`, etc).

### 4) New persistent config utility
- Added `lib/languageLessonConfig.ts`.
- Uses AsyncStorage to load/save lesson JSON.
- Parses/normalizes config and computes SHA-256 hash via `expo-crypto`.

### 5) Settings/UI integration
- Added `Language Lesson` connector option and modal wiring.
- Added `components/settings/LanguageLessonConnectorInfo.tsx` with:
1. Enable toggle
2. Entry point to edit lesson JSON
- Added `components/settings/LanguageLessonConfigModal.tsx`:
1. JSON editor
2. Save validation
3. Clear + copy actions
4. Full logging hooks for RCA

### 6) Toolkit wiring
- Registered `language_lesson` in toolkit registry (`toolkit_functions.ts`).
- Updated `ToolkitManager` so `language_lesson` defaults to disabled unless enabled.

### 7) Sample data + dependency
- Added `modules/vm-webrtc/toolkits/sample_language_lesson.json`.
- Added `zod` dependency update in `package.json`/`bun.lock`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Language Lesson connector with enable/disable toggle and connector UI.
  * Language Lesson configuration modal to view, edit, validate, save, clear, and copy lesson JSON.
  * Interactive language exercises: start, grade, and advance exercises with progress tracking and persistent storage.
  * Improved group display (names, icons, colors) and included a sample lesson dataset for immediate use.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->