### PR TITLE
Basic MCP server support - no oauth token refresh yet

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ An open-source voice assistant for iOS that connects to your data and the web.
 **Current features**:
 
 * Voice interaction via OpenAI Realtime API  (note: secure API key storage in iOS keychain)
-* Connectors: DeepWiki MCP, Google Drive, GitHub, Hugging Face Papers, Hacker News, Web Search
+* Connectors: DeepWiki MCP, Google Drive, GitHub, Hugging Face Papers, Hacker News, Web Search, **MCP** *(user-defined; can be enabled in settings)*
 
 **Roadmap**:
 
@@ -354,7 +354,7 @@ All connectors use statically defined tools with explicit function definitions, 
 
 ### MCP Support
 
-Not yet implemented since all tools are currently local. Future versions will add MCP server support via cloud or local tunnel connections.
+**MCP** *(can be enabled in settings)*: Connects to external MCP servers via a streamable HTTP endpoint. The MCP connector includes a configuration UI where you specify a Name, MCP Server URL (the HTTP endpoint), and an optional Bearer Token for authentication. The Bearer Token is sent as an `Authorization: Bearer` header on every request. The connector can be enabled or disabled in settings; when disabled, MCP features are hidden.
 
 ### Web Search
 
@@ -372,7 +372,6 @@ OpenAI is currently the only supported backend. Adding support for multiple prov
 1. Improve text mode support
 1. Investigate async voice processing to reduce cost
 1. Add support for alternative voice providers ([Unmute.sh](https://unmute.sh/), [Speaches.ai](https://speaches.ai), self-hosted)
-1. Remote MCP integration
 1. TypeScript MCP plugin support
 
 ## 🤝 How You Can Help

--- a/README.md
+++ b/README.md
@@ -356,6 +356,8 @@ All connectors use statically defined tools with explicit function definitions, 
 
 **MCP** *(can be enabled in settings)*: Connects to external MCP servers via a streamable HTTP endpoint. The MCP connector includes a configuration UI where you specify a Name, MCP Server URL (the HTTP endpoint), and an optional Bearer Token for authentication. The Bearer Token is sent as an `Authorization: Bearer` header on every request. The connector can be enabled or disabled in settings; when disabled, MCP features are hidden.
 
+> **Note:** Only static bearer tokens are supported at this time. OAuth token refresh is not yet implemented.
+
 ### Web Search
 
 GPT-4 web search serves as a temporary solution. The roadmap includes integrating a dedicated search API (e.g., Brave Search) using user-provided API tokens.

--- a/app/index.tsx
+++ b/app/index.tsx
@@ -16,6 +16,7 @@ import { ConfigureTranscription } from "../components/settings/ConfigureTranscri
 import { ConfigureVad } from "../components/settings/ConfigureVad";
 import { ConfigureVoice } from "../components/settings/ConfigureVoice";
 import { ConnectorsConfig } from "../components/settings/ConnectorsConfig";
+import { McpExtensionsScreen } from "../components/settings/McpExtensionsScreen";
 import { DeveloperMode } from "../components/ui/DeveloperMode";
 import { HamburgerButton } from "../components/ui/HamburgerButton";
 import {
@@ -101,6 +102,7 @@ export default function Index() {
   const [apiKeyConfigVisible, setApiKeyConfigVisible] = useState(false);
   const [developerModeVisible, setDeveloperModeVisible] = useState(false);
   const [connectorsConfigVisible, setConnectorsConfigVisible] = useState(false);
+  const [mcpExtensionsVisible, setMcpExtensionsVisible] = useState(false);
   const [advancedConfigVisible, setAdvancedConfigVisible] = useState(false);
   const [configureToolsVisible, setConfigureToolsVisible] = useState(false);
   const [baseConnectionOptions, setBaseConnectionOptions] =
@@ -403,6 +405,11 @@ export default function Index() {
         return;
       }
 
+      if (section.id === "mcp_extensions") {
+        setMcpExtensionsVisible(true);
+        return;
+      }
+
       if (section.id === "apiKey") {
         setApiKeyConfigVisible(true);
         return;
@@ -599,6 +606,10 @@ export default function Index() {
       <ConnectorsConfig
         visible={connectorsConfigVisible}
         onClose={() => setConnectorsConfigVisible(false)}
+      />
+      <McpExtensionsScreen
+        visible={mcpExtensionsVisible}
+        onClose={() => setMcpExtensionsVisible(false)}
       />
       <ConfigureApiKeyScreen
         visible={apiKeyConfigVisible}

--- a/components/settings/ConnectorsConfig.tsx
+++ b/components/settings/ConnectorsConfig.tsx
@@ -25,7 +25,6 @@ import { DailyPapersConnectorInfo } from "./DailyPapersConnectorInfo";
 import { GithubLegacyConnectorInfo } from "./GithubLegacyConnectorInfo";
 import { GDriveLegacyConnectorInfo } from "./GDriveLegacyConnectorInfo";
 import { LanguageLessonConnectorInfo } from "./LanguageLessonConnectorInfo";
-import { McpConnectorConfig } from "./McpConnectorConfig";
 
 export interface ConnectorsConfigProps {
   visible: boolean;
@@ -48,8 +47,6 @@ export const ConnectorsConfig: React.FC<ConnectorsConfigProps> = ({
     useState(false);
   const [githubLegacyInfoVisible, setGithubLegacyInfoVisible] = useState(false);
   const [gdriveLegacyInfoVisible, setGDriveLegacyInfoVisible] = useState(false);
-  const [mcpConfigVisible, setMcpConfigVisible] = useState(false);
-
   const handleConnectorPress = (connectorId: ConnectorId) => {
     if (connectorId === "github") {
       setGithubConfigVisible(true);
@@ -71,8 +68,6 @@ export const ConnectorsConfig: React.FC<ConnectorsConfigProps> = ({
       setGithubLegacyInfoVisible(true);
     } else if (connectorId === "gdrive_legacy") {
       setGDriveLegacyInfoVisible(true);
-    } else if (connectorId === "mcp") {
-      setMcpConfigVisible(true);
     }
   };
 
@@ -199,10 +194,6 @@ export const ConnectorsConfig: React.FC<ConnectorsConfigProps> = ({
         onClose={() => setGDriveLegacyInfoVisible(false)}
       />
 
-      <McpConnectorConfig
-        visible={mcpConfigVisible}
-        onClose={() => setMcpConfigVisible(false)}
-      />
     </Modal>
   );
 };

--- a/components/settings/ConnectorsConfig.tsx
+++ b/components/settings/ConnectorsConfig.tsx
@@ -25,6 +25,7 @@ import { DailyPapersConnectorInfo } from "./DailyPapersConnectorInfo";
 import { GithubLegacyConnectorInfo } from "./GithubLegacyConnectorInfo";
 import { GDriveLegacyConnectorInfo } from "./GDriveLegacyConnectorInfo";
 import { LanguageLessonConnectorInfo } from "./LanguageLessonConnectorInfo";
+import { McpConnectorConfig } from "./McpConnectorConfig";
 
 export interface ConnectorsConfigProps {
   visible: boolean;
@@ -47,6 +48,7 @@ export const ConnectorsConfig: React.FC<ConnectorsConfigProps> = ({
     useState(false);
   const [githubLegacyInfoVisible, setGithubLegacyInfoVisible] = useState(false);
   const [gdriveLegacyInfoVisible, setGDriveLegacyInfoVisible] = useState(false);
+  const [mcpConfigVisible, setMcpConfigVisible] = useState(false);
 
   const handleConnectorPress = (connectorId: ConnectorId) => {
     if (connectorId === "github") {
@@ -69,6 +71,8 @@ export const ConnectorsConfig: React.FC<ConnectorsConfigProps> = ({
       setGithubLegacyInfoVisible(true);
     } else if (connectorId === "gdrive_legacy") {
       setGDriveLegacyInfoVisible(true);
+    } else if (connectorId === "mcp") {
+      setMcpConfigVisible(true);
     }
   };
 
@@ -193,6 +197,11 @@ export const ConnectorsConfig: React.FC<ConnectorsConfigProps> = ({
       <GDriveLegacyConnectorInfo
         visible={gdriveLegacyInfoVisible}
         onClose={() => setGDriveLegacyInfoVisible(false)}
+      />
+
+      <McpConnectorConfig
+        visible={mcpConfigVisible}
+        onClose={() => setMcpConfigVisible(false)}
       />
     </Modal>
   );

--- a/components/settings/McpConnectorConfig.tsx
+++ b/components/settings/McpConnectorConfig.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from "react";
 import {
   ActivityIndicator,
+  Alert,
   KeyboardAvoidingView,
   Modal,
   Platform,
@@ -55,7 +56,7 @@ export const McpConnectorConfig: React.FC<McpConnectorConfigProps> = ({
     setTimeout(() => setCopyFeedback(false), 1500);
   };
 
-  const handleConnect = async () => {
+  const handleAdd = async () => {
     setIsConnecting(true);
     try {
       const token = bearerToken.trim() || undefined;
@@ -65,8 +66,16 @@ export const McpConnectorConfig: React.FC<McpConnectorConfigProps> = ({
         const id = `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
         await addMcpExtension({ id, name, serverUrl });
         if (token) await saveMcpBearerToken(id, token);
-        resetAndClose();
         onSave?.();
+        resetAndClose();
+        Alert.alert(
+          "Connected Successfully",
+          "Extension added. You can update its config anytime from the Extensions (MCP) screen.",
+          [{ text: "OK" }]
+        );
+      } else {
+        const detail = result.error ?? `Server returned ${result.statusCode}`;
+        Alert.alert("Connection Failed", detail, [{ text: "OK" }]);
       }
     } finally {
       setIsConnecting(false);
@@ -219,17 +228,16 @@ export const McpConnectorConfig: React.FC<McpConnectorConfigProps> = ({
           <Pressable
             style={({ pressed }) => [
               styles.connectButton,
-              (!name.trim() || !serverUrl.trim() || isConnecting) &&
-                styles.connectButtonDisabled,
+              (!name.trim() || !serverUrl.trim() || isConnecting) && styles.connectButtonDisabled,
               pressed && styles.connectButtonPressed,
             ]}
-            onPress={handleConnect}
+            onPress={handleAdd}
             disabled={!name.trim() || !serverUrl.trim() || isConnecting}
           >
             {isConnecting ? (
               <ActivityIndicator color="#FFFFFF" size="small" />
             ) : (
-              <Text style={styles.connectButtonText}>Connect</Text>
+              <Text style={styles.connectButtonText}>Add</Text>
             )}
           </Pressable>
         </View>

--- a/components/settings/McpConnectorConfig.tsx
+++ b/components/settings/McpConnectorConfig.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 import {
   ActivityIndicator,
   Alert,
@@ -16,20 +16,26 @@ import * as Clipboard from "expo-clipboard";
 import { probeMcpServer } from "../../modules/vm-webrtc/src/mcp_client/extensions";
 import {
   addMcpExtension,
+  getMcpBearerToken,
   saveMcpBearerToken,
+  type McpExtensionRecord,
 } from "../../lib/secure-storage";
 
 export interface McpConnectorConfigProps {
   visible: boolean;
   onClose: () => void;
-  onSave?: () => void;
+  existingExtension?: McpExtensionRecord;
+  onSave?: (updated?: McpExtensionRecord) => void;
 }
 
 export const McpConnectorConfig: React.FC<McpConnectorConfigProps> = ({
   visible,
   onClose,
+  existingExtension,
   onSave,
 }) => {
+  const isEditing = !!existingExtension;
+
   const [name, setName] = useState("");
   const [serverUrl, setServerUrl] = useState("");
   const [bearerToken, setBearerToken] = useState("");
@@ -37,6 +43,19 @@ export const McpConnectorConfig: React.FC<McpConnectorConfigProps> = ({
   const [isConnecting, setIsConnecting] = useState(false);
   const [tokenVisible, setTokenVisible] = useState(false);
   const [copyFeedback, setCopyFeedback] = useState(false);
+
+  useEffect(() => {
+    if (visible && existingExtension) {
+      setName(existingExtension.name);
+      setServerUrl(existingExtension.serverUrl);
+      getMcpBearerToken(existingExtension.id).then((token) => {
+        if (token) {
+          setBearerToken(token);
+          setAdvancedExpanded(true);
+        }
+      });
+    }
+  }, [visible, existingExtension]);
 
   const sanitizeToken = (value: string) => value.replace(/[\r\n\t ]+/g, "");
 
@@ -56,21 +75,26 @@ export const McpConnectorConfig: React.FC<McpConnectorConfigProps> = ({
     setTimeout(() => setCopyFeedback(false), 1500);
   };
 
-  const handleAdd = async () => {
+  const handleSave = async () => {
     setIsConnecting(true);
     try {
       const token = bearerToken.trim() || undefined;
       const result = await probeMcpServer(serverUrl, token, name);
 
       if (result.success) {
-        const id = `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
-        await addMcpExtension({ id, name, serverUrl });
-        if (token) await saveMcpBearerToken(id, token);
-        onSave?.();
+        const id = existingExtension?.id ?? `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+        const record: McpExtensionRecord = { id, name, serverUrl };
+        await addMcpExtension(record);
+        if (token) {
+          await saveMcpBearerToken(id, token);
+        }
+        onSave?.(record);
         resetAndClose();
         Alert.alert(
-          "Connected Successfully",
-          "Extension added. You can update its config anytime from the Extensions (MCP) screen.",
+          isEditing ? "Saved" : "Connected Successfully",
+          isEditing
+            ? "Extension updated."
+            : "Extension added. You can update its config anytime from the Extensions (MCP) screen.",
           [{ text: "OK" }]
         );
       } else {
@@ -103,7 +127,9 @@ export const McpConnectorConfig: React.FC<McpConnectorConfigProps> = ({
         behavior={Platform.OS === "ios" ? "padding" : "height"}
       >
         <View style={styles.header}>
-          <Text style={styles.headerTitle}>Add MCP Extension</Text>
+          <Text style={styles.headerTitle}>
+            {isEditing ? "Edit MCP Extension" : "Add MCP Extension"}
+          </Text>
         </View>
 
         <ScrollView
@@ -231,13 +257,13 @@ export const McpConnectorConfig: React.FC<McpConnectorConfigProps> = ({
               (!name.trim() || !serverUrl.trim() || isConnecting) && styles.connectButtonDisabled,
               pressed && styles.connectButtonPressed,
             ]}
-            onPress={handleAdd}
+            onPress={handleSave}
             disabled={!name.trim() || !serverUrl.trim() || isConnecting}
           >
             {isConnecting ? (
               <ActivityIndicator color="#FFFFFF" size="small" />
             ) : (
-              <Text style={styles.connectButtonText}>Add</Text>
+              <Text style={styles.connectButtonText}>{isEditing ? "Save" : "Add"}</Text>
             )}
           </Pressable>
         </View>

--- a/components/settings/McpConnectorConfig.tsx
+++ b/components/settings/McpConnectorConfig.tsx
@@ -11,127 +11,74 @@ import {
   TextInput,
   View,
 } from "react-native";
-import { log } from "../../lib/logger";
+import * as Clipboard from "expo-clipboard";
+import { probeMcpServer } from "../../modules/vm-webrtc/src/mcp_client/extensions";
+import {
+  addMcpExtension,
+  saveMcpBearerToken,
+} from "../../lib/secure-storage";
 
 export interface McpConnectorConfigProps {
   visible: boolean;
   onClose: () => void;
+  onSave?: () => void;
 }
 
 export const McpConnectorConfig: React.FC<McpConnectorConfigProps> = ({
   visible,
   onClose,
+  onSave,
 }) => {
   const [name, setName] = useState("");
   const [serverUrl, setServerUrl] = useState("");
   const [bearerToken, setBearerToken] = useState("");
   const [advancedExpanded, setAdvancedExpanded] = useState(false);
   const [isConnecting, setIsConnecting] = useState(false);
+  const [tokenVisible, setTokenVisible] = useState(false);
+  const [copyFeedback, setCopyFeedback] = useState(false);
+
+  const sanitizeToken = (value: string) => value.replace(/[\r\n\t ]+/g, "");
+
+  const handleTokenChange = (value: string) => {
+    setBearerToken(sanitizeToken(value));
+  };
+
+  const handlePaste = async () => {
+    const text = await Clipboard.getStringAsync();
+    if (text) setBearerToken(sanitizeToken(text));
+  };
+
+  const handleCopy = async () => {
+    if (!bearerToken) return;
+    await Clipboard.setStringAsync(bearerToken);
+    setCopyFeedback(true);
+    setTimeout(() => setCopyFeedback(false), 1500);
+  };
 
   const handleConnect = async () => {
     setIsConnecting(true);
     try {
-      const headers: Record<string, string> = {
-        "Content-Type": "application/json",
-        "Accept": "application/json, text/event-stream",
-      };
-      if (bearerToken.trim()) {
-        headers["Authorization"] = `Bearer ${bearerToken.trim()}`;
-      }
+      const token = bearerToken.trim() || undefined;
+      const result = await probeMcpServer(serverUrl, token, name);
 
-      const requestBody = {
-        jsonrpc: "2.0",
-        method: "initialize",
-        params: {
-          protocolVersion: "2024-11-05",
-          capabilities: {},
-          clientInfo: { name: "arty", version: "1.0.0" },
-        },
-        id: 1,
-      };
-      const requestBodyStr = JSON.stringify(requestBody);
-
-      log.info(
-        "[mcp_connector] Step 1: sending request",
-        { allowSensitiveLogging: true },
-        {
-          connector_name: name,
-          method: "POST",
-          server_url: serverUrl,
-          request_headers: headers,
-          request_body: requestBody,
-        }
-      );
-
-      let response: Response;
-      try {
-        response = await fetch(serverUrl, {
-          method: "POST",
-          headers,
-          body: requestBodyStr,
-        });
-      } catch (fetchError: any) {
-        log.error(
-          "[mcp_connector] Step 1: network error reaching MCP server",
-          {},
-          { connector_name: name, server_url: serverUrl, error: fetchError?.message }
-        );
-        return;
-      }
-
-      const responseHeaders: Record<string, string> = {};
-      response.headers.forEach((value, key) => {
-        responseHeaders[key] = value;
-      });
-
-      let responseBody: string | null = null;
-      try {
-        responseBody = await response.text();
-      } catch {
-        responseBody = null;
-      }
-
-      const logAttrs = {
-        connector_name: name,
-        server_url: serverUrl,
-        status_code: response.status,
-        status_text: response.statusText,
-        response_headers: responseHeaders,
-        response_body_snippet: responseBody?.slice(0, 500) ?? null,
-        www_authenticate: responseHeaders["www-authenticate"] ?? null,
-        resource_metadata_url: null as string | null,
-      };
-
-      // Extract resource_metadata from WWW-Authenticate if present
-      const wwwAuth = responseHeaders["www-authenticate"] ?? "";
-      const resourceMetadataMatch = wwwAuth.match(/resource_metadata="([^"]+)"/);
-      if (resourceMetadataMatch) {
-        logAttrs.resource_metadata_url = resourceMetadataMatch[1];
-      }
-
-      if (response.status === 401) {
-        log.info(
-          "[mcp_connector] Step 1: got 401 — server requires auth (expected)",
-          { allowSensitiveLogging: true },
-          logAttrs
-        );
-      } else {
-        log.info(
-          "[mcp_connector] Step 1: server responded",
-          { allowSensitiveLogging: true },
-          logAttrs
-        );
+      if (result.success) {
+        const id = `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+        await addMcpExtension({ id, name, serverUrl });
+        if (token) await saveMcpBearerToken(id, token);
+        resetAndClose();
+        onSave?.();
       }
     } finally {
       setIsConnecting(false);
     }
   };
 
-  const handleCancel = () => {
+  const resetAndClose = () => {
     setName("");
     setServerUrl("");
     setBearerToken("");
     setAdvancedExpanded(false);
+    setTokenVisible(false);
     onClose();
   };
 
@@ -140,14 +87,14 @@ export const McpConnectorConfig: React.FC<McpConnectorConfigProps> = ({
       animationType="slide"
       presentationStyle="formSheet"
       visible={visible}
-      onRequestClose={handleCancel}
+      onRequestClose={resetAndClose}
     >
       <KeyboardAvoidingView
         style={styles.container}
         behavior={Platform.OS === "ios" ? "padding" : "height"}
       >
         <View style={styles.header}>
-          <Text style={styles.headerTitle}>Add MCP Connector</Text>
+          <Text style={styles.headerTitle}>Add MCP Extension</Text>
         </View>
 
         <ScrollView
@@ -161,7 +108,7 @@ export const McpConnectorConfig: React.FC<McpConnectorConfigProps> = ({
               style={styles.input}
               value={name}
               onChangeText={setName}
-              placeholder="Enter connector name..."
+              placeholder="Enter extension name..."
               placeholderTextColor="#AEAEB2"
               autoCapitalize="none"
               autoCorrect={false}
@@ -198,20 +145,61 @@ export const McpConnectorConfig: React.FC<McpConnectorConfigProps> = ({
           {advancedExpanded && (
             <View style={styles.advancedSection}>
               <Text style={styles.label}>Bearer Token</Text>
-              <TextInput
-                style={styles.input}
-                value={bearerToken}
-                onChangeText={setBearerToken}
-                placeholder="Optional JWT or access token..."
-                placeholderTextColor="#AEAEB2"
-                autoCapitalize="none"
-                autoCorrect={false}
-                secureTextEntry
-              />
+
+              <View style={styles.tokenInputRow}>
+                <TextInput
+                  style={[styles.input, styles.tokenInput]}
+                  value={bearerToken}
+                  onChangeText={handleTokenChange}
+                  placeholder="Optional JWT or access token..."
+                  placeholderTextColor="#AEAEB2"
+                  autoCapitalize="none"
+                  autoCorrect={false}
+                  secureTextEntry={!tokenVisible}
+                  multiline={false}
+                />
+                <Pressable
+                  style={({ pressed }) => [
+                    styles.tokenIconButton,
+                    pressed && styles.tokenIconButtonPressed,
+                  ]}
+                  onPress={() => setTokenVisible((v) => !v)}
+                >
+                  <Text style={styles.tokenIconText}>
+                    {tokenVisible ? "🙈" : "👁️"}
+                  </Text>
+                </Pressable>
+              </View>
+
+              <View style={styles.tokenActions}>
+                <Pressable
+                  style={({ pressed }) => [
+                    styles.tokenActionButton,
+                    pressed && styles.tokenActionButtonPressed,
+                  ]}
+                  onPress={handlePaste}
+                >
+                  <Text style={styles.tokenActionText}>Paste</Text>
+                </Pressable>
+                <Pressable
+                  style={({ pressed }) => [
+                    styles.tokenActionButton,
+                    !bearerToken && styles.tokenActionButtonDisabled,
+                    pressed && styles.tokenActionButtonPressed,
+                  ]}
+                  onPress={handleCopy}
+                  disabled={!bearerToken}
+                >
+                  <Text style={styles.tokenActionText}>
+                    {copyFeedback ? "Copied!" : "Copy"}
+                  </Text>
+                </Pressable>
+              </View>
+
               <Text style={styles.hint}>
                 Sent as{" "}
                 <Text style={styles.hintMono}>Authorization: Bearer …</Text> on
-                every request
+                every request. Newlines are stripped automatically.
               </Text>
             </View>
           )}
@@ -223,7 +211,7 @@ export const McpConnectorConfig: React.FC<McpConnectorConfigProps> = ({
               styles.cancelButton,
               pressed && styles.cancelButtonPressed,
             ]}
-            onPress={handleCancel}
+            onPress={resetAndClose}
           >
             <Text style={styles.cancelButtonText}>Cancel</Text>
           </Pressable>
@@ -231,7 +219,8 @@ export const McpConnectorConfig: React.FC<McpConnectorConfigProps> = ({
           <Pressable
             style={({ pressed }) => [
               styles.connectButton,
-              (!name.trim() || !serverUrl.trim() || isConnecting) && styles.connectButtonDisabled,
+              (!name.trim() || !serverUrl.trim() || isConnecting) &&
+                styles.connectButtonDisabled,
               pressed && styles.connectButtonPressed,
             ]}
             onPress={handleConnect}
@@ -309,7 +298,6 @@ const styles = StyleSheet.create({
     paddingVertical: 14,
     borderTopWidth: 1,
     borderTopColor: "#E5E5EA",
-    marginBottom: 0,
   },
   advancedToggleText: {
     fontSize: 15,
@@ -322,6 +310,54 @@ const styles = StyleSheet.create({
   },
   advancedSection: {
     marginBottom: 24,
+  },
+  tokenInputRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 8,
+  },
+  tokenInput: {
+    flex: 1,
+  },
+  tokenIconButton: {
+    width: 44,
+    height: 44,
+    borderRadius: 10,
+    backgroundColor: "#FFFFFF",
+    borderWidth: 1,
+    borderColor: "#E5E5EA",
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  tokenIconButtonPressed: {
+    opacity: 0.6,
+  },
+  tokenIconText: {
+    fontSize: 18,
+  },
+  tokenActions: {
+    flexDirection: "row",
+    gap: 8,
+    marginTop: 8,
+  },
+  tokenActionButton: {
+    paddingVertical: 7,
+    paddingHorizontal: 16,
+    borderRadius: 8,
+    backgroundColor: "#FFFFFF",
+    borderWidth: 1,
+    borderColor: "#E5E5EA",
+  },
+  tokenActionButtonDisabled: {
+    opacity: 0.4,
+  },
+  tokenActionButtonPressed: {
+    opacity: 0.6,
+  },
+  tokenActionText: {
+    fontSize: 13,
+    fontWeight: "600",
+    color: "#0A84FF",
   },
   footer: {
     flexDirection: "row",

--- a/components/settings/McpConnectorConfig.tsx
+++ b/components/settings/McpConnectorConfig.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useState } from "react";
 import {
   ActivityIndicator,
   Alert,
+  DeviceEventEmitter,
   KeyboardAvoidingView,
   Modal,
   Platform,
@@ -17,9 +18,13 @@ import { probeMcpServer } from "../../modules/vm-webrtc/src/mcp_client/extension
 import {
   addMcpExtension,
   getMcpBearerToken,
+  getMcpExtensions,
   saveMcpBearerToken,
+  toNormalizedName,
+  uniqueNormalizedName,
   type McpExtensionRecord,
 } from "../../lib/secure-storage";
+import { CONNECTOR_SETTINGS_CHANGED_EVENT } from "../../modules/vm-webrtc/src/ToolkitManager";
 
 export interface McpConnectorConfigProps {
   visible: boolean;
@@ -39,6 +44,7 @@ export const McpConnectorConfig: React.FC<McpConnectorConfigProps> = ({
   const [name, setName] = useState("");
   const [serverUrl, setServerUrl] = useState("");
   const [bearerToken, setBearerToken] = useState("");
+  const [normalizedNamePreview, setNormalizedNamePreview] = useState("");
   const [advancedExpanded, setAdvancedExpanded] = useState(false);
   const [isConnecting, setIsConnecting] = useState(false);
   const [tokenVisible, setTokenVisible] = useState(false);
@@ -48,12 +54,15 @@ export const McpConnectorConfig: React.FC<McpConnectorConfigProps> = ({
     if (visible && existingExtension) {
       setName(existingExtension.name);
       setServerUrl(existingExtension.serverUrl);
+      setNormalizedNamePreview(existingExtension.normalizedName ?? toNormalizedName(existingExtension.name));
       getMcpBearerToken(existingExtension.id).then((token) => {
         if (token) {
           setBearerToken(token);
           setAdvancedExpanded(true);
         }
       });
+    } else if (visible) {
+      setNormalizedNamePreview("");
     }
   }, [visible, existingExtension]);
 
@@ -83,11 +92,14 @@ export const McpConnectorConfig: React.FC<McpConnectorConfigProps> = ({
 
       if (result.success) {
         const id = existingExtension?.id ?? `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
-        const record: McpExtensionRecord = { id, name, serverUrl };
+        const allExtensions = await getMcpExtensions();
+        const normalizedName = uniqueNormalizedName(toNormalizedName(name), allExtensions, existingExtension?.id);
+        const record: McpExtensionRecord = { id, name, normalizedName, serverUrl };
         await addMcpExtension(record);
         if (token) {
           await saveMcpBearerToken(id, token);
         }
+        DeviceEventEmitter.emit(CONNECTOR_SETTINGS_CHANGED_EVENT);
         onSave?.(record);
         resetAndClose();
         Alert.alert(
@@ -110,6 +122,7 @@ export const McpConnectorConfig: React.FC<McpConnectorConfigProps> = ({
     setName("");
     setServerUrl("");
     setBearerToken("");
+    setNormalizedNamePreview("");
     setAdvancedExpanded(false);
     setTokenVisible(false);
     onClose();
@@ -142,12 +155,20 @@ export const McpConnectorConfig: React.FC<McpConnectorConfigProps> = ({
             <TextInput
               style={styles.input}
               value={name}
-              onChangeText={setName}
+              onChangeText={(v) => {
+                setName(v);
+                setNormalizedNamePreview(toNormalizedName(v));
+              }}
               placeholder="Enter extension name..."
               placeholderTextColor="#AEAEB2"
               autoCapitalize="none"
               autoCorrect={false}
             />
+            {normalizedNamePreview ? (
+              <Text style={styles.hint}>
+                ID: <Text style={styles.hintMono}>{normalizedNamePreview}</Text>
+              </Text>
+            ) : null}
           </View>
 
           <View style={styles.section}>

--- a/components/settings/McpConnectorConfig.tsx
+++ b/components/settings/McpConnectorConfig.tsx
@@ -1,0 +1,270 @@
+import React, { useState } from "react";
+import {
+  KeyboardAvoidingView,
+  Modal,
+  Platform,
+  Pressable,
+  ScrollView,
+  StyleSheet,
+  Text,
+  TextInput,
+  View,
+} from "react-native";
+
+export interface McpConnectorConfigProps {
+  visible: boolean;
+  onClose: () => void;
+}
+
+export const McpConnectorConfig: React.FC<McpConnectorConfigProps> = ({
+  visible,
+  onClose,
+}) => {
+  const [name, setName] = useState("");
+  const [serverUrl, setServerUrl] = useState("");
+  const [bearerToken, setBearerToken] = useState("");
+  const [advancedExpanded, setAdvancedExpanded] = useState(false);
+
+  const handleConnect = () => {
+    // TODO: wire up MCP connection logic
+    onClose();
+  };
+
+  const handleCancel = () => {
+    setName("");
+    setServerUrl("");
+    setBearerToken("");
+    setAdvancedExpanded(false);
+    onClose();
+  };
+
+  return (
+    <Modal
+      animationType="slide"
+      presentationStyle="formSheet"
+      visible={visible}
+      onRequestClose={handleCancel}
+    >
+      <KeyboardAvoidingView
+        style={styles.container}
+        behavior={Platform.OS === "ios" ? "padding" : "height"}
+      >
+        <View style={styles.header}>
+          <Text style={styles.headerTitle}>Add MCP Connector</Text>
+        </View>
+
+        <ScrollView
+          style={styles.scrollView}
+          contentContainerStyle={styles.scrollContent}
+          keyboardShouldPersistTaps="handled"
+        >
+          <View style={styles.section}>
+            <Text style={styles.label}>Name</Text>
+            <TextInput
+              style={styles.input}
+              value={name}
+              onChangeText={setName}
+              placeholder="Enter connector name..."
+              placeholderTextColor="#AEAEB2"
+              autoCapitalize="none"
+              autoCorrect={false}
+            />
+          </View>
+
+          <View style={styles.section}>
+            <Text style={styles.label}>MCP Server URL</Text>
+            <TextInput
+              style={styles.input}
+              value={serverUrl}
+              onChangeText={setServerUrl}
+              placeholder="https://..."
+              placeholderTextColor="#AEAEB2"
+              autoCapitalize="none"
+              autoCorrect={false}
+              keyboardType="url"
+            />
+            <Text style={styles.hint}>
+              Streamable HTTP endpoint for the MCP server
+            </Text>
+          </View>
+
+          <Pressable
+            style={styles.advancedToggle}
+            onPress={() => setAdvancedExpanded((v) => !v)}
+          >
+            <Text style={styles.advancedToggleText}>Advanced</Text>
+            <Text style={styles.advancedChevron}>
+              {advancedExpanded ? "▲" : "▼"}
+            </Text>
+          </Pressable>
+
+          {advancedExpanded && (
+            <View style={styles.advancedSection}>
+              <Text style={styles.label}>Bearer Token</Text>
+              <TextInput
+                style={styles.input}
+                value={bearerToken}
+                onChangeText={setBearerToken}
+                placeholder="Optional JWT or access token..."
+                placeholderTextColor="#AEAEB2"
+                autoCapitalize="none"
+                autoCorrect={false}
+                secureTextEntry
+              />
+              <Text style={styles.hint}>
+                Sent as{" "}
+                <Text style={styles.hintMono}>Authorization: Bearer …</Text> on
+                every request
+              </Text>
+            </View>
+          )}
+        </ScrollView>
+
+        <View style={styles.footer}>
+          <Pressable
+            style={({ pressed }) => [
+              styles.cancelButton,
+              pressed && styles.cancelButtonPressed,
+            ]}
+            onPress={handleCancel}
+          >
+            <Text style={styles.cancelButtonText}>Cancel</Text>
+          </Pressable>
+
+          <Pressable
+            style={({ pressed }) => [
+              styles.connectButton,
+              (!name.trim() || !serverUrl.trim()) && styles.connectButtonDisabled,
+              pressed && styles.connectButtonPressed,
+            ]}
+            onPress={handleConnect}
+            disabled={!name.trim() || !serverUrl.trim()}
+          >
+            <Text style={styles.connectButtonText}>Connect</Text>
+          </Pressable>
+        </View>
+      </KeyboardAvoidingView>
+    </Modal>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: "#F5F5F7",
+  },
+  header: {
+    paddingHorizontal: 24,
+    paddingTop: 20,
+    paddingBottom: 16,
+    borderBottomWidth: 1,
+    borderBottomColor: "#E5E5EA",
+  },
+  headerTitle: {
+    fontSize: 20,
+    fontWeight: "700",
+    color: "#1C1C1E",
+  },
+  scrollView: {
+    flex: 1,
+  },
+  scrollContent: {
+    paddingHorizontal: 24,
+    paddingTop: 24,
+    paddingBottom: 32,
+  },
+  section: {
+    marginBottom: 24,
+  },
+  label: {
+    fontSize: 14,
+    fontWeight: "600",
+    color: "#1C1C1E",
+    marginBottom: 8,
+  },
+  input: {
+    backgroundColor: "#FFFFFF",
+    borderWidth: 1,
+    borderColor: "#E5E5EA",
+    borderRadius: 10,
+    paddingHorizontal: 14,
+    paddingVertical: 12,
+    fontSize: 15,
+    color: "#1C1C1E",
+  },
+  hint: {
+    fontSize: 12,
+    color: "#8E8E93",
+    marginTop: 6,
+    lineHeight: 17,
+  },
+  hintMono: {
+    fontFamily: Platform.OS === "ios" ? "Menlo" : "monospace",
+  },
+  advancedToggle: {
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "space-between",
+    paddingVertical: 14,
+    borderTopWidth: 1,
+    borderTopColor: "#E5E5EA",
+    marginBottom: 0,
+  },
+  advancedToggleText: {
+    fontSize: 15,
+    fontWeight: "600",
+    color: "#636366",
+  },
+  advancedChevron: {
+    fontSize: 11,
+    color: "#AEAEB2",
+  },
+  advancedSection: {
+    marginBottom: 24,
+  },
+  footer: {
+    flexDirection: "row",
+    gap: 12,
+    paddingHorizontal: 24,
+    paddingTop: 16,
+    paddingBottom: 32,
+    borderTopWidth: 1,
+    borderTopColor: "#E5E5EA",
+    backgroundColor: "#F5F5F7",
+  },
+  cancelButton: {
+    flex: 1,
+    paddingVertical: 14,
+    borderRadius: 12,
+    alignItems: "center",
+    backgroundColor: "#FFFFFF",
+    borderWidth: 1,
+    borderColor: "#E5E5EA",
+  },
+  cancelButtonPressed: {
+    opacity: 0.7,
+  },
+  cancelButtonText: {
+    fontSize: 16,
+    fontWeight: "600",
+    color: "#636366",
+  },
+  connectButton: {
+    flex: 1,
+    paddingVertical: 14,
+    borderRadius: 12,
+    alignItems: "center",
+    backgroundColor: "#1C1C1E",
+  },
+  connectButtonDisabled: {
+    backgroundColor: "#AEAEB2",
+  },
+  connectButtonPressed: {
+    opacity: 0.85,
+  },
+  connectButtonText: {
+    fontSize: 16,
+    fontWeight: "600",
+    color: "#FFFFFF",
+  },
+});

--- a/components/settings/McpConnectorConfig.tsx
+++ b/components/settings/McpConnectorConfig.tsx
@@ -31,20 +31,45 @@ export const McpConnectorConfig: React.FC<McpConnectorConfigProps> = ({
   const handleConnect = async () => {
     setIsConnecting(true);
     try {
-      const headers: Record<string, string> = {};
+      const headers: Record<string, string> = {
+        "Content-Type": "application/json",
+        "Accept": "application/json, text/event-stream",
+      };
       if (bearerToken.trim()) {
         headers["Authorization"] = `Bearer ${bearerToken.trim()}`;
       }
 
+      const requestBody = {
+        jsonrpc: "2.0",
+        method: "initialize",
+        params: {
+          protocolVersion: "2024-11-05",
+          capabilities: {},
+          clientInfo: { name: "arty", version: "1.0.0" },
+        },
+        id: 1,
+      };
+      const requestBodyStr = JSON.stringify(requestBody);
+
       log.info(
-        "[mcp_connector] Probing MCP server (Step 1: initial request)",
-        {},
-        { connector_name: name, server_url: serverUrl, has_bearer_token: !!bearerToken.trim() }
+        "[mcp_connector] Step 1: sending request",
+        { allowSensitiveLogging: true },
+        {
+          connector_name: name,
+          method: "POST",
+          server_url: serverUrl,
+          request_headers: headers,
+          request_body: requestBody,
+        }
       );
 
       let response: Response;
       try {
-        response = await fetch(serverUrl, { method: "GET", headers });
+        response = await fetch(serverUrl, {
+          method: "POST",
+          headers,
+          body: requestBodyStr,
+        });
       } catch (fetchError: any) {
         log.error(
           "[mcp_connector] Step 1: network error reaching MCP server",

--- a/components/settings/McpConnectorConfig.tsx
+++ b/components/settings/McpConnectorConfig.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from "react";
 import {
+  ActivityIndicator,
   KeyboardAvoidingView,
   Modal,
   Platform,
@@ -10,6 +11,7 @@ import {
   TextInput,
   View,
 } from "react-native";
+import { log } from "../../lib/logger";
 
 export interface McpConnectorConfigProps {
   visible: boolean;
@@ -24,10 +26,80 @@ export const McpConnectorConfig: React.FC<McpConnectorConfigProps> = ({
   const [serverUrl, setServerUrl] = useState("");
   const [bearerToken, setBearerToken] = useState("");
   const [advancedExpanded, setAdvancedExpanded] = useState(false);
+  const [isConnecting, setIsConnecting] = useState(false);
 
-  const handleConnect = () => {
-    // TODO: wire up MCP connection logic
-    onClose();
+  const handleConnect = async () => {
+    setIsConnecting(true);
+    try {
+      const headers: Record<string, string> = {};
+      if (bearerToken.trim()) {
+        headers["Authorization"] = `Bearer ${bearerToken.trim()}`;
+      }
+
+      log.info(
+        "[mcp_connector] Probing MCP server (Step 1: initial request)",
+        {},
+        { connector_name: name, server_url: serverUrl, has_bearer_token: !!bearerToken.trim() }
+      );
+
+      let response: Response;
+      try {
+        response = await fetch(serverUrl, { method: "GET", headers });
+      } catch (fetchError: any) {
+        log.error(
+          "[mcp_connector] Step 1: network error reaching MCP server",
+          {},
+          { connector_name: name, server_url: serverUrl, error: fetchError?.message }
+        );
+        return;
+      }
+
+      const responseHeaders: Record<string, string> = {};
+      response.headers.forEach((value, key) => {
+        responseHeaders[key] = value;
+      });
+
+      let responseBody: string | null = null;
+      try {
+        responseBody = await response.text();
+      } catch {
+        responseBody = null;
+      }
+
+      const logAttrs = {
+        connector_name: name,
+        server_url: serverUrl,
+        status_code: response.status,
+        status_text: response.statusText,
+        response_headers: responseHeaders,
+        response_body_snippet: responseBody?.slice(0, 500) ?? null,
+        www_authenticate: responseHeaders["www-authenticate"] ?? null,
+        resource_metadata_url: null as string | null,
+      };
+
+      // Extract resource_metadata from WWW-Authenticate if present
+      const wwwAuth = responseHeaders["www-authenticate"] ?? "";
+      const resourceMetadataMatch = wwwAuth.match(/resource_metadata="([^"]+)"/);
+      if (resourceMetadataMatch) {
+        logAttrs.resource_metadata_url = resourceMetadataMatch[1];
+      }
+
+      if (response.status === 401) {
+        log.info(
+          "[mcp_connector] Step 1: got 401 — server requires auth (expected)",
+          { allowSensitiveLogging: true },
+          logAttrs
+        );
+      } else {
+        log.info(
+          "[mcp_connector] Step 1: server responded",
+          { allowSensitiveLogging: true },
+          logAttrs
+        );
+      }
+    } finally {
+      setIsConnecting(false);
+    }
   };
 
   const handleCancel = () => {
@@ -134,13 +206,17 @@ export const McpConnectorConfig: React.FC<McpConnectorConfigProps> = ({
           <Pressable
             style={({ pressed }) => [
               styles.connectButton,
-              (!name.trim() || !serverUrl.trim()) && styles.connectButtonDisabled,
+              (!name.trim() || !serverUrl.trim() || isConnecting) && styles.connectButtonDisabled,
               pressed && styles.connectButtonPressed,
             ]}
             onPress={handleConnect}
-            disabled={!name.trim() || !serverUrl.trim()}
+            disabled={!name.trim() || !serverUrl.trim() || isConnecting}
           >
-            <Text style={styles.connectButtonText}>Connect</Text>
+            {isConnecting ? (
+              <ActivityIndicator color="#FFFFFF" size="small" />
+            ) : (
+              <Text style={styles.connectButtonText}>Connect</Text>
+            )}
           </Pressable>
         </View>
       </KeyboardAvoidingView>

--- a/components/settings/McpExtensionDetailScreen.tsx
+++ b/components/settings/McpExtensionDetailScreen.tsx
@@ -3,6 +3,7 @@ import {
   ActionSheetIOS,
   ActivityIndicator,
   Alert,
+  DeviceEventEmitter,
   Modal,
   Platform,
   Pressable,
@@ -23,6 +24,7 @@ import {
   getMcpBearerToken,
   type McpExtensionRecord,
 } from "../../lib/secure-storage";
+import { CONNECTOR_SETTINGS_CHANGED_EVENT } from "../../modules/vm-webrtc/src/ToolkitManager";
 import { McpConnectorConfig } from "./McpConnectorConfig";
 
 export interface McpExtensionDetailScreenProps {
@@ -76,6 +78,7 @@ export const McpExtensionDetailScreen: React.FC<McpExtensionDetailScreenProps> =
   const handleRemove = () => {
     const doRemove = async () => {
       await deleteMcpExtension(currentExtension.id);
+      DeviceEventEmitter.emit(CONNECTOR_SETTINGS_CHANGED_EVENT);
       onRemove(currentExtension.id);
       onClose();
     };
@@ -108,6 +111,7 @@ export const McpExtensionDetailScreen: React.FC<McpExtensionDetailScreenProps> =
   const handleToggleDisabled = async (enabled: boolean) => {
     const updated = { ...currentExtension, disabled: !enabled };
     await addMcpExtension(updated);
+    DeviceEventEmitter.emit(CONNECTOR_SETTINGS_CHANGED_EVENT);
     setCurrentExtension(updated);
     onUpdated(updated);
   };

--- a/components/settings/McpExtensionDetailScreen.tsx
+++ b/components/settings/McpExtensionDetailScreen.tsx
@@ -10,6 +10,7 @@ import {
   SafeAreaView,
   ScrollView,
   StyleSheet,
+  Switch,
   Text,
   View,
 } from "react-native";
@@ -17,6 +18,7 @@ import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { MCPClient } from "../../modules/vm-webrtc/src/mcp_client/client";
 import type { Tool } from "../../modules/vm-webrtc/src/mcp_client/types";
 import {
+  addMcpExtension,
   deleteMcpExtension,
   getMcpBearerToken,
   type McpExtensionRecord,
@@ -103,6 +105,13 @@ export const McpExtensionDetailScreen: React.FC<McpExtensionDetailScreenProps> =
     }
   };
 
+  const handleToggleDisabled = async (enabled: boolean) => {
+    const updated = { ...currentExtension, disabled: !enabled };
+    await addMcpExtension(updated);
+    setCurrentExtension(updated);
+    onUpdated(updated);
+  };
+
   const handleConfigureSave = (updated?: McpExtensionRecord) => {
     setConfigureVisible(false);
     if (updated) {
@@ -146,6 +155,16 @@ export const McpExtensionDetailScreen: React.FC<McpExtensionDetailScreenProps> =
                 {currentExtension.serverUrl}
               </Text>
             </View>
+          </View>
+
+          <View style={styles.enableRow}>
+            <Text style={styles.enableLabel}>Enabled</Text>
+            <Switch
+              value={!currentExtension.disabled}
+              onValueChange={handleToggleDisabled}
+              trackColor={{ false: "#E5E5EA", true: "#34C759" }}
+              thumbColor="#FFFFFF"
+            />
           </View>
 
           <View style={styles.sectionHeader}>
@@ -268,6 +287,22 @@ const styles = StyleSheet.create({
     gap: 14,
     borderWidth: 1,
     borderColor: "#E5E5EA",
+  },
+  enableRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "space-between",
+    backgroundColor: "#FFFFFF",
+    borderRadius: 14,
+    paddingHorizontal: 16,
+    paddingVertical: 12,
+    borderWidth: 1,
+    borderColor: "#E5E5EA",
+  },
+  enableLabel: {
+    fontSize: 16,
+    fontWeight: "500",
+    color: "#1C1C1E",
   },
   iconContainer: {
     width: 48,

--- a/components/settings/McpExtensionDetailScreen.tsx
+++ b/components/settings/McpExtensionDetailScreen.tsx
@@ -1,0 +1,433 @@
+import React, { useCallback, useEffect, useState } from "react";
+import {
+  ActionSheetIOS,
+  ActivityIndicator,
+  Alert,
+  Modal,
+  Platform,
+  Pressable,
+  RefreshControl,
+  SafeAreaView,
+  ScrollView,
+  StyleSheet,
+  Text,
+  View,
+} from "react-native";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
+import { MCPClient } from "../../modules/vm-webrtc/src/mcp_client/client";
+import type { Tool } from "../../modules/vm-webrtc/src/mcp_client/types";
+import {
+  deleteMcpExtension,
+  getMcpBearerToken,
+  type McpExtensionRecord,
+} from "../../lib/secure-storage";
+import { McpConnectorConfig } from "./McpConnectorConfig";
+
+export interface McpExtensionDetailScreenProps {
+  extension: McpExtensionRecord;
+  visible: boolean;
+  onClose: () => void;
+  onRemove: (id: string) => void;
+  onUpdated: (updated: McpExtensionRecord) => void;
+}
+
+export const McpExtensionDetailScreen: React.FC<McpExtensionDetailScreenProps> = ({
+  extension,
+  visible,
+  onClose,
+  onRemove,
+  onUpdated,
+}) => {
+  const insets = useSafeAreaInsets();
+  const [currentExtension, setCurrentExtension] = useState(extension);
+  const [tools, setTools] = useState<Tool[]>([]);
+  const [toolsLoading, setToolsLoading] = useState(false);
+  const [toolsError, setToolsError] = useState<string | null>(null);
+  const [configureVisible, setConfigureVisible] = useState(false);
+
+  useEffect(() => {
+    setCurrentExtension(extension);
+  }, [extension]);
+
+  const fetchTools = useCallback(async () => {
+    setToolsLoading(true);
+    setToolsError(null);
+    try {
+      const token = await getMcpBearerToken(currentExtension.id);
+      const client = new MCPClient(currentExtension.serverUrl, token ?? undefined);
+      const result = await client.listTools();
+      setTools(result.tools ?? []);
+    } catch (err) {
+      setToolsError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setToolsLoading(false);
+    }
+  }, [currentExtension.id, currentExtension.serverUrl]);
+
+  useEffect(() => {
+    if (visible) {
+      setTools([]);
+      fetchTools();
+    }
+  }, [visible]);
+
+  const handleRemove = () => {
+    const doRemove = async () => {
+      await deleteMcpExtension(currentExtension.id);
+      onRemove(currentExtension.id);
+      onClose();
+    };
+
+    if (Platform.OS === "ios") {
+      ActionSheetIOS.showActionSheetWithOptions(
+        {
+          title: `Remove "${currentExtension.name}"?`,
+          message: "This will disconnect the extension and delete all saved credentials.",
+          options: ["Cancel", "Remove"],
+          destructiveButtonIndex: 1,
+          cancelButtonIndex: 0,
+        },
+        (buttonIndex) => {
+          if (buttonIndex === 1) doRemove();
+        }
+      );
+    } else {
+      Alert.alert(
+        "Remove Extension",
+        `Remove "${currentExtension.name}"? This will disconnect the extension and delete all saved credentials.`,
+        [
+          { text: "Cancel", style: "cancel" },
+          { text: "Remove", style: "destructive", onPress: doRemove },
+        ]
+      );
+    }
+  };
+
+  const handleConfigureSave = (updated?: McpExtensionRecord) => {
+    setConfigureVisible(false);
+    if (updated) {
+      setCurrentExtension(updated);
+      onUpdated(updated);
+      fetchTools();
+    }
+  };
+
+  return (
+    <Modal
+      animationType="slide"
+      presentationStyle="formSheet"
+      visible={visible}
+      onRequestClose={onClose}
+    >
+      <SafeAreaView style={styles.safeArea}>
+        <View style={styles.header}>
+          <Pressable
+            onPress={onClose}
+            style={({ pressed }) => [styles.backButton, pressed && styles.backButtonPressed]}
+          >
+            <Text style={styles.backButtonText}>‹ Back</Text>
+          </Pressable>
+        </View>
+
+        <ScrollView
+          style={styles.scrollView}
+          contentContainerStyle={[styles.scrollContent, { paddingBottom: insets.bottom + 24 }]}
+          refreshControl={
+            <RefreshControl refreshing={toolsLoading} onRefresh={fetchTools} tintColor="#8E8E93" />
+          }
+        >
+          <View style={styles.infoCard}>
+            <View style={styles.iconContainer}>
+              <Text style={styles.iconText}>🔌</Text>
+            </View>
+            <View style={styles.infoBody}>
+              <Text style={styles.extensionName}>{currentExtension.name}</Text>
+              <Text style={styles.extensionUrl} numberOfLines={2}>
+                {currentExtension.serverUrl}
+              </Text>
+            </View>
+          </View>
+
+          <View style={styles.sectionHeader}>
+            <Text style={styles.sectionTitle}>Tools</Text>
+            <Pressable
+              onPress={fetchTools}
+              disabled={toolsLoading}
+              style={({ pressed }) => [
+                styles.refreshButton,
+                pressed && styles.refreshButtonPressed,
+              ]}
+            >
+              {toolsLoading ? (
+                <ActivityIndicator size="small" color="#0A84FF" />
+              ) : (
+                <Text style={styles.refreshButtonText}>↻ Refresh</Text>
+              )}
+            </Pressable>
+          </View>
+
+          {toolsError ? (
+            <View style={styles.errorContainer}>
+              <Text style={styles.errorText}>{toolsError}</Text>
+              <Pressable
+                onPress={fetchTools}
+                style={({ pressed }) => [styles.retryButton, pressed && styles.retryButtonPressed]}
+              >
+                <Text style={styles.retryButtonText}>Retry</Text>
+              </Pressable>
+            </View>
+          ) : tools.length === 0 && !toolsLoading ? (
+            <View style={styles.emptyTools}>
+              <Text style={styles.emptyToolsText}>No tools found</Text>
+            </View>
+          ) : (
+            <View style={styles.toolsList}>
+              {tools.map((tool, idx) => (
+                <View
+                  key={tool.name}
+                  style={[styles.toolRow, idx < tools.length - 1 && styles.toolRowBorder]}
+                >
+                  <Text style={styles.toolName}>{tool.name}</Text>
+                  {!!tool.description && (
+                    <Text style={styles.toolDescription} numberOfLines={2}>
+                      {tool.description}
+                    </Text>
+                  )}
+                </View>
+              ))}
+            </View>
+          )}
+        </ScrollView>
+
+        <View style={[styles.footer, { paddingBottom: insets.bottom + 16 }]}>
+          <Pressable
+            style={({ pressed }) => [styles.configureButton, pressed && styles.configureButtonPressed]}
+            onPress={() => setConfigureVisible(true)}
+          >
+            <Text style={styles.configureButtonText}>Configure</Text>
+          </Pressable>
+          <Pressable
+            style={({ pressed }) => [styles.removeButton, pressed && styles.removeButtonPressed]}
+            onPress={handleRemove}
+          >
+            <Text style={styles.removeButtonText}>Remove</Text>
+          </Pressable>
+        </View>
+      </SafeAreaView>
+
+      <McpConnectorConfig
+        visible={configureVisible}
+        onClose={() => setConfigureVisible(false)}
+        existingExtension={currentExtension}
+        onSave={handleConfigureSave}
+      />
+    </Modal>
+  );
+};
+
+const styles = StyleSheet.create({
+  safeArea: {
+    flex: 1,
+    backgroundColor: "#F5F5F7",
+  },
+  header: {
+    paddingHorizontal: 16,
+    paddingTop: 12,
+    paddingBottom: 12,
+    borderBottomWidth: 1,
+    borderBottomColor: "#E5E5EA",
+  },
+  backButton: {
+    alignSelf: "flex-start",
+    paddingVertical: 4,
+    paddingHorizontal: 4,
+    borderRadius: 8,
+  },
+  backButtonPressed: {
+    backgroundColor: "rgba(10, 132, 255, 0.08)",
+  },
+  backButtonText: {
+    fontSize: 17,
+    color: "#0A84FF",
+    fontWeight: "400",
+  },
+  scrollView: {
+    flex: 1,
+  },
+  scrollContent: {
+    paddingHorizontal: 20,
+    paddingTop: 20,
+    gap: 16,
+  },
+  infoCard: {
+    flexDirection: "row",
+    alignItems: "center",
+    backgroundColor: "#FFFFFF",
+    borderRadius: 14,
+    padding: 16,
+    gap: 14,
+    borderWidth: 1,
+    borderColor: "#E5E5EA",
+  },
+  iconContainer: {
+    width: 48,
+    height: 48,
+    borderRadius: 14,
+    backgroundColor: "#F0FFF4",
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  iconText: {
+    fontSize: 24,
+  },
+  infoBody: {
+    flex: 1,
+    gap: 4,
+  },
+  extensionName: {
+    fontSize: 17,
+    fontWeight: "600",
+    color: "#1C1C1E",
+  },
+  extensionUrl: {
+    fontSize: 13,
+    color: "#8E8E93",
+    lineHeight: 18,
+  },
+  sectionHeader: {
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "space-between",
+  },
+  sectionTitle: {
+    fontSize: 13,
+    fontWeight: "600",
+    color: "#8E8E93",
+    textTransform: "uppercase",
+    letterSpacing: 0.5,
+  },
+  refreshButton: {
+    paddingVertical: 6,
+    paddingHorizontal: 12,
+    borderRadius: 8,
+    backgroundColor: "#FFFFFF",
+    borderWidth: 1,
+    borderColor: "#E5E5EA",
+    minWidth: 80,
+    alignItems: "center",
+  },
+  refreshButtonPressed: {
+    opacity: 0.6,
+  },
+  refreshButtonText: {
+    fontSize: 13,
+    color: "#0A84FF",
+    fontWeight: "600",
+  },
+  errorContainer: {
+    backgroundColor: "#FFF2F2",
+    borderRadius: 12,
+    padding: 16,
+    gap: 12,
+    borderWidth: 1,
+    borderColor: "#FFD0D0",
+  },
+  errorText: {
+    fontSize: 13,
+    color: "#FF3B30",
+    lineHeight: 18,
+  },
+  retryButton: {
+    alignSelf: "flex-start",
+    paddingVertical: 6,
+    paddingHorizontal: 14,
+    borderRadius: 8,
+    backgroundColor: "#FFFFFF",
+    borderWidth: 1,
+    borderColor: "#E5E5EA",
+  },
+  retryButtonPressed: {
+    opacity: 0.6,
+  },
+  retryButtonText: {
+    fontSize: 13,
+    fontWeight: "600",
+    color: "#FF3B30",
+  },
+  emptyTools: {
+    paddingVertical: 32,
+    alignItems: "center",
+  },
+  emptyToolsText: {
+    fontSize: 15,
+    color: "#8E8E93",
+  },
+  toolsList: {
+    backgroundColor: "#FFFFFF",
+    borderRadius: 14,
+    borderWidth: 1,
+    borderColor: "#E5E5EA",
+    overflow: "hidden",
+  },
+  toolRow: {
+    paddingHorizontal: 16,
+    paddingVertical: 12,
+    gap: 3,
+  },
+  toolRowBorder: {
+    borderBottomWidth: 1,
+    borderBottomColor: "#F2F2F7",
+  },
+  toolName: {
+    fontSize: 14,
+    fontWeight: "600",
+    color: "#1C1C1E",
+    fontFamily: Platform.OS === "ios" ? "Menlo" : "monospace",
+  },
+  toolDescription: {
+    fontSize: 12,
+    color: "#8E8E93",
+    lineHeight: 17,
+  },
+  footer: {
+    flexDirection: "row",
+    gap: 12,
+    paddingHorizontal: 20,
+    paddingTop: 16,
+    borderTopWidth: 1,
+    borderTopColor: "#E5E5EA",
+    backgroundColor: "#F5F5F7",
+  },
+  configureButton: {
+    flex: 1,
+    paddingVertical: 14,
+    borderRadius: 12,
+    alignItems: "center",
+    backgroundColor: "#1C1C1E",
+  },
+  configureButtonPressed: {
+    opacity: 0.85,
+  },
+  configureButtonText: {
+    fontSize: 16,
+    fontWeight: "600",
+    color: "#FFFFFF",
+  },
+  removeButton: {
+    flex: 1,
+    paddingVertical: 14,
+    borderRadius: 12,
+    alignItems: "center",
+    backgroundColor: "#FFFFFF",
+    borderWidth: 1,
+    borderColor: "#FF3B30",
+  },
+  removeButtonPressed: {
+    backgroundColor: "#FFF2F2",
+  },
+  removeButtonText: {
+    fontSize: 16,
+    fontWeight: "600",
+    color: "#FF3B30",
+  },
+});

--- a/components/settings/McpExtensionsScreen.tsx
+++ b/components/settings/McpExtensionsScreen.tsx
@@ -1,6 +1,5 @@
 import React, { useCallback, useEffect, useState } from "react";
 import {
-  Alert,
   Modal,
   Pressable,
   SafeAreaView,
@@ -11,11 +10,11 @@ import {
 } from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import {
-  deleteMcpExtension,
   getMcpExtensions,
   type McpExtensionRecord,
 } from "../../lib/secure-storage";
 import { McpConnectorConfig } from "./McpConnectorConfig";
+import { McpExtensionDetailScreen } from "./McpExtensionDetailScreen";
 
 export interface McpExtensionsScreenProps {
   visible: boolean;
@@ -29,6 +28,7 @@ export const McpExtensionsScreen: React.FC<McpExtensionsScreenProps> = ({
   const insets = useSafeAreaInsets();
   const [extensions, setExtensions] = useState<McpExtensionRecord[]>([]);
   const [addVisible, setAddVisible] = useState(false);
+  const [detailExtension, setDetailExtension] = useState<McpExtensionRecord | null>(null);
 
   const loadExtensions = useCallback(async () => {
     const list = await getMcpExtensions();
@@ -39,22 +39,13 @@ export const McpExtensionsScreen: React.FC<McpExtensionsScreenProps> = ({
     if (visible) loadExtensions();
   }, [visible, loadExtensions]);
 
-  const handleDelete = (ext: McpExtensionRecord) => {
-    Alert.alert(
-      "Remove Extension",
-      `Remove "${ext.name}"?`,
-      [
-        { text: "Cancel", style: "cancel" },
-        {
-          text: "Remove",
-          style: "destructive",
-          onPress: async () => {
-            await deleteMcpExtension(ext.id);
-            loadExtensions();
-          },
-        },
-      ]
-    );
+  const handleRemove = (id: string) => {
+    setDetailExtension(null);
+    setExtensions((prev) => prev.filter((e) => e.id !== id));
+  };
+
+  const handleUpdated = (updated: McpExtensionRecord) => {
+    setExtensions((prev) => prev.map((e) => (e.id === updated.id ? updated : e)));
   };
 
   return (
@@ -116,7 +107,11 @@ export const McpExtensionsScreen: React.FC<McpExtensionsScreenProps> = ({
             ]}
           >
             {extensions.map((ext) => (
-              <View key={ext.id} style={styles.card}>
+              <Pressable
+                key={ext.id}
+                style={({ pressed }) => [styles.card, pressed && styles.cardPressed]}
+                onPress={() => setDetailExtension(ext)}
+              >
                 <View style={styles.cardIcon}>
                   <Text style={styles.cardIconText}>🔌</Text>
                 </View>
@@ -126,16 +121,8 @@ export const McpExtensionsScreen: React.FC<McpExtensionsScreenProps> = ({
                     {ext.serverUrl}
                   </Text>
                 </View>
-                <Pressable
-                  style={({ pressed }) => [
-                    styles.deleteButton,
-                    pressed && styles.deleteButtonPressed,
-                  ]}
-                  onPress={() => handleDelete(ext)}
-                >
-                  <Text style={styles.deleteButtonText}>✕</Text>
-                </Pressable>
-              </View>
+                <Text style={styles.cardChevron}>›</Text>
+              </Pressable>
             ))}
           </ScrollView>
         )}
@@ -149,6 +136,16 @@ export const McpExtensionsScreen: React.FC<McpExtensionsScreenProps> = ({
           loadExtensions();
         }}
       />
+
+      {detailExtension && (
+        <McpExtensionDetailScreen
+          extension={detailExtension}
+          visible={detailExtension !== null}
+          onClose={() => setDetailExtension(null)}
+          onRemove={handleRemove}
+          onUpdated={handleUpdated}
+        />
+      )}
     </Modal>
   );
 };
@@ -264,6 +261,9 @@ const styles = StyleSheet.create({
     borderWidth: 1,
     borderColor: "#E5E5EA",
   },
+  cardPressed: {
+    backgroundColor: "#F2F2F7",
+  },
   cardIcon: {
     width: 40,
     height: 40,
@@ -288,20 +288,9 @@ const styles = StyleSheet.create({
     fontSize: 12,
     color: "#8E8E93",
   },
-  deleteButton: {
-    width: 28,
-    height: 28,
-    borderRadius: 14,
-    backgroundColor: "#F2F2F7",
-    alignItems: "center",
-    justifyContent: "center",
-  },
-  deleteButtonPressed: {
-    backgroundColor: "#FFE5E5",
-  },
-  deleteButtonText: {
-    fontSize: 12,
-    color: "#8E8E93",
-    fontWeight: "600",
+  cardChevron: {
+    fontSize: 22,
+    color: "#C7C7CC",
+    fontWeight: "300",
   },
 });

--- a/components/settings/McpExtensionsScreen.tsx
+++ b/components/settings/McpExtensionsScreen.tsx
@@ -120,6 +120,9 @@ export const McpExtensionsScreen: React.FC<McpExtensionsScreenProps> = ({
                   <Text style={styles.cardUrl} numberOfLines={1}>
                     {ext.serverUrl}
                   </Text>
+                  <Text style={[styles.cardStatus, ext.disabled && styles.cardStatusDisabled]}>
+                    {ext.disabled ? "Disabled" : "Enabled"}
+                  </Text>
                 </View>
                 <Text style={styles.cardChevron}>›</Text>
               </Pressable>
@@ -286,6 +289,15 @@ const styles = StyleSheet.create({
   },
   cardUrl: {
     fontSize: 12,
+    color: "#8E8E93",
+  },
+  cardStatus: {
+    fontSize: 11,
+    fontWeight: "500",
+    color: "#34C759",
+    marginTop: 1,
+  },
+  cardStatusDisabled: {
     color: "#8E8E93",
   },
   cardChevron: {

--- a/components/settings/McpExtensionsScreen.tsx
+++ b/components/settings/McpExtensionsScreen.tsx
@@ -1,0 +1,307 @@
+import React, { useCallback, useEffect, useState } from "react";
+import {
+  Alert,
+  Modal,
+  Pressable,
+  SafeAreaView,
+  ScrollView,
+  StyleSheet,
+  Text,
+  View,
+} from "react-native";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
+import {
+  deleteMcpExtension,
+  getMcpExtensions,
+  type McpExtensionRecord,
+} from "../../lib/secure-storage";
+import { McpConnectorConfig } from "./McpConnectorConfig";
+
+export interface McpExtensionsScreenProps {
+  visible: boolean;
+  onClose: () => void;
+}
+
+export const McpExtensionsScreen: React.FC<McpExtensionsScreenProps> = ({
+  visible,
+  onClose,
+}) => {
+  const insets = useSafeAreaInsets();
+  const [extensions, setExtensions] = useState<McpExtensionRecord[]>([]);
+  const [addVisible, setAddVisible] = useState(false);
+
+  const loadExtensions = useCallback(async () => {
+    const list = await getMcpExtensions();
+    setExtensions(list);
+  }, []);
+
+  useEffect(() => {
+    if (visible) loadExtensions();
+  }, [visible, loadExtensions]);
+
+  const handleDelete = (ext: McpExtensionRecord) => {
+    Alert.alert(
+      "Remove Extension",
+      `Remove "${ext.name}"?`,
+      [
+        { text: "Cancel", style: "cancel" },
+        {
+          text: "Remove",
+          style: "destructive",
+          onPress: async () => {
+            await deleteMcpExtension(ext.id);
+            loadExtensions();
+          },
+        },
+      ]
+    );
+  };
+
+  return (
+    <Modal
+      animationType="slide"
+      presentationStyle="formSheet"
+      visible={visible}
+      onRequestClose={onClose}
+    >
+      <SafeAreaView style={styles.safeArea}>
+        <View style={styles.header}>
+          <Text style={styles.headerTitle}>Extensions (MCP)</Text>
+          <View style={styles.headerRight}>
+            <Pressable
+              onPress={() => setAddVisible(true)}
+              style={({ pressed }) => [
+                styles.addButton,
+                pressed && styles.addButtonPressed,
+              ]}
+            >
+              <Text style={styles.addButtonText}>＋</Text>
+            </Pressable>
+            <Pressable
+              onPress={onClose}
+              style={({ pressed }) => [
+                styles.doneButton,
+                pressed && styles.doneButtonPressed,
+              ]}
+            >
+              <Text style={styles.doneButtonText}>Done</Text>
+            </Pressable>
+          </View>
+        </View>
+
+        {extensions.length === 0 ? (
+          <View style={styles.emptyState}>
+            <Text style={styles.emptyIcon}>🔌</Text>
+            <Text style={styles.emptyTitle}>No MCP Extensions</Text>
+            <Text style={styles.emptySubtitle}>
+              Connect to any MCP-compatible server to extend the assistant with
+              custom tools.
+            </Text>
+            <Pressable
+              style={({ pressed }) => [
+                styles.emptyAddButton,
+                pressed && styles.emptyAddButtonPressed,
+              ]}
+              onPress={() => setAddVisible(true)}
+            >
+              <Text style={styles.emptyAddButtonText}>＋ Add your first MCP extension</Text>
+            </Pressable>
+          </View>
+        ) : (
+          <ScrollView
+            style={styles.scrollView}
+            contentContainerStyle={[
+              styles.scrollContent,
+              { paddingBottom: insets.bottom + 24 },
+            ]}
+          >
+            {extensions.map((ext) => (
+              <View key={ext.id} style={styles.card}>
+                <View style={styles.cardIcon}>
+                  <Text style={styles.cardIconText}>🔌</Text>
+                </View>
+                <View style={styles.cardBody}>
+                  <Text style={styles.cardName}>{ext.name}</Text>
+                  <Text style={styles.cardUrl} numberOfLines={1}>
+                    {ext.serverUrl}
+                  </Text>
+                </View>
+                <Pressable
+                  style={({ pressed }) => [
+                    styles.deleteButton,
+                    pressed && styles.deleteButtonPressed,
+                  ]}
+                  onPress={() => handleDelete(ext)}
+                >
+                  <Text style={styles.deleteButtonText}>✕</Text>
+                </Pressable>
+              </View>
+            ))}
+          </ScrollView>
+        )}
+      </SafeAreaView>
+
+      <McpConnectorConfig
+        visible={addVisible}
+        onClose={() => setAddVisible(false)}
+        onSave={() => {
+          setAddVisible(false);
+          loadExtensions();
+        }}
+      />
+    </Modal>
+  );
+};
+
+const styles = StyleSheet.create({
+  safeArea: {
+    flex: 1,
+    backgroundColor: "#F5F5F7",
+  },
+  header: {
+    paddingHorizontal: 24,
+    paddingTop: 12,
+    paddingBottom: 16,
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "space-between",
+    borderBottomWidth: 1,
+    borderBottomColor: "#E5E5EA",
+  },
+  headerTitle: {
+    fontSize: 24,
+    fontWeight: "700",
+    color: "#1C1C1E",
+  },
+  headerRight: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 12,
+  },
+  addButton: {
+    width: 36,
+    height: 36,
+    borderRadius: 18,
+    backgroundColor: "#1C1C1E",
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  addButtonPressed: {
+    opacity: 0.7,
+  },
+  addButtonText: {
+    color: "#FFFFFF",
+    fontSize: 20,
+    lineHeight: 24,
+  },
+  doneButton: {
+    paddingVertical: 8,
+    paddingHorizontal: 4,
+    borderRadius: 8,
+  },
+  doneButtonPressed: {
+    backgroundColor: "rgba(10, 132, 255, 0.08)",
+  },
+  doneButtonText: {
+    color: "#0A84FF",
+    fontSize: 16,
+    fontWeight: "600",
+  },
+  emptyState: {
+    flex: 1,
+    alignItems: "center",
+    justifyContent: "center",
+    paddingHorizontal: 40,
+    gap: 12,
+  },
+  emptyIcon: {
+    fontSize: 56,
+    marginBottom: 4,
+  },
+  emptyTitle: {
+    fontSize: 20,
+    fontWeight: "700",
+    color: "#1C1C1E",
+    textAlign: "center",
+  },
+  emptySubtitle: {
+    fontSize: 14,
+    color: "#636366",
+    textAlign: "center",
+    lineHeight: 20,
+    marginBottom: 8,
+  },
+  emptyAddButton: {
+    paddingVertical: 14,
+    paddingHorizontal: 24,
+    borderRadius: 14,
+    backgroundColor: "#1C1C1E",
+  },
+  emptyAddButtonPressed: {
+    opacity: 0.8,
+  },
+  emptyAddButtonText: {
+    fontSize: 16,
+    fontWeight: "600",
+    color: "#FFFFFF",
+  },
+  scrollView: {
+    flex: 1,
+  },
+  scrollContent: {
+    paddingHorizontal: 20,
+    paddingTop: 20,
+    gap: 12,
+  },
+  card: {
+    flexDirection: "row",
+    alignItems: "center",
+    backgroundColor: "#FFFFFF",
+    borderRadius: 14,
+    paddingHorizontal: 16,
+    paddingVertical: 14,
+    gap: 14,
+    borderWidth: 1,
+    borderColor: "#E5E5EA",
+  },
+  cardIcon: {
+    width: 40,
+    height: 40,
+    borderRadius: 12,
+    backgroundColor: "#F0FFF4",
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  cardIconText: {
+    fontSize: 20,
+  },
+  cardBody: {
+    flex: 1,
+    gap: 2,
+  },
+  cardName: {
+    fontSize: 15,
+    fontWeight: "600",
+    color: "#1C1C1E",
+  },
+  cardUrl: {
+    fontSize: 12,
+    color: "#8E8E93",
+  },
+  deleteButton: {
+    width: 28,
+    height: 28,
+    borderRadius: 14,
+    backgroundColor: "#F2F2F7",
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  deleteButtonPressed: {
+    backgroundColor: "#FFE5E5",
+  },
+  deleteButtonText: {
+    fontSize: 12,
+    color: "#8E8E93",
+    fontWeight: "600",
+  },
+});

--- a/components/settings/connectorOptions.ts
+++ b/components/settings/connectorOptions.ts
@@ -8,7 +8,8 @@ export type ConnectorId =
   | "daily_papers"
   | "language_lesson"
   | "github_legacy"
-  | "gdrive_legacy";
+  | "gdrive_legacy"
+  | "mcp";
 
 export type ConnectorOption = {
   id: ConnectorId;
@@ -89,5 +90,12 @@ export const CONNECTOR_OPTIONS: ConnectorOption[] = [
     icon: "🔧",
     backgroundColor: "#FFF8EF",
     iconBackgroundColor: "#FFF3E6",
+  },
+  {
+    id: "mcp",
+    name: "MCP",
+    icon: "🔌",
+    backgroundColor: "#F0FFF4",
+    iconBackgroundColor: "#DCFFE8",
   },
 ];

--- a/components/settings/connectorOptions.ts
+++ b/components/settings/connectorOptions.ts
@@ -9,7 +9,7 @@ export type ConnectorId =
   | "language_lesson"
   | "github_legacy"
   | "gdrive_legacy"
-  | "mcp";
+;
 
 export type ConnectorOption = {
   id: ConnectorId;
@@ -90,12 +90,5 @@ export const CONNECTOR_OPTIONS: ConnectorOption[] = [
     icon: "🔧",
     backgroundColor: "#FFF8EF",
     iconBackgroundColor: "#FFF3E6",
-  },
-  {
-    id: "mcp",
-    name: "MCP",
-    icon: "🔌",
-    backgroundColor: "#F0FFF4",
-    iconBackgroundColor: "#DCFFE8",
   },
 ];

--- a/components/ui/HamburgerMenu.tsx
+++ b/components/ui/HamburgerMenu.tsx
@@ -45,11 +45,19 @@ export const MENU_SECTIONS: MenuSection[] = [
   },
   {
     id: "connectors",
-    title: "Configure Connectors",
+    title: "Extensions (One-off)",
     description: "Connect to GitHub, Drive, and more.",
     icon: "🔗",
     iconBackgroundColor: "#E8F5FF",
     backgroundColor: "#F0F9FF",
+  },
+  {
+    id: "mcp_extensions",
+    title: "Extensions (MCP)",
+    description: "Connect to any MCP-compatible server.",
+    icon: "🔌",
+    iconBackgroundColor: "#DCFFE8",
+    backgroundColor: "#F0FFF4",
   },
   {
     id: "advanced",

--- a/docs/plans/mcp_auth_plan.md
+++ b/docs/plans/mcp_auth_plan.md
@@ -1,0 +1,40 @@
+# MCP OAuth Authentication Plan
+
+## Overview
+
+Implement OAuth 2.0 authentication for MCP server connections following the MCP authorization spec with PKCE and dynamic client registration.
+
+## Steps
+
+### Step 1 — Fetch MCP Server Metadata
+
+Connect to the MCP server and fetch the root metadata to discover the `resource_metadata_url`.
+
+### Step 2 — Fetch Resource Metadata
+
+Fetch `resource_metadata_url` to retrieve the `authorization_servers` list.
+
+### Step 3 — Probe OAuth Authorization Server
+
+Send a request to `/.well-known/oauth-authorization-server` on the auth server to discover:
+- `authorization_endpoint`
+- `token_endpoint`
+- `registration_endpoint`
+
+### Step 4 — Dynamic Client Registration
+
+POST to `registration_endpoint` to dynamically register the client and receive a `client_id`.
+
+### Step 5 — Open In-App Browser for Authorization
+
+Open an in-app browser to `authorization_endpoint` with:
+- PKCE `code_challenge`
+- `resource` param
+
+### Step 6 — Exchange Code for Token
+
+Handle the redirect callback, then POST to `token_endpoint` with:
+- `code`
+- `code_verifier`
+
+Store the resulting access token securely.

--- a/docs/plans/mcp_extension_detail_screen.md
+++ b/docs/plans/mcp_extension_detail_screen.md
@@ -1,0 +1,187 @@
+# MCP Extension Detail Screen Plan
+
+## Goal
+
+Tapping a saved MCP extension in `McpExtensionsScreen` navigates to a detail screen showing
+the extension's metadata, its live tools list, and action buttons (Configure, Remove).
+
+---
+
+## Current State
+
+- `McpExtensionsScreen` renders a flat list of `McpExtensionRecord` cards with only a delete
+  button per row.
+- Navigation is modal-state-based (no React Navigation stack).
+- `MCPClient` in `modules/vm-webrtc/src/mcp_client/client.ts` can already call `tools/list`.
+- `McpConnectorConfig` is the existing "add / edit" form modal.
+
+---
+
+## Navigation Approach
+
+Since the app uses modal-state navigation (not React Navigation), keep the same pattern:
+add a `detailExtension: McpExtensionRecord | null` state in `McpExtensionsScreen`. When
+non-null, render `McpExtensionDetailScreen` in place of (or layered over) the list using
+an animated slide or a nested modal.
+
+**Recommended:** render `McpExtensionDetailScreen` as a full-screen modal with
+`animationType="slide"` (matches iOS "push" feel without needing a stack navigator).
+
+```
+McpExtensionsScreen
+  └─ (tap row) → detailExtension state set
+       └─ <McpExtensionDetailScreen> (full-screen slide modal)
+            ├─ (tap Configure) → <McpConnectorConfig> (sheet modal on top)
+            └─ (tap Remove) → ActionSheet confirm → dismiss both modals
+```
+
+---
+
+## Screen Layout — `McpExtensionDetailScreen`
+
+```
+┌─────────────────────────────────────────┐
+│  < Back          [Extension name]        │
+├─────────────────────────────────────────┤
+│  [Icon]  Extension Name                 │
+│          URL: https://...               │
+├─────────────────────────────────────────┤
+│  TOOLS                    [↻ Refresh]   │
+│  ─────────────────────────────────────  │
+│  • tool_name_one                        │
+│    Description text if available        │
+│  ─────────────────────────────────────  │
+│  • tool_name_two                        │
+│    ...                                  │
+│  (loading spinner / error state)        │
+├─────────────────────────────────────────┤
+│  [Configure]           [Remove]         │
+└─────────────────────────────────────────┘
+```
+
+---
+
+## Components to Create / Modify
+
+### 1. `components/settings/McpExtensionDetailScreen.tsx` (new)
+
+**Props:**
+```typescript
+interface Props {
+  extension: McpExtensionRecord;
+  visible: boolean;
+  onClose: () => void;
+  onRemove: (id: string) => void;
+  onUpdated: (updated: McpExtensionRecord) => void;
+}
+```
+
+**State:**
+```typescript
+tools: McpTool[]          // fetched tool list
+toolsLoading: boolean
+toolsError: string | null
+configureVisible: boolean
+```
+
+**Auto-refresh on mount:**
+```typescript
+useEffect(() => {
+  fetchTools();
+}, []); // runs once when modal becomes visible
+```
+
+**`fetchTools` function:**
+- Instantiate `MCPClient` with `extension.serverUrl` + stored bearer token
+  (call `getMcpBearerToken(extension.id)`)
+- Call `client.listTools()` (or equivalent `tools/list` JSON-RPC call)
+- On success: set `tools`, clear error
+- On failure: set `toolsError`, keep stale tools if any
+
+**Refresh button:** calls `fetchTools()` manually; shows `ActivityIndicator` in button
+while loading.
+
+**Pull-to-refresh:** wrap tools list in `ScrollView` with `refreshControl` prop
+(`RefreshControl` component) — standard iOS pattern.
+
+**Configure button:** sets `configureVisible = true`, renders `McpConnectorConfig`
+in edit mode (pre-populated with current extension values).
+
+**Remove button:** show iOS `ActionSheetIOS` (or cross-platform `Alert` with
+destructive style) to confirm, then call `deleteMcpExtension(extension.id)`,
+call `onRemove(extension.id)`, and close.
+
+---
+
+### 2. `components/settings/McpConnectorConfig.tsx` (modify)
+
+Add an optional `existingExtension?: McpExtensionRecord` prop so it can pre-populate
+fields for editing. On save in edit mode, update the record in storage instead of
+adding a new one.
+
+---
+
+### 3. `components/settings/McpExtensionsScreen.tsx` (modify)
+
+- Add state: `detailExtension: McpExtensionRecord | null`
+- Make each list row tappable (`TouchableOpacity` / `Pressable`) → sets `detailExtension`
+- Remove the inline delete button (Remove moves to detail screen)
+- Render `<McpExtensionDetailScreen>` when `detailExtension !== null`
+- Handle `onRemove`: remove from local `extensions` state + clear `detailExtension`
+- Handle `onUpdated`: update extension in local `extensions` state
+
+---
+
+## Data / API
+
+### Fetching Tools
+
+Use `MCPClient` already in the codebase. Need a `listTools()` method if not already present:
+
+```typescript
+async listTools(): Promise<McpTool[]> {
+  const response = await this.sendRequest({
+    jsonrpc: "2.0",
+    id: 1,
+    method: "tools/list",
+    params: {}
+  });
+  return response.result?.tools ?? [];
+}
+```
+
+`McpTool` type (add to `types.ts` if missing):
+```typescript
+interface McpTool {
+  name: string;
+  description?: string;
+  inputSchema?: object;
+}
+```
+
+---
+
+## iOS Best Practices Checklist
+
+- **Slide modal** (`animationType="slide"`) for detail screen — matches iOS push navigation feel
+- **Back button** in header ("< Back" or chevron icon) closes modal
+- **Pull-to-refresh** (`RefreshControl`) on tools list
+- **Auto-refresh on screen appear** — call `fetchTools()` in `useEffect([], [])`
+- **Loading state** — `ActivityIndicator` centered while first fetch runs; spinner in
+  refresh button on subsequent fetches (keeps stale list visible)
+- **Error state** — inline error message with "Retry" link, not a blocking alert
+- **Destructive confirmation** — `ActionSheetIOS` with red "Remove" option for iOS;
+  fall back to `Alert` with destructive button style on Android
+- **Haptic feedback** — `Haptics.impactAsync(ImpactFeedbackStyle.Medium)` on Remove confirm
+- **Empty tools state** — friendly message ("No tools found") rather than blank space
+- **Safe area** — wrap in `SafeAreaView` to respect notch / home indicator
+
+---
+
+## Implementation Order
+
+1. Add `listTools()` to `MCPClient` + `McpTool` type
+2. Create `McpExtensionDetailScreen` with static info + Remove action (no tools yet)
+3. Wire up tap-to-detail in `McpExtensionsScreen`
+4. Add tools fetch + loading/error/refresh UI to detail screen
+5. Add edit/configure support to `McpConnectorConfig` + wire Configure button

--- a/lib/secure-storage.ts
+++ b/lib/secure-storage.ts
@@ -770,6 +770,64 @@ export async function hasContext7ApiKey(): Promise<boolean> {
   }
 }
 
+// MCP Extensions
+
+export interface McpExtensionRecord {
+  id: string;
+  name: string;
+  serverUrl: string;
+}
+
+const MCP_EXTENSIONS_KEY = "VIBEMACHINE_MCP_EXTENSIONS";
+const MCP_TOKEN_PREFIX = "VIBEMACHINE_MCP_TOKEN_";
+
+export async function getMcpExtensions(): Promise<McpExtensionRecord[]> {
+  try {
+    const raw = await AsyncStorage.getItem(MCP_EXTENSIONS_KEY);
+    if (!raw) return [];
+    return JSON.parse(raw) as McpExtensionRecord[];
+  } catch (err) {
+    log.error("❌ Failed to load MCP extensions", {}, { error: (err as Error).message });
+    return [];
+  }
+}
+
+export async function saveMcpExtensions(extensions: McpExtensionRecord[]): Promise<void> {
+  await AsyncStorage.setItem(MCP_EXTENSIONS_KEY, JSON.stringify(extensions));
+}
+
+export async function addMcpExtension(extension: McpExtensionRecord): Promise<void> {
+  const existing = await getMcpExtensions();
+  const filtered = existing.filter((e) => e.id !== extension.id);
+  await saveMcpExtensions([...filtered, extension]);
+}
+
+export async function deleteMcpExtension(id: string): Promise<void> {
+  const existing = await getMcpExtensions();
+  await saveMcpExtensions(existing.filter((e) => e.id !== id));
+  await deleteMcpBearerToken(id);
+}
+
+export async function saveMcpBearerToken(id: string, token: string): Promise<void> {
+  await SecureStore.setItemAsync(`${MCP_TOKEN_PREFIX}${id}`, token);
+}
+
+export async function getMcpBearerToken(id: string): Promise<string | null> {
+  try {
+    return await SecureStore.getItemAsync(`${MCP_TOKEN_PREFIX}${id}`);
+  } catch {
+    return null;
+  }
+}
+
+export async function deleteMcpBearerToken(id: string): Promise<void> {
+  try {
+    await SecureStore.deleteItemAsync(`${MCP_TOKEN_PREFIX}${id}`);
+  } catch {
+    // token may not exist
+  }
+}
+
 // Pydantic Logfire Enabled State Functions
 // Note: These use AsyncStorage, not SecureStore, so no caching is needed
 

--- a/lib/secure-storage.ts
+++ b/lib/secure-storage.ts
@@ -853,12 +853,12 @@ export async function deleteMcpExtension(id: string): Promise<void> {
 }
 
 export async function saveMcpBearerToken(id: string, token: string): Promise<void> {
-  await SecureStore.setItemAsync(`${MCP_TOKEN_PREFIX}${id}`, token);
+  await setCachedValue(`${MCP_TOKEN_PREFIX}${id}`, token);
 }
 
 export async function getMcpBearerToken(id: string): Promise<string | null> {
   try {
-    return await SecureStore.getItemAsync(`${MCP_TOKEN_PREFIX}${id}`);
+    return await getCachedValue(`${MCP_TOKEN_PREFIX}${id}`);
   } catch {
     return null;
   }
@@ -866,7 +866,7 @@ export async function getMcpBearerToken(id: string): Promise<string | null> {
 
 export async function deleteMcpBearerToken(id: string): Promise<void> {
   try {
-    await SecureStore.deleteItemAsync(`${MCP_TOKEN_PREFIX}${id}`);
+    await deleteCachedValue(`${MCP_TOKEN_PREFIX}${id}`);
   } catch {
     // token may not exist
   }

--- a/lib/secure-storage.ts
+++ b/lib/secure-storage.ts
@@ -776,6 +776,7 @@ export interface McpExtensionRecord {
   id: string;
   name: string;
   serverUrl: string;
+  disabled?: boolean;
 }
 
 const MCP_EXTENSIONS_KEY = "VIBEMACHINE_MCP_EXTENSIONS";

--- a/lib/secure-storage.ts
+++ b/lib/secure-storage.ts
@@ -775,8 +775,40 @@ export async function hasContext7ApiKey(): Promise<boolean> {
 export interface McpExtensionRecord {
   id: string;
   name: string;
+  normalizedName: string;
   serverUrl: string;
   disabled?: boolean;
+}
+
+// "My Cool Server!" → "my_cool_server"
+export function toNormalizedName(input: string): string {
+  return input
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "_")
+    .replace(/^_+|_+$/g, "");
+}
+
+const RESERVED_GROUP_NAMES = new Set([
+  "hacker_news", "daily_papers", "web", "google_drive",
+  "deepwiki", "context7", "github", "language_lesson",
+  "github_legacy", "gdrive_legacy",
+]);
+
+export function uniqueNormalizedName(
+  base: string,
+  existingExtensions: McpExtensionRecord[],
+  excludeId?: string,
+): string {
+  const taken = new Set([
+    ...RESERVED_GROUP_NAMES,
+    ...existingExtensions
+      .filter((e) => e.id !== excludeId)
+      .map((e) => e.normalizedName),
+  ]);
+  if (!taken.has(base)) return base;
+  let n = 2;
+  while (taken.has(`${base}_${n}`)) n++;
+  return `${base}_${n}`;
 }
 
 const MCP_EXTENSIONS_KEY = "VIBEMACHINE_MCP_EXTENSIONS";
@@ -786,7 +818,18 @@ export async function getMcpExtensions(): Promise<McpExtensionRecord[]> {
   try {
     const raw = await AsyncStorage.getItem(MCP_EXTENSIONS_KEY);
     if (!raw) return [];
-    return JSON.parse(raw) as McpExtensionRecord[];
+    const parsed = JSON.parse(raw) as McpExtensionRecord[];
+
+    let needsSave = false;
+    for (const ext of parsed) {
+      if (!ext.normalizedName) {
+        ext.normalizedName = uniqueNormalizedName(toNormalizedName(ext.name), parsed, ext.id);
+        needsSave = true;
+      }
+    }
+    if (needsSave) await saveMcpExtensions(parsed);
+
+    return parsed;
   } catch (err) {
     log.error("❌ Failed to load MCP extensions", {}, { error: (err as Error).message });
     return [];

--- a/modules/vm-webrtc/src/ToolkitManager.ts
+++ b/modules/vm-webrtc/src/ToolkitManager.ts
@@ -6,7 +6,12 @@ import { DeviceEventEmitter } from "react-native";
 import toolkitGroupsData from "../toolkits/toolkitGroups.json";
 
 import { log } from "../../../lib/logger";
-import { getContext7ApiKey } from "../../../lib/secure-storage";
+import {
+  getContext7ApiKey,
+  getMcpBearerToken,
+  getMcpExtensions,
+  type McpExtensionRecord,
+} from "../../../lib/secure-storage";
 import type {
   RemoteMcpToolkitDefinition,
   ToolDefinition,
@@ -673,6 +678,118 @@ export const getToolkitDefinitions = async (): Promise<ToolDefinition[]> => {
   }
 };
 
+async function fetchAndCacheUserExtensionTools(
+  ext: McpExtensionRecord,
+  client: MCPClient,
+  cacheKey: string,
+  groupName: string,
+): Promise<void> {
+  const token = await getMcpBearerToken(ext.id);
+  const options: RequestOptions = {
+    ...REMOTE_TOOLKIT_DISCOVERY_OPTIONS,
+    ...(token ? { headers: { Authorization: `Bearer ${token}` } } : {}),
+  };
+
+  const result = await client.listTools(undefined, options);
+  if (!result.tools || result.tools.length === 0) {
+    setDynamicToolkitDefinitionsForServer(groupName, []);
+    return;
+  }
+
+  const cachedTools = await convertToolsForCache(result.tools, groupName, ext.name);
+  await registerUserExtensionToolsFromCache(ext, client, cachedTools);
+  setDynamicToolkitDefinitionsForServer(groupName, cachedTools.map((t) => t.definition));
+  await writeRemoteToolkitCache(cacheKey, { lastFetched: Date.now(), tools: cachedTools });
+
+  log.info(
+    "[ToolkitManager] Fetched and cached user MCP extension tools",
+    {},
+    { name: ext.name, group: groupName, toolCount: cachedTools.length },
+  );
+}
+
+async function registerUserExtensionToolsFromCache(
+  ext: McpExtensionRecord,
+  client: MCPClient,
+  tools: RemoteToolkitCacheEntry["tools"],
+): Promise<void> {
+  const groupName = ext.normalizedName;
+  for (const tool of tools) {
+    const toolName = tool.name;
+    registerMcpTool(groupName, toolName, async (args: any) => {
+      log.info(
+        "[ToolkitManager] Executing user MCP extension tool",
+        {},
+        { group: groupName, toolName, url: ext.serverUrl },
+      );
+      const token = await getMcpBearerToken(ext.id);
+      const options: RequestOptions = {
+        ...REMOTE_TOOLKIT_DISCOVERY_OPTIONS,
+        ...(token ? { headers: { Authorization: `Bearer ${token}` } } : {}),
+      };
+      const result = await client.callTool({ name: toolName, arguments: args }, options, groupName);
+      return { result: JSON.stringify(result, null, 2), updatedToolSessionContext: {} };
+    });
+  }
+}
+
+async function loadUserMcpExtensionTools(): Promise<void> {
+  const extensions = await getMcpExtensions().catch(() => [] as McpExtensionRecord[]);
+  const enabled = extensions.filter((ext) => !ext.disabled);
+
+  if (enabled.length === 0) return;
+
+  log.info(
+    "[ToolkitManager] Loading user MCP extension tools",
+    {},
+    { count: enabled.length, names: enabled.map((e) => e.normalizedName) },
+  );
+
+  for (const ext of enabled) {
+    const groupName = ext.normalizedName;
+    const cacheKey = `user_ext:${ext.id}`;
+
+    try {
+      const cached = await readRemoteToolkitCache(cacheKey);
+      const client = getOrCreateMcpClient(ext.serverUrl);
+
+      if (cached && cached.tools.length > 0) {
+        const isStale = Date.now() - cached.lastFetched > REMOTE_TOOLKIT_CACHE_TTL_MS;
+        log.debug(
+          "[ToolkitManager] Loading user extension tools from cache",
+          {},
+          { name: ext.name, group: groupName, toolCount: cached.tools.length, isStale },
+        );
+        await registerUserExtensionToolsFromCache(ext, client, cached.tools);
+        setDynamicToolkitDefinitionsForServer(groupName, cached.tools.map((t) => t.definition));
+        if (isStale) {
+          fetchAndCacheUserExtensionTools(ext, client, cacheKey, groupName).catch((error) => {
+            log.warn(
+              "[ToolkitManager] Background refresh of user extension cache failed",
+              {},
+              { name: ext.name, error: error instanceof Error ? error.message : String(error) },
+            );
+          });
+        }
+      } else {
+        await fetchAndCacheUserExtensionTools(ext, client, cacheKey, groupName);
+      }
+    } catch (error) {
+      log.error(
+        "[ToolkitManager] Failed to load user MCP extension tools",
+        {},
+        {
+          name: ext.name,
+          group: groupName,
+          url: ext.serverUrl,
+          error: error instanceof Error ? error.message : String(error),
+        },
+        error instanceof Error ? error : new Error(String(error)),
+      );
+    }
+  }
+}
+
 /**
  * Internal function that actually fetches toolkit definitions.
  */
@@ -711,6 +828,9 @@ async function fetchToolkitDefinitions(): Promise<ToolDefinition[]> {
       toolCount: definitions.length,
     });
   }
+
+  // Load user MCP extension tools (enabled extensions stored in secure storage)
+  await loadUserMcpExtensionTools();
 
   const allTools = rebuildToolkitDefinitionsCache();
 

--- a/modules/vm-webrtc/src/ToolkitManager.ts
+++ b/modules/vm-webrtc/src/ToolkitManager.ts
@@ -159,6 +159,7 @@ async function reloadToolkitGroups(): Promise<void> {
   staticToolkitDefinitionsCache = null;
   toolkitDefinitionsCache = null;
   toolkitDefinitionsPromise = null;
+  userExtensionClientsByExtId.clear();
 
   // Rebuild toolkit groups cache
   const groups = await getFilteredToolkitGroups();
@@ -356,6 +357,8 @@ type RemoteToolkitCacheEntry = {
 const dynamicToolkitDefinitionsByServer = new Map<string, ToolDefinition[]>();
 const remoteCacheRefreshPromises = new Map<string, Promise<void>>();
 const mcpClientsByServerUrl = new Map<string, MCPClient>();
+// User extension clients keyed by extension ID (bearer token baked into constructor)
+const userExtensionClientsByExtId = new Map<string, MCPClient>();
 
 /**
  * Get or create a cached MCP client for the given server URL.
@@ -373,6 +376,15 @@ function getOrCreateMcpClient(serverUrl: string): MCPClient {
     );
     client = new MCPClient(serverUrl);
     mcpClientsByServerUrl.set(serverUrl, client);
+  }
+  return client;
+}
+
+function getOrCreateUserExtensionClient(extId: string, serverUrl: string, bearerToken: string | null): MCPClient {
+  let client = userExtensionClientsByExtId.get(extId);
+  if (!client) {
+    client = new MCPClient(serverUrl, bearerToken ?? undefined);
+    userExtensionClientsByExtId.set(extId, client);
   }
   return client;
 }
@@ -684,13 +696,7 @@ async function fetchAndCacheUserExtensionTools(
   cacheKey: string,
   groupName: string,
 ): Promise<void> {
-  const token = await getMcpBearerToken(ext.id);
-  const options: RequestOptions = {
-    ...REMOTE_TOOLKIT_DISCOVERY_OPTIONS,
-    ...(token ? { headers: { Authorization: `Bearer ${token}` } } : {}),
-  };
-
-  const result = await client.listTools(undefined, options);
+  const result = await client.listTools(undefined, REMOTE_TOOLKIT_DISCOVERY_OPTIONS);
   if (!result.tools || result.tools.length === 0) {
     setDynamicToolkitDefinitionsForServer(groupName, []);
     return;
@@ -722,12 +728,11 @@ async function registerUserExtensionToolsFromCache(
         {},
         { group: groupName, toolName, url: ext.serverUrl },
       );
-      const token = await getMcpBearerToken(ext.id);
-      const options: RequestOptions = {
-        ...REMOTE_TOOLKIT_DISCOVERY_OPTIONS,
-        ...(token ? { headers: { Authorization: `Bearer ${token}` } } : {}),
-      };
-      const result = await client.callTool({ name: toolName, arguments: args }, options, groupName);
+      const result = await client.callTool(
+        { name: toolName, arguments: args },
+        REMOTE_TOOLKIT_DISCOVERY_OPTIONS,
+        groupName,
+      );
       return { result: JSON.stringify(result, null, 2), updatedToolSessionContext: {} };
     });
   }
@@ -751,7 +756,8 @@ async function loadUserMcpExtensionTools(): Promise<void> {
 
     try {
       const cached = await readRemoteToolkitCache(cacheKey);
-      const client = getOrCreateMcpClient(ext.serverUrl);
+      const bearerToken = await getMcpBearerToken(ext.id);
+      const client = getOrCreateUserExtensionClient(ext.id, ext.serverUrl, bearerToken);
 
       if (cached && cached.tools.length > 0) {
         const isStale = Date.now() - cached.lastFetched > REMOTE_TOOLKIT_CACHE_TTL_MS;

--- a/modules/vm-webrtc/src/mcp_client/client.ts
+++ b/modules/vm-webrtc/src/mcp_client/client.ts
@@ -35,12 +35,14 @@ const MAX_MCP_RESULT_LENGTH = 25000;
  */
 export class MCPClient {
   private endpoint: string;
+  private authToken?: string;
   private requestId = 0;
   private sessionId: string | null = null;
   private initializePromise: Promise<void> | null = null;
 
-  constructor(endpoint: string) {
+  constructor(endpoint: string, authToken?: string) {
     this.endpoint = endpoint;
+    this.authToken = authToken;
   }
 
   /**
@@ -74,12 +76,17 @@ export class MCPClient {
     };
 
     try {
+      const initHeaders: Record<string, string> = {
+        "Content-Type": "application/json",
+        Accept: "application/json, text/event-stream",
+      };
+      if (this.authToken) {
+        initHeaders["Authorization"] = `Bearer ${this.authToken}`;
+      }
+
       const res = await fetch(this.endpoint, {
         method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-          Accept: "application/json, text/event-stream",
-        },
+        headers: initHeaders,
         body: JSON.stringify(body),
       });
 
@@ -316,6 +323,7 @@ export class MCPClient {
       const headers: Record<string, string> = {
         "Content-Type": "application/json",
         Accept: "application/json, text/event-stream",
+        ...(this.authToken ? { Authorization: `Bearer ${this.authToken}` } : {}),
         ...(options?.headers || {}),
       };
 

--- a/modules/vm-webrtc/src/mcp_client/extensions.ts
+++ b/modules/vm-webrtc/src/mcp_client/extensions.ts
@@ -1,0 +1,122 @@
+import { log } from "../../../../lib/logger";
+
+export interface McpProbeResult {
+  success: boolean;
+  statusCode: number;
+  wwwAuthenticate: string | null;
+  resourceMetadataUrl: string | null;
+  responseBodySnippet: string | null;
+  responseHeaders: Record<string, string>;
+  error?: string;
+}
+
+const MCP_INITIALIZE_BODY = JSON.stringify({
+  jsonrpc: "2.0",
+  method: "initialize",
+  params: {
+    protocolVersion: "2024-11-05",
+    capabilities: {},
+    clientInfo: { name: "arty", version: "1.0.0" },
+  },
+  id: 1,
+});
+
+export async function probeMcpServer(
+  serverUrl: string,
+  bearerToken?: string,
+  connectorName?: string
+): Promise<McpProbeResult> {
+  const headers: Record<string, string> = {
+    "Content-Type": "application/json",
+    Accept: "application/json, text/event-stream",
+  };
+  if (bearerToken) {
+    headers["Authorization"] = `Bearer ${bearerToken}`;
+  }
+
+  log.info(
+    "[mcp_extensions] Step 1: sending request",
+    { allowSensitiveLogging: true },
+    {
+      connector_name: connectorName,
+      method: "POST",
+      server_url: serverUrl,
+      request_headers: headers,
+    }
+  );
+
+  let response: Response;
+  try {
+    response = await fetch(serverUrl, {
+      method: "POST",
+      headers,
+      body: MCP_INITIALIZE_BODY,
+    });
+  } catch (fetchError: any) {
+    log.error(
+      "[mcp_extensions] Step 1: network error",
+      {},
+      { connector_name: connectorName, server_url: serverUrl, error: fetchError?.message }
+    );
+    return {
+      success: false,
+      statusCode: 0,
+      wwwAuthenticate: null,
+      resourceMetadataUrl: null,
+      responseBodySnippet: null,
+      responseHeaders: {},
+      error: fetchError?.message ?? "Network error",
+    };
+  }
+
+  const responseHeaders: Record<string, string> = {};
+  response.headers.forEach((value, key) => {
+    responseHeaders[key] = value;
+  });
+
+  let responseBodySnippet: string | null = null;
+  try {
+    responseBodySnippet = (await response.text()).slice(0, 500);
+  } catch {
+    responseBodySnippet = null;
+  }
+
+  const wwwAuthenticate = responseHeaders["www-authenticate"] ?? null;
+  let resourceMetadataUrl: string | null = null;
+  if (wwwAuthenticate) {
+    const match = wwwAuthenticate.match(/resource_metadata="([^"]+)"/);
+    if (match) resourceMetadataUrl = match[1];
+  }
+
+  const result: McpProbeResult = {
+    success: response.status === 200,
+    statusCode: response.status,
+    wwwAuthenticate,
+    resourceMetadataUrl,
+    responseBodySnippet,
+    responseHeaders,
+  };
+
+  const logLevel = response.status === 401 ? "info" : response.status === 200 ? "info" : "warn";
+  const logMessage =
+    response.status === 401
+      ? "[mcp_extensions] Step 1: got 401 — server requires auth"
+      : "[mcp_extensions] Step 1: server responded";
+
+  log[logLevel](
+    logMessage,
+    { allowSensitiveLogging: true },
+    {
+      connector_name: connectorName,
+      server_url: serverUrl,
+      status_code: response.status,
+      status_text: response.statusText,
+      response_headers: responseHeaders,
+      response_body_snippet: responseBodySnippet,
+      www_authenticate: wwwAuthenticate,
+      resource_metadata_url: resourceMetadataUrl,
+    }
+  );
+
+  return result;
+}

--- a/modules/vm-webrtc/src/mcp_client/extensions.ts
+++ b/modules/vm-webrtc/src/mcp_client/extensions.ts
@@ -34,14 +34,19 @@ export async function probeMcpServer(
     headers["Authorization"] = `Bearer ${bearerToken}`;
   }
 
+  const sanitizedHeaders = Object.fromEntries(
+    Object.entries(headers).map(([k, v]) =>
+      k.toLowerCase() === "authorization" ? [k, "[REDACTED]"] : [k, v]
+    )
+  );
   log.info(
     "[mcp_extensions] Step 1: sending request",
-    { allowSensitiveLogging: true },
+    {},
     {
       connector_name: connectorName,
       method: "POST",
       server_url: serverUrl,
-      request_headers: headers,
+      request_headers: sanitizedHeaders,
     }
   );
 

--- a/wizard.ts
+++ b/wizard.ts
@@ -183,6 +183,12 @@ const BUILD_OPTIONS: BuildOption[] = [
     command: "eas build --platform ios --profile production --non-interactive && eas submit --platform ios",
     description: "Build and submit iOS app to App Store",
   },
+  {
+    name: "Open in Xcode",
+    flag: "open-xcode",
+    command: "xed ios",
+    description: "Open iOS project in Xcode",
+  },
 ];
 
 async function executeCommand(command: string): Promise<number> {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Add full MCP Extensions flow: Extensions list screen, extension detail screen, and an Add/Edit connector modal with bearer-token support, copy/paste and show/hide token UX, enable/disable, connect/test, and remove actions.
  * Integrates user MCP extensions into available tools and build wizard adds an Xcode launcher option.
  * Menu now shows a distinct "Extensions (MCP)" entry.

* **Documentation**
  * New MCP OAuth plan and MCP extension detail docs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->