### PR TITLE
MCP OAuth sequence - full auth sequence, including dynamic client registration

### DIFF
--- a/app/index.tsx
+++ b/app/index.tsx
@@ -1,6 +1,6 @@
 import { Camera } from "expo-camera";
 import { useCallback, useEffect, useState } from "react";
-import { Alert, AppState, Platform, StyleSheet, Text, View } from "react-native";
+import { Alert, AppState, Linking, Platform, StyleSheet, Text, View } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
 
 import { AdvancedConfigurationSheet } from "../components/settings/AdvancedConfigurationSheet";
@@ -137,6 +137,16 @@ export default function Index() {
   useEffect(() => {
     const sub = AppState.addEventListener("change", (nextState) => {
       log.info("[app] AppState change", {}, { nextState });
+    });
+    return () => sub.remove();
+  }, []);
+
+  useEffect(() => {
+    Linking.getInitialURL().then((url) => {
+      log.info("[app] Linking.getInitialURL", {}, { url });
+    });
+    const sub = Linking.addEventListener("url", ({ url }) => {
+      log.info("[app] Linking url received", {}, { url });
     });
     return () => sub.remove();
   }, []);

--- a/app/index.tsx
+++ b/app/index.tsx
@@ -41,7 +41,18 @@ import {
 } from "../lib/languagePreference";
 import { log } from "../lib/logger";
 import { loadMainPromptAddition } from "../lib/mainPrompt";
-import { getApiKey } from "../lib/secure-storage";
+import {
+  completeMcpOAuthFromCallbackUrl,
+  type McpOAuthPendingState,
+} from "../lib/mcp-oauth";
+import {
+  addMcpExtension,
+  clearMcpPendingOAuthSession,
+  getApiKey,
+  getMcpPendingOAuthSession,
+} from "../lib/secure-storage";
+import { DeviceEventEmitter } from "react-native";
+import { CONNECTOR_SETTINGS_CHANGED_EVENT } from "../modules/vm-webrtc/src/ToolkitManager";
 import {
   DEFAULT_TRANSCRIPTION_ENABLED,
   loadTranscriptionPreference,
@@ -142,12 +153,54 @@ export default function Index() {
   }, []);
 
   useEffect(() => {
+    const handleIncomingUrl = async (url: string) => {
+      log.info("[app] Linking url received", {}, { url });
+
+      if (!url.startsWith("vibemachine://mcp-oauth-callback")) return;
+
+      const params = new URLSearchParams(url.split("?")[1] ?? "");
+      const code = params.get("code");
+      if (!code) {
+        log.warn("[app] Linking: mcp-oauth-callback URL has no code param", {}, { url });
+        return;
+      }
+
+      const raw = await getMcpPendingOAuthSession();
+      if (!raw) {
+        log.warn("[app] Linking: no pending OAuth session found in storage");
+        return;
+      }
+
+      const pending = raw as McpOAuthPendingState;
+      log.info("[app] Linking: completing OAuth for extension", {}, {
+        extensionId: pending.extensionId,
+        extensionName: pending.extensionName,
+      });
+
+      try {
+        await completeMcpOAuthFromCallbackUrl(url, pending);
+        await addMcpExtension({
+          id: pending.extensionId,
+          name: pending.extensionName,
+          normalizedName: pending.extensionNormalizedName,
+          serverUrl: pending.extensionServerUrl,
+        });
+        DeviceEventEmitter.emit(CONNECTOR_SETTINGS_CHANGED_EVENT);
+        await clearMcpPendingOAuthSession();
+        log.info("[app] Linking: extension registered successfully", {}, { extensionName: pending.extensionName });
+        Alert.alert("Signed in successfully", `${pending.extensionName} is now connected.`);
+      } catch (err: any) {
+        log.error("[app] Linking: OAuth completion failed", {}, { message: err?.message });
+        Alert.alert("Sign-in failed", err?.message ?? "Could not complete authentication.");
+      }
+    };
+
     Linking.getInitialURL().then((url) => {
       log.info("[app] Linking.getInitialURL", {}, { url });
+      if (url) handleIncomingUrl(url);
     });
-    const sub = Linking.addEventListener("url", ({ url }) => {
-      log.info("[app] Linking url received", {}, { url });
-    });
+
+    const sub = Linking.addEventListener("url", ({ url }) => handleIncomingUrl(url));
     return () => sub.remove();
   }, []);
 

--- a/app/index.tsx
+++ b/app/index.tsx
@@ -178,17 +178,22 @@ export default function Index() {
       });
 
       try {
+        log.info("[app] Linking: calling completeMcpOAuthFromCallbackUrl");
         await completeMcpOAuthFromCallbackUrl(url, pending);
+        log.info("[app] Linking: token exchange complete, saving extension record");
         await addMcpExtension({
           id: pending.extensionId,
           name: pending.extensionName,
           normalizedName: pending.extensionNormalizedName,
           serverUrl: pending.extensionServerUrl,
         });
-        DeviceEventEmitter.emit(CONNECTOR_SETTINGS_CHANGED_EVENT);
+        log.info("[app] Linking: extension record saved, clearing pending session");
         await clearMcpPendingOAuthSession();
+        log.info("[app] Linking: emitting CONNECTOR_SETTINGS_CHANGED_EVENT");
+        DeviceEventEmitter.emit(CONNECTOR_SETTINGS_CHANGED_EVENT);
         log.info("[app] Linking: extension registered successfully", {}, { extensionName: pending.extensionName });
         Alert.alert("Signed in successfully", `${pending.extensionName} is now connected.`);
+        log.info("[app] Linking: Alert shown");
       } catch (err: any) {
         log.error("[app] Linking: OAuth completion failed", {}, { message: err?.message });
         Alert.alert("Sign-in failed", err?.message ?? "Could not complete authentication.");

--- a/app/index.tsx
+++ b/app/index.tsx
@@ -1,6 +1,6 @@
 import { Camera } from "expo-camera";
 import { useCallback, useEffect, useState } from "react";
-import { Alert, Platform, StyleSheet, Text, View } from "react-native";
+import { Alert, AppState, Platform, StyleSheet, Text, View } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
 
 import { AdvancedConfigurationSheet } from "../components/settings/AdvancedConfigurationSheet";
@@ -133,6 +133,17 @@ export default function Index() {
   const [onboardingVisible, setOnboardingVisible] = useState(false);
   const [onboardingCheckToken, setOnboardingCheckToken] = useState(0);
   const [onboardingCompletionToken, setOnboardingCompletionToken] = useState(0);
+
+  useEffect(() => {
+    const sub = AppState.addEventListener("change", (nextState) => {
+      log.info("[app] AppState change", {}, { nextState });
+    });
+    return () => sub.remove();
+  }, []);
+
+  useEffect(() => {
+    log.info("[app] mcpExtensionsVisible changed", {}, { mcpExtensionsVisible });
+  }, [mcpExtensionsVisible]);
 
   // Load connection options on mount and when API key config screen closes
   useEffect(() => {

--- a/app/index.tsx
+++ b/app/index.tsx
@@ -1,6 +1,6 @@
 import { Camera } from "expo-camera";
 import { useCallback, useEffect, useState } from "react";
-import { Alert, AppState, Linking, Platform, StyleSheet, Text, View } from "react-native";
+import { Alert, AppState, Platform, StyleSheet, Text, View } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
 
 import { AdvancedConfigurationSheet } from "../components/settings/AdvancedConfigurationSheet";
@@ -41,18 +41,7 @@ import {
 } from "../lib/languagePreference";
 import { log } from "../lib/logger";
 import { loadMainPromptAddition } from "../lib/mainPrompt";
-import {
-  completeMcpOAuthFromCallbackUrl,
-  type McpOAuthPendingState,
-} from "../lib/mcp-oauth";
-import {
-  addMcpExtension,
-  clearMcpPendingOAuthSession,
-  getApiKey,
-  getMcpPendingOAuthSession,
-} from "../lib/secure-storage";
-import { DeviceEventEmitter } from "react-native";
-import { CONNECTOR_SETTINGS_CHANGED_EVENT } from "../modules/vm-webrtc/src/ToolkitManager";
+import { getApiKey } from "../lib/secure-storage";
 import {
   DEFAULT_TRANSCRIPTION_ENABLED,
   loadTranscriptionPreference,
@@ -149,63 +138,6 @@ export default function Index() {
     const sub = AppState.addEventListener("change", (nextState) => {
       log.info("[app] AppState change", {}, { nextState });
     });
-    return () => sub.remove();
-  }, []);
-
-  useEffect(() => {
-    const handleIncomingUrl = async (url: string) => {
-      log.info("[app] Linking url received", {}, { url });
-
-      if (!url.startsWith("vibemachine://mcp-oauth-callback")) return;
-
-      const params = new URLSearchParams(url.split("?")[1] ?? "");
-      const code = params.get("code");
-      if (!code) {
-        log.warn("[app] Linking: mcp-oauth-callback URL has no code param", {}, { url });
-        return;
-      }
-
-      const raw = await getMcpPendingOAuthSession();
-      if (!raw) {
-        log.warn("[app] Linking: no pending OAuth session found in storage");
-        return;
-      }
-
-      const pending = raw as McpOAuthPendingState;
-      log.info("[app] Linking: completing OAuth for extension", {}, {
-        extensionId: pending.extensionId,
-        extensionName: pending.extensionName,
-      });
-
-      try {
-        log.info("[app] Linking: calling completeMcpOAuthFromCallbackUrl");
-        await completeMcpOAuthFromCallbackUrl(url, pending);
-        log.info("[app] Linking: token exchange complete, saving extension record");
-        await addMcpExtension({
-          id: pending.extensionId,
-          name: pending.extensionName,
-          normalizedName: pending.extensionNormalizedName,
-          serverUrl: pending.extensionServerUrl,
-        });
-        log.info("[app] Linking: extension record saved, clearing pending session");
-        await clearMcpPendingOAuthSession();
-        log.info("[app] Linking: emitting CONNECTOR_SETTINGS_CHANGED_EVENT");
-        DeviceEventEmitter.emit(CONNECTOR_SETTINGS_CHANGED_EVENT);
-        log.info("[app] Linking: extension registered successfully", {}, { extensionName: pending.extensionName });
-        Alert.alert("Signed in successfully", `${pending.extensionName} is now connected.`);
-        log.info("[app] Linking: Alert shown");
-      } catch (err: any) {
-        log.error("[app] Linking: OAuth completion failed", {}, { message: err?.message });
-        Alert.alert("Sign-in failed", err?.message ?? "Could not complete authentication.");
-      }
-    };
-
-    Linking.getInitialURL().then((url) => {
-      log.info("[app] Linking.getInitialURL", {}, { url });
-      if (url) handleIncomingUrl(url);
-    });
-
-    const sub = Linking.addEventListener("url", ({ url }) => handleIncomingUrl(url));
     return () => sub.remove();
   }, []);
 
@@ -689,6 +621,11 @@ export default function Index() {
       <McpExtensionsScreen
         visible={mcpExtensionsVisible}
         onClose={() => setMcpExtensionsVisible(false)}
+        onBeforeBrowserOpen={() => {
+          setMcpExtensionsVisible(false);
+          setMenuVisible(false);
+        }}
+        onNeedsManualCallback={() => setMcpExtensionsVisible(true)}
       />
       <ConfigureApiKeyScreen
         visible={apiKeyConfigVisible}

--- a/components/settings/McpConnectorConfig.tsx
+++ b/components/settings/McpConnectorConfig.tsx
@@ -25,7 +25,11 @@ import {
   uniqueNormalizedName,
   type McpExtensionRecord,
 } from "../../lib/secure-storage";
-import { performMcpOAuthFlow } from "../../lib/mcp-oauth";
+import {
+  completeMcpOAuthFromCallbackUrl,
+  performMcpOAuthFlow,
+  type McpOAuthPendingState,
+} from "../../lib/mcp-oauth";
 import { CONNECTOR_SETTINGS_CHANGED_EVENT } from "../../modules/vm-webrtc/src/ToolkitManager";
 
 export interface McpConnectorConfigProps {
@@ -53,6 +57,10 @@ export const McpConnectorConfig: React.FC<McpConnectorConfigProps> = ({
   const [tokenVisible, setTokenVisible] = useState(false);
   const [copyFeedback, setCopyFeedback] = useState(false);
   const [hasOAuthToken, setHasOAuthToken] = useState(false);
+  const [pendingOAuth, setPendingOAuth] = useState<McpOAuthPendingState | null>(null);
+  const [pendingExtensionId, setPendingExtensionId] = useState<string | null>(null);
+  const [callbackUrl, setCallbackUrl] = useState("");
+  const [callbackError, setCallbackError] = useState("");
 
   useEffect(() => {
     if (visible && existingExtension) {
@@ -128,8 +136,13 @@ export const McpConnectorConfig: React.FC<McpConnectorConfigProps> = ({
         const id = existingExtension?.id ?? `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
         setConnectingLabel("Opening sign-in…");
         try {
-          await performMcpOAuthFlow(id, result.resourceMetadataUrl, name);
-          await persistExtension(id);
+          const oauthResult = await performMcpOAuthFlow(id, result.resourceMetadataUrl, name);
+          if (oauthResult.type === "success") {
+            await persistExtension(id);
+          } else {
+            setPendingOAuth(oauthResult.pendingState);
+            setPendingExtensionId(id);
+          }
         } catch (oauthError: any) {
           Alert.alert(
             "Authentication Failed",
@@ -153,6 +166,22 @@ export const McpConnectorConfig: React.FC<McpConnectorConfigProps> = ({
     }
   };
 
+  const handleCompleteOAuth = async () => {
+    if (!pendingOAuth || !pendingExtensionId) return;
+    setCallbackError("");
+    setIsConnecting(true);
+    setConnectingLabel("Completing sign-in…");
+    try {
+      await completeMcpOAuthFromCallbackUrl(callbackUrl.trim(), pendingOAuth);
+      await persistExtension(pendingExtensionId);
+    } catch (err: any) {
+      setCallbackError(err?.message ?? "Failed to complete sign-in. Check the URL and try again.");
+    } finally {
+      setIsConnecting(false);
+      setConnectingLabel("Connecting…");
+    }
+  };
+
   const resetAndClose = () => {
     setName("");
     setServerUrl("");
@@ -161,6 +190,10 @@ export const McpConnectorConfig: React.FC<McpConnectorConfigProps> = ({
     setAdvancedExpanded(false);
     setTokenVisible(false);
     setHasOAuthToken(false);
+    setPendingOAuth(null);
+    setPendingExtensionId(null);
+    setCallbackUrl("");
+    setCallbackError("");
     onClose();
   };
 
@@ -186,123 +219,166 @@ export const McpConnectorConfig: React.FC<McpConnectorConfigProps> = ({
           contentContainerStyle={styles.scrollContent}
           keyboardShouldPersistTaps="handled"
         >
-          <View style={styles.section}>
-            <Text style={styles.label}>Name</Text>
-            <TextInput
-              style={styles.input}
-              value={name}
-              onChangeText={(v) => {
-                setName(v);
-                setNormalizedNamePreview(toNormalizedName(v));
-              }}
-              placeholder="Enter extension name..."
-              placeholderTextColor="#AEAEB2"
-              autoCapitalize="none"
-              autoCorrect={false}
-            />
-            {normalizedNamePreview ? (
-              <Text style={styles.hint}>
-                ID: <Text style={styles.hintMono}>{normalizedNamePreview}</Text>
+          {pendingOAuth ? (
+            <View style={styles.callbackSection}>
+              <Text style={styles.callbackTitle}>Complete Sign-in</Text>
+              <Text style={styles.callbackBody}>
+                The browser closed before the redirect was received. Copy the callback URL shown in the browser (it starts with{" "}
+                <Text style={styles.hintMono}>vibemachine://mcp-oauth-callback</Text>
+                ) and paste it below.
               </Text>
-            ) : null}
-          </View>
-
-          <View style={styles.section}>
-            <Text style={styles.label}>MCP Server URL</Text>
-            <TextInput
-              style={styles.input}
-              value={serverUrl}
-              onChangeText={setServerUrl}
-              placeholder="https://..."
-              placeholderTextColor="#AEAEB2"
-              autoCapitalize="none"
-              autoCorrect={false}
-              keyboardType="url"
-            />
-            <Text style={styles.hint}>
-              Streamable HTTP endpoint for the MCP server
-            </Text>
-          </View>
-
-          {hasOAuthToken && (
-            <View style={styles.oauthBadge}>
-              <Text style={styles.oauthBadgeText}>Authenticated via OAuth</Text>
-              <Text style={styles.oauthBadgeHint}>
-                Tap {isEditing ? "Save" : "Add"} to re-authenticate
-              </Text>
+              <TextInput
+                style={[styles.input, styles.callbackInput]}
+                value={callbackUrl}
+                onChangeText={(v) => {
+                  setCallbackUrl(v);
+                  setCallbackError("");
+                }}
+                placeholder="vibemachine://mcp-oauth-callback?code=…"
+                placeholderTextColor="#AEAEB2"
+                autoCapitalize="none"
+                autoCorrect={false}
+                multiline
+              />
+              {callbackError ? (
+                <Text style={styles.callbackError}>{callbackError}</Text>
+              ) : null}
+              <Pressable
+                style={({ pressed }) => [
+                  styles.tryAgainButton,
+                  pressed && styles.tryAgainButtonPressed,
+                ]}
+                onPress={() => {
+                  setPendingOAuth(null);
+                  setPendingExtensionId(null);
+                  setCallbackUrl("");
+                  setCallbackError("");
+                }}
+              >
+                <Text style={styles.tryAgainText}>Open sign-in browser again</Text>
+              </Pressable>
             </View>
-          )}
-
-          <Pressable
-            style={styles.advancedToggle}
-            onPress={() => setAdvancedExpanded((v) => !v)}
-          >
-            <Text style={styles.advancedToggleText}>Advanced</Text>
-            <Text style={styles.advancedChevron}>
-              {advancedExpanded ? "▲" : "▼"}
-            </Text>
-          </Pressable>
-
-          {advancedExpanded && (
-            <View style={styles.advancedSection}>
-              <Text style={styles.label}>Bearer Token</Text>
-
-              <View style={styles.tokenInputRow}>
+          ) : (
+            <>
+              <View style={styles.section}>
+                <Text style={styles.label}>Name</Text>
                 <TextInput
-                  style={[styles.input, styles.tokenInput]}
-                  value={bearerToken}
-                  onChangeText={handleTokenChange}
-                  placeholder="Optional JWT or access token..."
+                  style={styles.input}
+                  value={name}
+                  onChangeText={(v) => {
+                    setName(v);
+                    setNormalizedNamePreview(toNormalizedName(v));
+                  }}
+                  placeholder="Enter extension name..."
                   placeholderTextColor="#AEAEB2"
                   autoCapitalize="none"
                   autoCorrect={false}
-                  secureTextEntry={!tokenVisible}
-                  multiline={false}
                 />
-                <Pressable
-                  style={({ pressed }) => [
-                    styles.tokenIconButton,
-                    pressed && styles.tokenIconButtonPressed,
-                  ]}
-                  onPress={() => setTokenVisible((v) => !v)}
-                >
-                  <Text style={styles.tokenIconText}>
-                    {tokenVisible ? "🙈" : "👁️"}
+                {normalizedNamePreview ? (
+                  <Text style={styles.hint}>
+                    ID: <Text style={styles.hintMono}>{normalizedNamePreview}</Text>
                   </Text>
-                </Pressable>
+                ) : null}
               </View>
 
-              <View style={styles.tokenActions}>
-                <Pressable
-                  style={({ pressed }) => [
-                    styles.tokenActionButton,
-                    pressed && styles.tokenActionButtonPressed,
-                  ]}
-                  onPress={handlePaste}
-                >
-                  <Text style={styles.tokenActionText}>Paste</Text>
-                </Pressable>
-                <Pressable
-                  style={({ pressed }) => [
-                    styles.tokenActionButton,
-                    !bearerToken && styles.tokenActionButtonDisabled,
-                    pressed && styles.tokenActionButtonPressed,
-                  ]}
-                  onPress={handleCopy}
-                  disabled={!bearerToken}
-                >
-                  <Text style={styles.tokenActionText}>
-                    {copyFeedback ? "Copied!" : "Copy"}
-                  </Text>
-                </Pressable>
+              <View style={styles.section}>
+                <Text style={styles.label}>MCP Server URL</Text>
+                <TextInput
+                  style={styles.input}
+                  value={serverUrl}
+                  onChangeText={setServerUrl}
+                  placeholder="https://..."
+                  placeholderTextColor="#AEAEB2"
+                  autoCapitalize="none"
+                  autoCorrect={false}
+                  keyboardType="url"
+                />
+                <Text style={styles.hint}>
+                  Streamable HTTP endpoint for the MCP server
+                </Text>
               </View>
 
-              <Text style={styles.hint}>
-                Sent as{" "}
-                <Text style={styles.hintMono}>Authorization: Bearer …</Text> on
-                every request. Newlines are stripped automatically.
-              </Text>
-            </View>
+              {hasOAuthToken && (
+                <View style={styles.oauthBadge}>
+                  <Text style={styles.oauthBadgeText}>Authenticated via OAuth</Text>
+                  <Text style={styles.oauthBadgeHint}>
+                    Tap {isEditing ? "Save" : "Add"} to re-authenticate
+                  </Text>
+                </View>
+              )}
+
+              <Pressable
+                style={styles.advancedToggle}
+                onPress={() => setAdvancedExpanded((v) => !v)}
+              >
+                <Text style={styles.advancedToggleText}>Advanced</Text>
+                <Text style={styles.advancedChevron}>
+                  {advancedExpanded ? "▲" : "▼"}
+                </Text>
+              </Pressable>
+
+              {advancedExpanded && (
+                <View style={styles.advancedSection}>
+                  <Text style={styles.label}>Bearer Token</Text>
+
+                  <View style={styles.tokenInputRow}>
+                    <TextInput
+                      style={[styles.input, styles.tokenInput]}
+                      value={bearerToken}
+                      onChangeText={handleTokenChange}
+                      placeholder="Optional JWT or access token..."
+                      placeholderTextColor="#AEAEB2"
+                      autoCapitalize="none"
+                      autoCorrect={false}
+                      secureTextEntry={!tokenVisible}
+                      multiline={false}
+                    />
+                    <Pressable
+                      style={({ pressed }) => [
+                        styles.tokenIconButton,
+                        pressed && styles.tokenIconButtonPressed,
+                      ]}
+                      onPress={() => setTokenVisible((v) => !v)}
+                    >
+                      <Text style={styles.tokenIconText}>
+                        {tokenVisible ? "🙈" : "👁️"}
+                      </Text>
+                    </Pressable>
+                  </View>
+
+                  <View style={styles.tokenActions}>
+                    <Pressable
+                      style={({ pressed }) => [
+                        styles.tokenActionButton,
+                        pressed && styles.tokenActionButtonPressed,
+                      ]}
+                      onPress={handlePaste}
+                    >
+                      <Text style={styles.tokenActionText}>Paste</Text>
+                    </Pressable>
+                    <Pressable
+                      style={({ pressed }) => [
+                        styles.tokenActionButton,
+                        !bearerToken && styles.tokenActionButtonDisabled,
+                        pressed && styles.tokenActionButtonPressed,
+                      ]}
+                      onPress={handleCopy}
+                      disabled={!bearerToken}
+                    >
+                      <Text style={styles.tokenActionText}>
+                        {copyFeedback ? "Copied!" : "Copy"}
+                      </Text>
+                    </Pressable>
+                  </View>
+
+                  <Text style={styles.hint}>
+                    Sent as{" "}
+                    <Text style={styles.hintMono}>Authorization: Bearer …</Text> on
+                    every request. Newlines are stripped automatically.
+                  </Text>
+                </View>
+              )}
+            </>
           )}
         </ScrollView>
 
@@ -317,24 +393,45 @@ export const McpConnectorConfig: React.FC<McpConnectorConfigProps> = ({
             <Text style={styles.cancelButtonText}>Cancel</Text>
           </Pressable>
 
-          <Pressable
-            style={({ pressed }) => [
-              styles.connectButton,
-              (!name.trim() || !serverUrl.trim() || isConnecting) && styles.connectButtonDisabled,
-              pressed && styles.connectButtonPressed,
-            ]}
-            onPress={handleSave}
-            disabled={!name.trim() || !serverUrl.trim() || isConnecting}
-          >
-            {isConnecting ? (
-              <View style={styles.connectingRow}>
-                <ActivityIndicator color="#FFFFFF" size="small" />
-                <Text style={styles.connectingLabel}>{connectingLabel}</Text>
-              </View>
-            ) : (
-              <Text style={styles.connectButtonText}>{isEditing ? "Save" : "Add"}</Text>
-            )}
-          </Pressable>
+          {pendingOAuth ? (
+            <Pressable
+              style={({ pressed }) => [
+                styles.connectButton,
+                (!callbackUrl.trim() || isConnecting) && styles.connectButtonDisabled,
+                pressed && styles.connectButtonPressed,
+              ]}
+              onPress={handleCompleteOAuth}
+              disabled={!callbackUrl.trim() || isConnecting}
+            >
+              {isConnecting ? (
+                <View style={styles.connectingRow}>
+                  <ActivityIndicator color="#FFFFFF" size="small" />
+                  <Text style={styles.connectingLabel}>{connectingLabel}</Text>
+                </View>
+              ) : (
+                <Text style={styles.connectButtonText}>Complete Sign-in</Text>
+              )}
+            </Pressable>
+          ) : (
+            <Pressable
+              style={({ pressed }) => [
+                styles.connectButton,
+                (!name.trim() || !serverUrl.trim() || isConnecting) && styles.connectButtonDisabled,
+                pressed && styles.connectButtonPressed,
+              ]}
+              onPress={handleSave}
+              disabled={!name.trim() || !serverUrl.trim() || isConnecting}
+            >
+              {isConnecting ? (
+                <View style={styles.connectingRow}>
+                  <ActivityIndicator color="#FFFFFF" size="small" />
+                  <Text style={styles.connectingLabel}>{connectingLabel}</Text>
+                </View>
+              ) : (
+                <Text style={styles.connectButtonText}>{isEditing ? "Save" : "Add"}</Text>
+              )}
+            </Pressable>
+          )}
         </View>
       </KeyboardAvoidingView>
     </Modal>
@@ -533,5 +630,42 @@ const styles = StyleSheet.create({
     fontSize: 12,
     color: "#4CAF50",
     marginTop: 2,
+  },
+  callbackSection: {
+    gap: 14,
+  },
+  callbackTitle: {
+    fontSize: 17,
+    fontWeight: "700",
+    color: "#1C1C1E",
+  },
+  callbackBody: {
+    fontSize: 14,
+    color: "#636366",
+    lineHeight: 20,
+  },
+  callbackInput: {
+    minHeight: 80,
+    textAlignVertical: "top",
+    paddingTop: 12,
+    fontFamily: Platform.OS === "ios" ? "Menlo" : "monospace",
+    fontSize: 13,
+  },
+  callbackError: {
+    fontSize: 13,
+    color: "#FF3B30",
+    lineHeight: 18,
+  },
+  tryAgainButton: {
+    alignSelf: "flex-start",
+    paddingVertical: 6,
+  },
+  tryAgainButtonPressed: {
+    opacity: 0.5,
+  },
+  tryAgainText: {
+    fontSize: 14,
+    fontWeight: "600",
+    color: "#0A84FF",
   },
 });

--- a/components/settings/McpConnectorConfig.tsx
+++ b/components/settings/McpConnectorConfig.tsx
@@ -17,6 +17,7 @@ import * as Clipboard from "expo-clipboard";
 import { probeMcpServer } from "../../modules/vm-webrtc/src/mcp_client/extensions";
 import {
   addMcpExtension,
+  deleteMcpBearerToken,
   getMcpBearerToken,
   getMcpExtensions,
   getMcpRefreshToken,
@@ -102,13 +103,19 @@ export const McpConnectorConfig: React.FC<McpConnectorConfigProps> = ({
     setTimeout(() => setCopyFeedback(false), 1500);
   };
 
-  const persistExtension = async (id: string, manualToken?: string) => {
+  const persistExtension = async (
+    id: string,
+    manualToken?: string,
+    options?: { preserveExistingToken?: boolean },
+  ) => {
     const allExtensions = await getMcpExtensions();
     const normalizedName = uniqueNormalizedName(toNormalizedName(name), allExtensions, existingExtension?.id);
     const record: McpExtensionRecord = { id, name, normalizedName, serverUrl };
     await addMcpExtension(record);
     if (manualToken) {
       await saveMcpBearerToken(id, manualToken);
+    } else if (!options?.preserveExistingToken) {
+      await deleteMcpBearerToken(id);
     }
     DeviceEventEmitter.emit(CONNECTOR_SETTINGS_CHANGED_EVENT);
     onSave?.(record);
@@ -138,7 +145,7 @@ export const McpConnectorConfig: React.FC<McpConnectorConfigProps> = ({
         try {
           const oauthResult = await performMcpOAuthFlow(id, result.resourceMetadataUrl, name);
           if (oauthResult.type === "success") {
-            await persistExtension(id);
+            await persistExtension(id, undefined, { preserveExistingToken: true });
           } else {
             setPendingOAuth(oauthResult.pendingState);
             setPendingExtensionId(id);
@@ -173,7 +180,7 @@ export const McpConnectorConfig: React.FC<McpConnectorConfigProps> = ({
     setConnectingLabel("Completing sign-in…");
     try {
       await completeMcpOAuthFromCallbackUrl(callbackUrl.trim(), pendingOAuth);
-      await persistExtension(pendingExtensionId);
+      await persistExtension(pendingExtensionId, undefined, { preserveExistingToken: true });
     } catch (err: any) {
       setCallbackError(err?.message ?? "Failed to complete sign-in. Check the URL and try again.");
     } finally {

--- a/components/settings/McpConnectorConfig.tsx
+++ b/components/settings/McpConnectorConfig.tsx
@@ -19,11 +19,13 @@ import {
   addMcpExtension,
   getMcpBearerToken,
   getMcpExtensions,
+  getMcpRefreshToken,
   saveMcpBearerToken,
   toNormalizedName,
   uniqueNormalizedName,
   type McpExtensionRecord,
 } from "../../lib/secure-storage";
+import { performMcpOAuthFlow } from "../../lib/mcp-oauth";
 import { CONNECTOR_SETTINGS_CHANGED_EVENT } from "../../modules/vm-webrtc/src/ToolkitManager";
 
 export interface McpConnectorConfigProps {
@@ -47,22 +49,30 @@ export const McpConnectorConfig: React.FC<McpConnectorConfigProps> = ({
   const [normalizedNamePreview, setNormalizedNamePreview] = useState("");
   const [advancedExpanded, setAdvancedExpanded] = useState(false);
   const [isConnecting, setIsConnecting] = useState(false);
+  const [connectingLabel, setConnectingLabel] = useState("Connecting…");
   const [tokenVisible, setTokenVisible] = useState(false);
   const [copyFeedback, setCopyFeedback] = useState(false);
+  const [hasOAuthToken, setHasOAuthToken] = useState(false);
 
   useEffect(() => {
     if (visible && existingExtension) {
       setName(existingExtension.name);
       setServerUrl(existingExtension.serverUrl);
       setNormalizedNamePreview(existingExtension.normalizedName ?? toNormalizedName(existingExtension.name));
-      getMcpBearerToken(existingExtension.id).then((token) => {
-        if (token) {
+      Promise.all([
+        getMcpBearerToken(existingExtension.id),
+        getMcpRefreshToken(existingExtension.id),
+      ]).then(([token, refreshToken]) => {
+        if (refreshToken) {
+          setHasOAuthToken(true);
+        } else if (token) {
           setBearerToken(token);
           setAdvancedExpanded(true);
         }
       });
     } else if (visible) {
       setNormalizedNamePreview("");
+      setHasOAuthToken(false);
     }
   }, [visible, existingExtension]);
 
@@ -84,30 +94,54 @@ export const McpConnectorConfig: React.FC<McpConnectorConfigProps> = ({
     setTimeout(() => setCopyFeedback(false), 1500);
   };
 
+  const persistExtension = async (id: string, manualToken?: string) => {
+    const allExtensions = await getMcpExtensions();
+    const normalizedName = uniqueNormalizedName(toNormalizedName(name), allExtensions, existingExtension?.id);
+    const record: McpExtensionRecord = { id, name, normalizedName, serverUrl };
+    await addMcpExtension(record);
+    if (manualToken) {
+      await saveMcpBearerToken(id, manualToken);
+    }
+    DeviceEventEmitter.emit(CONNECTOR_SETTINGS_CHANGED_EVENT);
+    onSave?.(record);
+    resetAndClose();
+    Alert.alert(
+      isEditing ? "Saved" : "Connected Successfully",
+      isEditing
+        ? "Extension updated."
+        : "Extension added. You can update its config anytime from the Extensions (MCP) screen.",
+      [{ text: "OK" }],
+    );
+  };
+
   const handleSave = async () => {
     setIsConnecting(true);
+    setConnectingLabel("Connecting…");
     try {
       const token = bearerToken.trim() || undefined;
       const result = await probeMcpServer(serverUrl, token, name);
 
       if (result.success) {
         const id = existingExtension?.id ?? `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
-        const allExtensions = await getMcpExtensions();
-        const normalizedName = uniqueNormalizedName(toNormalizedName(name), allExtensions, existingExtension?.id);
-        const record: McpExtensionRecord = { id, name, normalizedName, serverUrl };
-        await addMcpExtension(record);
-        if (token) {
-          await saveMcpBearerToken(id, token);
+        await persistExtension(id, token);
+      } else if (result.statusCode === 401 && result.resourceMetadataUrl) {
+        const id = existingExtension?.id ?? `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+        setConnectingLabel("Opening sign-in…");
+        try {
+          await performMcpOAuthFlow(id, result.resourceMetadataUrl, name);
+          await persistExtension(id);
+        } catch (oauthError: any) {
+          Alert.alert(
+            "Authentication Failed",
+            oauthError?.message ?? "OAuth sign-in failed.",
+            [{ text: "OK" }],
+          );
         }
-        DeviceEventEmitter.emit(CONNECTOR_SETTINGS_CHANGED_EVENT);
-        onSave?.(record);
-        resetAndClose();
+      } else if (result.statusCode === 401) {
         Alert.alert(
-          isEditing ? "Saved" : "Connected Successfully",
-          isEditing
-            ? "Extension updated."
-            : "Extension added. You can update its config anytime from the Extensions (MCP) screen.",
-          [{ text: "OK" }]
+          "Authentication Required",
+          "This server requires a Bearer token. Enter it in the Advanced section.",
+          [{ text: "OK" }],
         );
       } else {
         const detail = result.error ?? `Server returned ${result.statusCode}`;
@@ -115,6 +149,7 @@ export const McpConnectorConfig: React.FC<McpConnectorConfigProps> = ({
       }
     } finally {
       setIsConnecting(false);
+      setConnectingLabel("Connecting…");
     }
   };
 
@@ -125,6 +160,7 @@ export const McpConnectorConfig: React.FC<McpConnectorConfigProps> = ({
     setNormalizedNamePreview("");
     setAdvancedExpanded(false);
     setTokenVisible(false);
+    setHasOAuthToken(false);
     onClose();
   };
 
@@ -187,6 +223,15 @@ export const McpConnectorConfig: React.FC<McpConnectorConfigProps> = ({
               Streamable HTTP endpoint for the MCP server
             </Text>
           </View>
+
+          {hasOAuthToken && (
+            <View style={styles.oauthBadge}>
+              <Text style={styles.oauthBadgeText}>Authenticated via OAuth</Text>
+              <Text style={styles.oauthBadgeHint}>
+                Tap {isEditing ? "Save" : "Add"} to re-authenticate
+              </Text>
+            </View>
+          )}
 
           <Pressable
             style={styles.advancedToggle}
@@ -282,7 +327,10 @@ export const McpConnectorConfig: React.FC<McpConnectorConfigProps> = ({
             disabled={!name.trim() || !serverUrl.trim() || isConnecting}
           >
             {isConnecting ? (
-              <ActivityIndicator color="#FFFFFF" size="small" />
+              <View style={styles.connectingRow}>
+                <ActivityIndicator color="#FFFFFF" size="small" />
+                <Text style={styles.connectingLabel}>{connectingLabel}</Text>
+              </View>
             ) : (
               <Text style={styles.connectButtonText}>{isEditing ? "Save" : "Add"}</Text>
             )}
@@ -458,5 +506,32 @@ const styles = StyleSheet.create({
     fontSize: 16,
     fontWeight: "600",
     color: "#FFFFFF",
+  },
+  connectingRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 8,
+  },
+  connectingLabel: {
+    fontSize: 14,
+    fontWeight: "600",
+    color: "#FFFFFF",
+  },
+  oauthBadge: {
+    backgroundColor: "#E8F5E9",
+    borderRadius: 10,
+    paddingHorizontal: 14,
+    paddingVertical: 10,
+    marginBottom: 16,
+  },
+  oauthBadgeText: {
+    fontSize: 14,
+    fontWeight: "600",
+    color: "#2E7D32",
+  },
+  oauthBadgeHint: {
+    fontSize: 12,
+    color: "#4CAF50",
+    marginTop: 2,
   },
 });

--- a/components/settings/McpConnectorConfig.tsx
+++ b/components/settings/McpConnectorConfig.tsx
@@ -32,6 +32,7 @@ import {
   type McpOAuthPendingState,
 } from "../../lib/mcp-oauth";
 import { CONNECTOR_SETTINGS_CHANGED_EVENT } from "../../modules/vm-webrtc/src/ToolkitManager";
+import { log } from "../../lib/logger";
 
 export interface McpConnectorConfigProps {
   visible: boolean;
@@ -87,6 +88,10 @@ export const McpConnectorConfig: React.FC<McpConnectorConfigProps> = ({
   }, [visible, existingExtension]);
 
   useEffect(() => {
+    log.info("[mcp_connector] visible changed", {}, { visible });
+  }, [visible]);
+
+  useEffect(() => {
     const showEvent = Platform.OS === "ios" ? "keyboardWillShow" : "keyboardDidShow";
     const hideEvent = Platform.OS === "ios" ? "keyboardWillHide" : "keyboardDidHide";
     const show = Keyboard.addListener(showEvent, (e) => setKeyboardPadding(e.endCoordinates.height));
@@ -120,6 +125,7 @@ export const McpConnectorConfig: React.FC<McpConnectorConfigProps> = ({
     manualToken?: string,
     options?: { preserveExistingToken?: boolean },
   ) => {
+    log.info("[mcp_connector] persistExtension start", {}, { id, isEditing, hasManualToken: !!manualToken, preserveExistingToken: options?.preserveExistingToken });
     const allExtensions = await getMcpExtensions();
     const normalizedName = uniqueNormalizedName(toNormalizedName(name), allExtensions, existingExtension?.id);
     const record: McpExtensionRecord = { id, name, normalizedName, serverUrl };
@@ -130,7 +136,9 @@ export const McpConnectorConfig: React.FC<McpConnectorConfigProps> = ({
       await deleteMcpBearerToken(id);
     }
     DeviceEventEmitter.emit(CONNECTOR_SETTINGS_CHANGED_EVENT);
+    log.info("[mcp_connector] calling onSave", {}, { id });
     onSave?.(record);
+    log.info("[mcp_connector] calling resetAndClose", {}, { id });
     resetAndClose();
     Alert.alert(
       isEditing ? "Saved" : "Connected Successfully",
@@ -154,8 +162,10 @@ export const McpConnectorConfig: React.FC<McpConnectorConfigProps> = ({
       } else if (result.statusCode === 401 && result.resourceMetadataUrl) {
         const id = existingExtension?.id ?? `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
         setConnectingLabel("Opening sign-in…");
+        log.info("[mcp_connector] entering OAuth branch", {}, { id, serverUrl, resourceMetadataUrl: result.resourceMetadataUrl });
         try {
           const oauthResult = await performMcpOAuthFlow(id, result.resourceMetadataUrl, name);
+          log.info("[mcp_connector] OAuth flow returned", {}, { oauthResult_type: oauthResult.type });
           if (oauthResult.type === "success") {
             await persistExtension(id, undefined, { preserveExistingToken: true });
           } else {
@@ -180,6 +190,7 @@ export const McpConnectorConfig: React.FC<McpConnectorConfigProps> = ({
         Alert.alert("Connection Failed", detail, [{ text: "OK" }]);
       }
     } finally {
+      log.info("[mcp_connector] handleSave finally — clearing isConnecting");
       setIsConnecting(false);
       setConnectingLabel("Connecting…");
     }
@@ -202,6 +213,7 @@ export const McpConnectorConfig: React.FC<McpConnectorConfigProps> = ({
   };
 
   const resetAndClose = () => {
+    log.info("[mcp_connector] resetAndClose");
     setName("");
     setServerUrl("");
     setBearerToken("");

--- a/components/settings/McpConnectorConfig.tsx
+++ b/components/settings/McpConnectorConfig.tsx
@@ -3,7 +3,7 @@ import {
   ActivityIndicator,
   Alert,
   DeviceEventEmitter,
-  KeyboardAvoidingView,
+  Keyboard,
   Modal,
   Platform,
   Pressable,
@@ -62,6 +62,7 @@ export const McpConnectorConfig: React.FC<McpConnectorConfigProps> = ({
   const [pendingExtensionId, setPendingExtensionId] = useState<string | null>(null);
   const [callbackUrl, setCallbackUrl] = useState("");
   const [callbackError, setCallbackError] = useState("");
+  const [keyboardPadding, setKeyboardPadding] = useState(0);
 
   useEffect(() => {
     if (visible && existingExtension) {
@@ -84,6 +85,17 @@ export const McpConnectorConfig: React.FC<McpConnectorConfigProps> = ({
       setHasOAuthToken(false);
     }
   }, [visible, existingExtension]);
+
+  useEffect(() => {
+    const showEvent = Platform.OS === "ios" ? "keyboardWillShow" : "keyboardDidShow";
+    const hideEvent = Platform.OS === "ios" ? "keyboardWillHide" : "keyboardDidHide";
+    const show = Keyboard.addListener(showEvent, (e) => setKeyboardPadding(e.endCoordinates.height));
+    const hide = Keyboard.addListener(hideEvent, () => setKeyboardPadding(0));
+    return () => {
+      show.remove();
+      hide.remove();
+    };
+  }, []);
 
   const sanitizeToken = (value: string) => value.replace(/[\r\n\t ]+/g, "");
 
@@ -211,10 +223,7 @@ export const McpConnectorConfig: React.FC<McpConnectorConfigProps> = ({
       visible={visible}
       onRequestClose={resetAndClose}
     >
-      <KeyboardAvoidingView
-        style={styles.container}
-        behavior={Platform.OS === "ios" ? "padding" : "height"}
-      >
+      <View style={[styles.container, { paddingBottom: keyboardPadding }]}>
         <View style={styles.header}>
           <Text style={styles.headerTitle}>
             {isEditing ? "Edit MCP Extension" : "Add MCP Extension"}
@@ -225,6 +234,7 @@ export const McpConnectorConfig: React.FC<McpConnectorConfigProps> = ({
           style={styles.scrollView}
           contentContainerStyle={styles.scrollContent}
           keyboardShouldPersistTaps="handled"
+          keyboardDismissMode="on-drag"
         >
           {pendingOAuth ? (
             <View style={styles.callbackSection}>
@@ -440,7 +450,7 @@ export const McpConnectorConfig: React.FC<McpConnectorConfigProps> = ({
             </Pressable>
           )}
         </View>
-      </KeyboardAvoidingView>
+      </View>
     </Modal>
   );
 };

--- a/components/settings/McpConnectorConfig.tsx
+++ b/components/settings/McpConnectorConfig.tsx
@@ -254,6 +254,7 @@ export const McpConnectorConfig: React.FC<McpConnectorConfigProps> = ({
           <Text style={styles.headerTitle}>
             {isEditing ? "Edit MCP Extension" : "Add MCP Extension"}
           </Text>
+          <Text style={styles.headerWarning}>⚠️ MCP auth is still experimental with known bugs</Text>
         </View>
 
         <ScrollView
@@ -497,6 +498,11 @@ const styles = StyleSheet.create({
     fontSize: 20,
     fontWeight: "700",
     color: "#1C1C1E",
+  },
+  headerWarning: {
+    fontSize: 12,
+    color: "#8E8E93",
+    marginTop: 4,
   },
   scrollView: {
     flex: 1,

--- a/components/settings/McpConnectorConfig.tsx
+++ b/components/settings/McpConnectorConfig.tsx
@@ -88,6 +88,11 @@ export const McpConnectorConfig: React.FC<McpConnectorConfigProps> = ({
   }, [visible, existingExtension]);
 
   useEffect(() => {
+    log.info("[mcp_connector] mounted");
+    return () => { log.info("[mcp_connector] UNMOUNTED"); };
+  }, []);
+
+  useEffect(() => {
     log.info("[mcp_connector] visible changed", {}, { visible });
   }, [visible]);
 
@@ -173,6 +178,7 @@ export const McpConnectorConfig: React.FC<McpConnectorConfigProps> = ({
             setPendingExtensionId(id);
           }
         } catch (oauthError: any) {
+          log.error("[mcp_connector] oauthError caught", {}, { message: oauthError?.message });
           Alert.alert(
             "Authentication Failed",
             oauthError?.message ?? "OAuth sign-in failed.",

--- a/components/settings/McpConnectorConfig.tsx
+++ b/components/settings/McpConnectorConfig.tsx
@@ -167,9 +167,11 @@ export const McpConnectorConfig: React.FC<McpConnectorConfigProps> = ({
       } else if (result.statusCode === 401 && result.resourceMetadataUrl) {
         const id = existingExtension?.id ?? `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
         setConnectingLabel("Opening sign-in…");
-        log.info("[mcp_connector] entering OAuth branch", {}, { id, serverUrl, resourceMetadataUrl: result.resourceMetadataUrl });
+        const allExtensions = await getMcpExtensions();
+        const normalizedName = uniqueNormalizedName(toNormalizedName(name), allExtensions, existingExtension?.id);
+        log.info("[mcp_connector] entering OAuth branch", {}, { id, serverUrl, normalizedName, resourceMetadataUrl: result.resourceMetadataUrl });
         try {
-          const oauthResult = await performMcpOAuthFlow(id, result.resourceMetadataUrl, name);
+          const oauthResult = await performMcpOAuthFlow(id, result.resourceMetadataUrl, name, { serverUrl, normalizedName });
           log.info("[mcp_connector] OAuth flow returned", {}, { oauthResult_type: oauthResult.type });
           if (oauthResult.type === "success") {
             await persistExtension(id, undefined, { preserveExistingToken: true });

--- a/components/settings/McpConnectorConfig.tsx
+++ b/components/settings/McpConnectorConfig.tsx
@@ -39,6 +39,8 @@ export interface McpConnectorConfigProps {
   onClose: () => void;
   existingExtension?: McpExtensionRecord;
   onSave?: (updated?: McpExtensionRecord) => void;
+  onBeforeBrowserOpen?: () => void;
+  onNeedsManualCallback?: () => void;
 }
 
 export const McpConnectorConfig: React.FC<McpConnectorConfigProps> = ({
@@ -46,6 +48,8 @@ export const McpConnectorConfig: React.FC<McpConnectorConfigProps> = ({
   onClose,
   existingExtension,
   onSave,
+  onBeforeBrowserOpen,
+  onNeedsManualCallback,
 }) => {
   const isEditing = !!existingExtension;
 
@@ -171,6 +175,7 @@ export const McpConnectorConfig: React.FC<McpConnectorConfigProps> = ({
         const normalizedName = uniqueNormalizedName(toNormalizedName(name), allExtensions, existingExtension?.id);
         log.info("[mcp_connector] entering OAuth branch", {}, { id, serverUrl, normalizedName, resourceMetadataUrl: result.resourceMetadataUrl });
         try {
+          onBeforeBrowserOpen?.();
           const oauthResult = await performMcpOAuthFlow(id, result.resourceMetadataUrl, name, { serverUrl, normalizedName });
           log.info("[mcp_connector] OAuth flow returned", {}, { oauthResult_type: oauthResult.type });
           if (oauthResult.type === "success") {
@@ -178,6 +183,7 @@ export const McpConnectorConfig: React.FC<McpConnectorConfigProps> = ({
           } else {
             setPendingOAuth(oauthResult.pendingState);
             setPendingExtensionId(id);
+            onNeedsManualCallback?.();
           }
         } catch (oauthError: any) {
           log.error("[mcp_connector] oauthError caught", {}, { message: oauthError?.message });

--- a/components/settings/McpExtensionDetailScreen.tsx
+++ b/components/settings/McpExtensionDetailScreen.tsx
@@ -15,6 +15,7 @@ import {
   Text,
   View,
 } from "react-native";
+import * as Clipboard from "expo-clipboard";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { MCPClient } from "../../modules/vm-webrtc/src/mcp_client/client";
 import type { Tool } from "../../modules/vm-webrtc/src/mcp_client/types";
@@ -48,6 +49,7 @@ export const McpExtensionDetailScreen: React.FC<McpExtensionDetailScreenProps> =
   const [toolsLoading, setToolsLoading] = useState(false);
   const [toolsError, setToolsError] = useState<string | null>(null);
   const [configureVisible, setConfigureVisible] = useState(false);
+  const [urlCopied, setUrlCopied] = useState(false);
 
   useEffect(() => {
     setCurrentExtension(extension);
@@ -159,6 +161,16 @@ export const McpExtensionDetailScreen: React.FC<McpExtensionDetailScreenProps> =
                 {currentExtension.serverUrl}
               </Text>
             </View>
+            <Pressable
+              style={({ pressed }) => [styles.copyButton, pressed && styles.copyButtonPressed]}
+              onPress={async () => {
+                await Clipboard.setStringAsync(currentExtension.serverUrl);
+                setUrlCopied(true);
+                setTimeout(() => setUrlCopied(false), 1500);
+              }}
+            >
+              <Text style={styles.copyButtonText}>{urlCopied ? "✓" : "⎘"}</Text>
+            </Pressable>
           </View>
 
           <View style={styles.enableRow}>
@@ -322,6 +334,21 @@ const styles = StyleSheet.create({
   infoBody: {
     flex: 1,
     gap: 4,
+  },
+  copyButton: {
+    width: 32,
+    height: 32,
+    borderRadius: 8,
+    backgroundColor: "#F2F2F7",
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  copyButtonPressed: {
+    opacity: 0.5,
+  },
+  copyButtonText: {
+    fontSize: 16,
+    color: "#636366",
   },
   extensionName: {
     fontSize: 17,

--- a/components/settings/McpExtensionDetailScreen.tsx
+++ b/components/settings/McpExtensionDetailScreen.tsx
@@ -21,6 +21,8 @@ import { MCPClient } from "../../modules/vm-webrtc/src/mcp_client/client";
 import type { Tool } from "../../modules/vm-webrtc/src/mcp_client/types";
 import {
   addMcpExtension,
+  clearMcpAuthCredentials,
+  deleteMcpBearerToken,
   deleteMcpExtension,
   getMcpBearerToken,
   type McpExtensionRecord,
@@ -124,6 +126,39 @@ export const McpExtensionDetailScreen: React.FC<McpExtensionDetailScreenProps> =
       setCurrentExtension(updated);
       onUpdated(updated);
       fetchTools();
+    }
+  };
+
+  const handleResetAuth = () => {
+    const doReset = async () => {
+      await deleteMcpBearerToken(currentExtension.id);
+      await clearMcpAuthCredentials(currentExtension.id);
+      DeviceEventEmitter.emit(CONNECTOR_SETTINGS_CHANGED_EVENT);
+      setConfigureVisible(true);
+    };
+
+    if (Platform.OS === "ios") {
+      ActionSheetIOS.showActionSheetWithOptions(
+        {
+          title: `Reset auth for "${currentExtension.name}"?`,
+          message: "All saved credentials will be deleted. You'll need to sign in again.",
+          options: ["Cancel", "Reset Auth"],
+          destructiveButtonIndex: 1,
+          cancelButtonIndex: 0,
+        },
+        (buttonIndex) => {
+          if (buttonIndex === 1) doReset();
+        }
+      );
+    } else {
+      Alert.alert(
+        "Reset Auth",
+        `Delete all saved credentials for "${currentExtension.name}"? You'll need to sign in again.`,
+        [
+          { text: "Cancel", style: "cancel" },
+          { text: "Reset Auth", style: "destructive", onPress: doReset },
+        ]
+      );
     }
   };
 
@@ -240,6 +275,12 @@ export const McpExtensionDetailScreen: React.FC<McpExtensionDetailScreenProps> =
             onPress={() => setConfigureVisible(true)}
           >
             <Text style={styles.configureButtonText}>Configure</Text>
+          </Pressable>
+          <Pressable
+            style={({ pressed }) => [styles.resetAuthButton, pressed && styles.resetAuthButtonPressed]}
+            onPress={handleResetAuth}
+          >
+            <Text style={styles.resetAuthButtonText}>Reset Auth</Text>
           </Pressable>
           <Pressable
             style={({ pressed }) => [styles.removeButton, pressed && styles.removeButtonPressed]}
@@ -478,6 +519,23 @@ const styles = StyleSheet.create({
     fontSize: 16,
     fontWeight: "600",
     color: "#FFFFFF",
+  },
+  resetAuthButton: {
+    flex: 1,
+    paddingVertical: 14,
+    borderRadius: 12,
+    alignItems: "center",
+    backgroundColor: "#FFFFFF",
+    borderWidth: 1,
+    borderColor: "#FF9500",
+  },
+  resetAuthButtonPressed: {
+    backgroundColor: "#FFF8F0",
+  },
+  resetAuthButtonText: {
+    fontSize: 16,
+    fontWeight: "600",
+    color: "#FF9500",
   },
   removeButton: {
     flex: 1,

--- a/components/settings/McpExtensionsScreen.tsx
+++ b/components/settings/McpExtensionsScreen.tsx
@@ -1,5 +1,7 @@
-import React, { useCallback, useEffect, useState } from "react";
+import React, { useCallback, useEffect, useRef, useState } from "react";
 import {
+  Alert,
+  DeviceEventEmitter,
   Modal,
   Pressable,
   SafeAreaView,
@@ -13,6 +15,7 @@ import {
   getMcpExtensions,
   type McpExtensionRecord,
 } from "../../lib/secure-storage";
+import { MCP_REAUTH_REQUIRED_EVENT } from "../../modules/vm-webrtc/src/ToolkitManager";
 import { McpConnectorConfig } from "./McpConnectorConfig";
 import { McpExtensionDetailScreen } from "./McpExtensionDetailScreen";
 
@@ -29,15 +32,39 @@ export const McpExtensionsScreen: React.FC<McpExtensionsScreenProps> = ({
   const [extensions, setExtensions] = useState<McpExtensionRecord[]>([]);
   const [addVisible, setAddVisible] = useState(false);
   const [detailExtension, setDetailExtension] = useState<McpExtensionRecord | null>(null);
+  const [reauthExtension, setReauthExtension] = useState<McpExtensionRecord | null>(null);
+  const extensionsRef = useRef<McpExtensionRecord[]>([]);
 
   const loadExtensions = useCallback(async () => {
     const list = await getMcpExtensions();
     setExtensions(list);
+    extensionsRef.current = list;
   }, []);
 
   useEffect(() => {
     if (visible) loadExtensions();
   }, [visible, loadExtensions]);
+
+  useEffect(() => {
+    const sub = DeviceEventEmitter.addListener(
+      MCP_REAUTH_REQUIRED_EVENT,
+      ({ id, name }: { id: string; name: string }) => {
+        const ext = extensionsRef.current.find((e) => e.id === id);
+        Alert.alert(
+          `"${name}" needs to sign in again`,
+          "Your session has expired.",
+          [
+            { text: "Later", style: "cancel" },
+            {
+              text: "Re-authenticate",
+              onPress: () => setReauthExtension(ext ?? { id, name, normalizedName: "", serverUrl: "" }),
+            },
+          ],
+        );
+      },
+    );
+    return () => sub.remove();
+  }, []);
 
   const handleRemove = (id: string) => {
     setDetailExtension(null);
@@ -149,6 +176,16 @@ export const McpExtensionsScreen: React.FC<McpExtensionsScreenProps> = ({
           onUpdated={handleUpdated}
         />
       )}
+
+      <McpConnectorConfig
+        visible={reauthExtension !== null}
+        existingExtension={reauthExtension ?? undefined}
+        onClose={() => setReauthExtension(null)}
+        onSave={() => {
+          setReauthExtension(null);
+          loadExtensions();
+        }}
+      />
     </Modal>
   );
 };

--- a/components/settings/McpExtensionsScreen.tsx
+++ b/components/settings/McpExtensionsScreen.tsx
@@ -22,11 +22,15 @@ import { McpExtensionDetailScreen } from "./McpExtensionDetailScreen";
 export interface McpExtensionsScreenProps {
   visible: boolean;
   onClose: () => void;
+  onBeforeBrowserOpen?: () => void;
+  onNeedsManualCallback?: () => void;
 }
 
 export const McpExtensionsScreen: React.FC<McpExtensionsScreenProps> = ({
   visible,
   onClose,
+  onBeforeBrowserOpen,
+  onNeedsManualCallback,
 }) => {
   const insets = useSafeAreaInsets();
   const [extensions, setExtensions] = useState<McpExtensionRecord[]>([]);
@@ -165,6 +169,14 @@ export const McpExtensionsScreen: React.FC<McpExtensionsScreenProps> = ({
           setAddVisible(false);
           loadExtensions();
         }}
+        onBeforeBrowserOpen={() => {
+          setAddVisible(false);
+          onBeforeBrowserOpen?.();
+        }}
+        onNeedsManualCallback={() => {
+          setAddVisible(true);
+          onNeedsManualCallback?.();
+        }}
       />
 
       {detailExtension && (
@@ -184,6 +196,14 @@ export const McpExtensionsScreen: React.FC<McpExtensionsScreenProps> = ({
         onSave={() => {
           setReauthExtension(null);
           loadExtensions();
+        }}
+        onBeforeBrowserOpen={() => {
+          setReauthExtension(null);
+          onBeforeBrowserOpen?.();
+        }}
+        onNeedsManualCallback={() => {
+          setReauthExtension(reauthExtension);
+          onNeedsManualCallback?.();
         }}
       />
     </Modal>

--- a/lib/logger.ts
+++ b/lib/logger.ts
@@ -183,10 +183,9 @@ const emit = (
     return;
   }
 
-  const applyRedaction =
-    redactionEnabled && options.allowSensitiveLogging !== true;
-  const safeMessage = applyRedaction ? sanitizeMessage(message) : message;
-  const safeArgs = applyRedaction ? sanitizeArgs(args) : args;
+  // Console always redacts — allowSensitiveLogging never bypasses console output.
+  const safeMessage = sanitizeMessage(message);
+  const safeArgs = sanitizeArgs(args);
 
   const timestamp = new Date().toISOString();
   const prefix = `[${LOG_PREFIX}][${level.toUpperCase()}][${timestamp}]`;
@@ -212,17 +211,23 @@ const emit = (
       break;
   }
 
-  // Send to logfire with log level as attribute (if enabled)
+  // Send to logfire with log level as attribute (if enabled).
+  // Logfire respects both redactionEnabled and allowSensitiveLogging.
   const emit2logfire = options.emit2logfire ?? true;
   if (emit2logfire) {
+    const applyRedactionForLogfire =
+      redactionEnabled && options.allowSensitiveLogging !== true;
+    const logfireMessage = applyRedactionForLogfire ? safeMessage : message;
+    const logfireArgs = applyRedactionForLogfire ? safeArgs : args;
+
     const attrs: Record<string, unknown> = {
       level,
       timestamp,
     };
 
     // Add any additional args as attributes
-    if (safeArgs.length > 0) {
-      safeArgs.forEach((arg, index) => {
+    if (logfireArgs.length > 0) {
+      logfireArgs.forEach((arg, index) => {
         if (arg && typeof arg === "object" && !Array.isArray(arg)) {
           Object.assign(attrs, arg);
         } else {
@@ -235,7 +240,7 @@ const emit = (
       attrs.is_native_logger = false;
     }
 
-    logfireEvent(safeMessage, attrs);
+    logfireEvent(logfireMessage, attrs);
   }
 };
 

--- a/lib/mcp-oauth.ts
+++ b/lib/mcp-oauth.ts
@@ -16,11 +16,23 @@ import {
   saveMcpTokenEndpoint,
 } from "./secure-storage";
 
+export interface McpOAuthPendingState {
+  extensionId: string;
+  codeVerifier: string;
+  redirectUri: string;
+  clientId: string;
+  tokenEndpoint: string;
+}
+
+export type McpOAuthFlowResult =
+  | { type: "success"; accessToken: string; refreshToken?: string }
+  | { type: "needs_manual_callback"; pendingState: McpOAuthPendingState };
+
 export async function performMcpOAuthFlow(
   extensionId: string,
   resourceMetadataUrl: string,
   connectorName?: string,
-): Promise<{ accessToken: string; refreshToken?: string }> {
+): Promise<McpOAuthFlowResult> {
   log.info(
     "[mcp_oauth] Starting OAuth flow",
     {},
@@ -75,29 +87,93 @@ export async function performMcpOAuthFlow(
   );
   const result = await request.promptAsync(discovery);
 
-  if (result.type !== "success" || !result.params.code) {
-    throw new Error(
-      result.type === "cancel" ? "Sign-in was cancelled." : "OAuth sign-in failed.",
+  if (result.type === "success" && result.params.code) {
+    log.info(
+      "[mcp_oauth] Step 6: exchanging code for token",
+      {},
+      { connector_name: connectorName },
     );
+    const tokens = await exchangeAndStore(
+      result.params.code,
+      clientId,
+      redirectUri,
+      request.codeVerifier ?? "",
+      oauthMeta.tokenEndpoint,
+      extensionId,
+      connectorName,
+    );
+    return { type: "success", ...tokens };
+  }
+
+  // Browser was dismissed or redirect wasn't intercepted — surface manual paste UI
+  log.info(
+    "[mcp_oauth] Browser closed without redirect, returning manual callback state",
+    {},
+    { connector_name: connectorName, result_type: result.type },
+  );
+  return {
+    type: "needs_manual_callback",
+    pendingState: {
+      extensionId,
+      codeVerifier: request.codeVerifier ?? "",
+      redirectUri,
+      clientId,
+      tokenEndpoint: oauthMeta.tokenEndpoint,
+    },
+  };
+}
+
+export async function completeMcpOAuthFromCallbackUrl(
+  callbackUrl: string,
+  pendingState: McpOAuthPendingState,
+): Promise<{ accessToken: string; refreshToken?: string }> {
+  const questionIdx = callbackUrl.indexOf("?");
+  if (questionIdx === -1) {
+    throw new Error("No authorization code found in that URL.");
+  }
+  const params = new URLSearchParams(callbackUrl.slice(questionIdx + 1));
+  const code = params.get("code");
+  if (!code) {
+    throw new Error("No authorization code found in that URL.");
   }
 
   log.info(
-    "[mcp_oauth] Step 6: exchanging code for token",
+    "[mcp_oauth] Completing OAuth from pasted callback URL",
     {},
-    { connector_name: connectorName },
+    { extension_id: pendingState.extensionId },
   );
+
+  return exchangeAndStore(
+    code,
+    pendingState.clientId,
+    pendingState.redirectUri,
+    pendingState.codeVerifier,
+    pendingState.tokenEndpoint,
+    pendingState.extensionId,
+  );
+}
+
+async function exchangeAndStore(
+  code: string,
+  clientId: string,
+  redirectUri: string,
+  codeVerifier: string,
+  tokenEndpoint: string,
+  extensionId: string,
+  connectorName?: string,
+): Promise<{ accessToken: string; refreshToken?: string }> {
   const tokenResponse = await AuthSession.exchangeCodeAsync(
     {
-      code: result.params.code,
+      code,
       clientId,
       redirectUri,
-      extraParams: { code_verifier: request.codeVerifier ?? "" },
+      extraParams: { code_verifier: codeVerifier },
     },
-    { tokenEndpoint: oauthMeta.tokenEndpoint },
+    { tokenEndpoint },
   );
 
   await saveMcpBearerToken(extensionId, tokenResponse.accessToken);
-  await saveMcpTokenEndpoint(extensionId, oauthMeta.tokenEndpoint);
+  await saveMcpTokenEndpoint(extensionId, tokenEndpoint);
   if (tokenResponse.refreshToken) {
     await saveMcpRefreshToken(extensionId, tokenResponse.refreshToken);
   }

--- a/lib/mcp-oauth.ts
+++ b/lib/mcp-oauth.ts
@@ -105,6 +105,16 @@ export async function performMcpOAuthFlow(
     return { type: "success", ...tokens };
   }
 
+  if (result.type === "error") {
+    const detail = (result as any).error_description ?? (result as any).error ?? JSON.stringify((result as any).params ?? result);
+    log.error(
+      "[mcp_oauth] OAuth server returned an error",
+      {},
+      { connector_name: connectorName, result },
+    );
+    throw new Error(`OAuth error: ${detail}`);
+  }
+
   // Browser was dismissed or redirect wasn't intercepted — surface manual paste UI
   log.info(
     "[mcp_oauth] Browser closed without redirect, returning manual callback state",

--- a/lib/mcp-oauth.ts
+++ b/lib/mcp-oauth.ts
@@ -1,0 +1,158 @@
+import * as AuthSession from "expo-auth-session";
+
+import {
+  fetchOAuthServerMetadata,
+  fetchResourceMetadata,
+  registerOAuthClient,
+} from "../modules/vm-webrtc/src/mcp_client/extensions";
+import { log } from "./logger";
+import {
+  getMcpClientId,
+  getMcpRefreshToken,
+  getMcpTokenEndpoint,
+  saveMcpBearerToken,
+  saveMcpClientId,
+  saveMcpRefreshToken,
+  saveMcpTokenEndpoint,
+} from "./secure-storage";
+
+export async function performMcpOAuthFlow(
+  extensionId: string,
+  resourceMetadataUrl: string,
+  connectorName?: string,
+): Promise<{ accessToken: string; refreshToken?: string }> {
+  log.info(
+    "[mcp_oauth] Starting OAuth flow",
+    {},
+    { extension_id: extensionId, connector_name: connectorName },
+  );
+
+  const resourceMetadata = await fetchResourceMetadata(resourceMetadataUrl, connectorName);
+  const authServerUrl = resourceMetadata.authorizationServers[0];
+  const oauthMeta = await fetchOAuthServerMetadata(authServerUrl, connectorName);
+
+  const redirectUri = AuthSession.makeRedirectUri({
+    scheme: "vibemachine",
+    path: "mcp-oauth-callback",
+  });
+
+  let clientId = await getMcpClientId(extensionId);
+  if (!clientId) {
+    if (!oauthMeta.registrationEndpoint) {
+      throw new Error(
+        "Server requires OAuth but has no registration_endpoint and no cached client_id",
+      );
+    }
+    const reg = await registerOAuthClient(
+      oauthMeta.registrationEndpoint,
+      redirectUri,
+      connectorName,
+    );
+    clientId = reg.clientId;
+    await saveMcpClientId(extensionId, clientId);
+  }
+
+  const discovery = {
+    authorizationEndpoint: oauthMeta.authorizationEndpoint,
+    tokenEndpoint: oauthMeta.tokenEndpoint,
+  };
+
+  const request = new AuthSession.AuthRequest({
+    clientId,
+    responseType: AuthSession.ResponseType.Code,
+    redirectUri,
+    scopes: [],
+    usePKCE: true,
+    extraParams: { resource: resourceMetadata.resource },
+  });
+
+  await request.makeAuthUrlAsync(discovery);
+
+  log.info(
+    "[mcp_oauth] Step 5: opening browser for authorization",
+    {},
+    { connector_name: connectorName },
+  );
+  const result = await request.promptAsync(discovery);
+
+  if (result.type !== "success" || !result.params.code) {
+    throw new Error(
+      result.type === "cancel" ? "Sign-in was cancelled." : "OAuth sign-in failed.",
+    );
+  }
+
+  log.info(
+    "[mcp_oauth] Step 6: exchanging code for token",
+    {},
+    { connector_name: connectorName },
+  );
+  const tokenResponse = await AuthSession.exchangeCodeAsync(
+    {
+      code: result.params.code,
+      clientId,
+      redirectUri,
+      extraParams: { code_verifier: request.codeVerifier ?? "" },
+    },
+    { tokenEndpoint: oauthMeta.tokenEndpoint },
+  );
+
+  await saveMcpBearerToken(extensionId, tokenResponse.accessToken);
+  await saveMcpTokenEndpoint(extensionId, oauthMeta.tokenEndpoint);
+  if (tokenResponse.refreshToken) {
+    await saveMcpRefreshToken(extensionId, tokenResponse.refreshToken);
+  }
+
+  log.info(
+    "[mcp_oauth] OAuth flow complete",
+    {},
+    { connector_name: connectorName, has_refresh_token: !!tokenResponse.refreshToken },
+  );
+
+  return {
+    accessToken: tokenResponse.accessToken,
+    refreshToken: tokenResponse.refreshToken ?? undefined,
+  };
+}
+
+export async function refreshMcpAccessToken(
+  extensionId: string,
+  connectorName?: string,
+): Promise<string | null> {
+  const [refreshToken, tokenEndpoint] = await Promise.all([
+    getMcpRefreshToken(extensionId),
+    getMcpTokenEndpoint(extensionId),
+  ]);
+
+  if (!refreshToken || !tokenEndpoint) return null;
+
+  const clientId = await getMcpClientId(extensionId);
+  if (!clientId) return null;
+
+  log.info(
+    "[mcp_oauth] Refreshing access token",
+    {},
+    { extension_id: extensionId, connector_name: connectorName },
+  );
+
+  try {
+    const tokenResponse = await AuthSession.refreshAsync(
+      { clientId, refreshToken },
+      { tokenEndpoint },
+    );
+
+    await saveMcpBearerToken(extensionId, tokenResponse.accessToken);
+    if (tokenResponse.refreshToken) {
+      await saveMcpRefreshToken(extensionId, tokenResponse.refreshToken);
+    }
+
+    log.info("[mcp_oauth] Token refresh succeeded", {}, { connector_name: connectorName });
+    return tokenResponse.accessToken;
+  } catch (err) {
+    log.warn(
+      "[mcp_oauth] Token refresh failed",
+      {},
+      { connector_name: connectorName, error: err instanceof Error ? err.message : String(err) },
+    );
+    return null;
+  }
+}

--- a/lib/mcp-oauth.ts
+++ b/lib/mcp-oauth.ts
@@ -7,11 +7,13 @@ import {
 } from "../modules/vm-webrtc/src/mcp_client/extensions";
 import { log } from "./logger";
 import {
+  clearMcpPendingOAuthSession,
   getMcpClientId,
   getMcpRefreshToken,
   getMcpTokenEndpoint,
   saveMcpBearerToken,
   saveMcpClientId,
+  saveMcpPendingOAuthSession,
   saveMcpRefreshToken,
   saveMcpTokenEndpoint,
 } from "./secure-storage";
@@ -22,6 +24,11 @@ export interface McpOAuthPendingState {
   redirectUri: string;
   clientId: string;
   tokenEndpoint: string;
+  // Extension record fields — needed by the Linking handler to register the extension
+  // when ASWebAuthenticationSession drops the callback on iOS
+  extensionName: string;
+  extensionServerUrl: string;
+  extensionNormalizedName: string;
 }
 
 export type McpOAuthFlowResult =
@@ -32,6 +39,7 @@ export async function performMcpOAuthFlow(
   extensionId: string,
   resourceMetadataUrl: string,
   connectorName?: string,
+  extensionInfo?: { serverUrl: string; normalizedName: string },
 ): Promise<McpOAuthFlowResult> {
   log.info(
     "[mcp_oauth] Starting OAuth flow",
@@ -80,26 +88,32 @@ export async function performMcpOAuthFlow(
 
   await request.makeAuthUrlAsync(discovery);
 
+  const pendingState: McpOAuthPendingState = {
+    extensionId,
+    codeVerifier: request.codeVerifier ?? "",
+    redirectUri,
+    clientId,
+    tokenEndpoint: oauthMeta.tokenEndpoint,
+    extensionName: connectorName ?? "",
+    extensionServerUrl: extensionInfo?.serverUrl ?? "",
+    extensionNormalizedName: extensionInfo?.normalizedName ?? "",
+  };
+
+  // Save pending state before opening the browser so the Linking handler in app/index.tsx
+  // can complete the flow if ASWebAuthenticationSession drops the callback (known iOS issue
+  // when presenting from nested formSheet modals).
+  await saveMcpPendingOAuthSession(pendingState);
+
   log.info(
     "[mcp_oauth] Step 5: opening browser for authorization",
     {},
     { connector_name: connectorName },
   );
-  // openOAuthBrowserAndAwaitRedirect — opens ASWebAuthenticationSession on iOS and
-  // waits for the redirect URI to be intercepted. Hangs if the session anchor is lost.
-  const browserTimeoutMs = 120_000;
-  const result = await Promise.race([
-    request.promptAsync(discovery),
-    new Promise<never>((_, reject) =>
-      setTimeout(
-        () => reject(new Error(`OAuth browser did not resolve after ${browserTimeoutMs / 1000}s`)),
-        browserTimeoutMs,
-      )
-    ),
-  ]).catch((err) => {
-    log.error("[mcp_oauth] promptAsync error or timeout", {}, { message: err?.message, connector_name: connectorName });
-    throw err;
-  });
+
+  // openOAuthBrowserAndAwaitRedirect — on iOS uses ASWebAuthenticationSession.
+  // May hang indefinitely if the session anchor is lost (nested modal bug).
+  // The Linking handler in app/index.tsx is the reliable fallback.
+  const result = await request.promptAsync(discovery);
 
   log.info(
     "[mcp_oauth] promptAsync returned",
@@ -127,6 +141,7 @@ export async function performMcpOAuthFlow(
       extensionId,
       connectorName,
     );
+    await clearMcpPendingOAuthSession();
     return { type: "success", ...tokens };
   }
 
@@ -137,6 +152,7 @@ export async function performMcpOAuthFlow(
       {},
       { connector_name: connectorName, result },
     );
+    await clearMcpPendingOAuthSession();
     throw new Error(`OAuth error: ${detail}`);
   }
 
@@ -146,16 +162,7 @@ export async function performMcpOAuthFlow(
     {},
     { connector_name: connectorName, result_type: result.type },
   );
-  return {
-    type: "needs_manual_callback",
-    pendingState: {
-      extensionId,
-      codeVerifier: request.codeVerifier ?? "",
-      redirectUri,
-      clientId,
-      tokenEndpoint: oauthMeta.tokenEndpoint,
-    },
-  };
+  return { type: "needs_manual_callback", pendingState };
 }
 
 export async function completeMcpOAuthFromCallbackUrl(

--- a/lib/mcp-oauth.ts
+++ b/lib/mcp-oauth.ts
@@ -7,13 +7,11 @@ import {
 } from "../modules/vm-webrtc/src/mcp_client/extensions";
 import { log } from "./logger";
 import {
-  clearMcpPendingOAuthSession,
   getMcpClientId,
   getMcpRefreshToken,
   getMcpTokenEndpoint,
   saveMcpBearerToken,
   saveMcpClientId,
-  saveMcpPendingOAuthSession,
   saveMcpRefreshToken,
   saveMcpTokenEndpoint,
 } from "./secure-storage";
@@ -24,8 +22,6 @@ export interface McpOAuthPendingState {
   redirectUri: string;
   clientId: string;
   tokenEndpoint: string;
-  // Extension record fields — needed by the Linking handler to register the extension
-  // when ASWebAuthenticationSession drops the callback on iOS
   extensionName: string;
   extensionServerUrl: string;
   extensionNormalizedName: string;
@@ -99,20 +95,12 @@ export async function performMcpOAuthFlow(
     extensionNormalizedName: extensionInfo?.normalizedName ?? "",
   };
 
-  // Save pending state before opening the browser so the Linking handler in app/index.tsx
-  // can complete the flow if ASWebAuthenticationSession drops the callback (known iOS issue
-  // when presenting from nested formSheet modals).
-  await saveMcpPendingOAuthSession(pendingState);
-
   log.info(
     "[mcp_oauth] Step 5: opening browser for authorization",
     {},
     { connector_name: connectorName },
   );
 
-  // openOAuthBrowserAndAwaitRedirect — on iOS uses ASWebAuthenticationSession.
-  // May hang indefinitely if the session anchor is lost (nested modal bug).
-  // The Linking handler in app/index.tsx is the reliable fallback.
   const result = await request.promptAsync(discovery);
 
   log.info(
@@ -141,7 +129,6 @@ export async function performMcpOAuthFlow(
       extensionId,
       connectorName,
     );
-    await clearMcpPendingOAuthSession();
     return { type: "success", ...tokens };
   }
 
@@ -152,7 +139,6 @@ export async function performMcpOAuthFlow(
       {},
       { connector_name: connectorName, result },
     );
-    await clearMcpPendingOAuthSession();
     throw new Error(`OAuth error: ${detail}`);
   }
 

--- a/lib/mcp-oauth.ts
+++ b/lib/mcp-oauth.ts
@@ -87,6 +87,17 @@ export async function performMcpOAuthFlow(
   );
   const result = await request.promptAsync(discovery);
 
+  log.info(
+    "[mcp_oauth] promptAsync returned",
+    {},
+    {
+      result_type: result.type,
+      params: result.type === "success" ? result.params : undefined,
+      error: (result as any).error ?? undefined,
+      connector_name: connectorName,
+    },
+  );
+
   if (result.type === "success" && result.params.code) {
     log.info(
       "[mcp_oauth] Step 6: exchanging code for token",

--- a/lib/mcp-oauth.ts
+++ b/lib/mcp-oauth.ts
@@ -85,7 +85,21 @@ export async function performMcpOAuthFlow(
     {},
     { connector_name: connectorName },
   );
-  const result = await request.promptAsync(discovery);
+  // openOAuthBrowserAndAwaitRedirect — opens ASWebAuthenticationSession on iOS and
+  // waits for the redirect URI to be intercepted. Hangs if the session anchor is lost.
+  const browserTimeoutMs = 120_000;
+  const result = await Promise.race([
+    request.promptAsync(discovery),
+    new Promise<never>((_, reject) =>
+      setTimeout(
+        () => reject(new Error(`OAuth browser did not resolve after ${browserTimeoutMs / 1000}s`)),
+        browserTimeoutMs,
+      )
+    ),
+  ]).catch((err) => {
+    log.error("[mcp_oauth] promptAsync error or timeout", {}, { message: err?.message, connector_name: connectorName });
+    throw err;
+  });
 
   log.info(
     "[mcp_oauth] promptAsync returned",

--- a/lib/secure-storage.ts
+++ b/lib/secure-storage.ts
@@ -813,6 +813,9 @@ export function uniqueNormalizedName(
 
 const MCP_EXTENSIONS_KEY = "VIBEMACHINE_MCP_EXTENSIONS";
 const MCP_TOKEN_PREFIX = "VIBEMACHINE_MCP_TOKEN_";
+const MCP_CLIENT_ID_PREFIX = "VIBEMACHINE_MCP_CLIENT_ID_";
+const MCP_REFRESH_TOKEN_PREFIX = "VIBEMACHINE_MCP_REFRESH_TOKEN_";
+const MCP_TOKEN_ENDPOINT_PREFIX = "VIBEMACHINE_MCP_TOKEN_ENDPOINT_";
 
 export async function getMcpExtensions(): Promise<McpExtensionRecord[]> {
   try {
@@ -850,6 +853,7 @@ export async function deleteMcpExtension(id: string): Promise<void> {
   const existing = await getMcpExtensions();
   await saveMcpExtensions(existing.filter((e) => e.id !== id));
   await deleteMcpBearerToken(id);
+  await deleteMcpOAuthData(id);
 }
 
 export async function saveMcpBearerToken(id: string, token: string): Promise<void> {
@@ -870,6 +874,50 @@ export async function deleteMcpBearerToken(id: string): Promise<void> {
   } catch {
     // token may not exist
   }
+}
+
+export async function saveMcpClientId(id: string, clientId: string): Promise<void> {
+  await setCachedValue(`${MCP_CLIENT_ID_PREFIX}${id}`, clientId);
+}
+
+export async function getMcpClientId(id: string): Promise<string | null> {
+  try {
+    return await getCachedValue(`${MCP_CLIENT_ID_PREFIX}${id}`);
+  } catch {
+    return null;
+  }
+}
+
+export async function saveMcpRefreshToken(id: string, token: string): Promise<void> {
+  await setCachedValue(`${MCP_REFRESH_TOKEN_PREFIX}${id}`, token);
+}
+
+export async function getMcpRefreshToken(id: string): Promise<string | null> {
+  try {
+    return await getCachedValue(`${MCP_REFRESH_TOKEN_PREFIX}${id}`);
+  } catch {
+    return null;
+  }
+}
+
+export async function saveMcpTokenEndpoint(id: string, url: string): Promise<void> {
+  await setCachedValue(`${MCP_TOKEN_ENDPOINT_PREFIX}${id}`, url);
+}
+
+export async function getMcpTokenEndpoint(id: string): Promise<string | null> {
+  try {
+    return await getCachedValue(`${MCP_TOKEN_ENDPOINT_PREFIX}${id}`);
+  } catch {
+    return null;
+  }
+}
+
+async function deleteMcpOAuthData(id: string): Promise<void> {
+  await Promise.allSettled([
+    deleteCachedValue(`${MCP_CLIENT_ID_PREFIX}${id}`),
+    deleteCachedValue(`${MCP_REFRESH_TOKEN_PREFIX}${id}`),
+    deleteCachedValue(`${MCP_TOKEN_ENDPOINT_PREFIX}${id}`),
+  ]);
 }
 
 // Pydantic Logfire Enabled State Functions

--- a/lib/secure-storage.ts
+++ b/lib/secure-storage.ts
@@ -980,8 +980,19 @@ export async function clearAllStoredSecrets(): Promise<void> {
     CONTEXT7_API_KEY,
   ];
 
+  // Add per-extension MCP SecureStore keys (bearer token + OAuth data) for every known extension
+  const mcpExtensions = await getMcpExtensions().catch(() => [] as McpExtensionRecord[]);
+  for (const ext of mcpExtensions) {
+    secureStoreKeys.push(
+      `${MCP_TOKEN_PREFIX}${ext.id}`,
+      `${MCP_CLIENT_ID_PREFIX}${ext.id}`,
+      `${MCP_REFRESH_TOKEN_PREFIX}${ext.id}`,
+      `${MCP_TOKEN_ENDPOINT_PREFIX}${ext.id}`,
+    );
+  }
+
   // Define all AsyncStorage keys that need to be deleted
-  const asyncStorageKeys = [LOGFIRE_ENABLED_KEY];
+  const asyncStorageKeys = [LOGFIRE_ENABLED_KEY, MCP_EXTENSIONS_KEY];
 
   try {
     // Log all keys that will be deleted BEFORE deletion

--- a/lib/secure-storage.ts
+++ b/lib/secure-storage.ts
@@ -920,6 +920,26 @@ export async function clearMcpAuthCredentials(id: string): Promise<void> {
   ]);
 }
 
+const MCP_PENDING_OAUTH_KEY = "VIBEMACHINE_MCP_PENDING_OAUTH";
+
+export async function saveMcpPendingOAuthSession(session: object): Promise<void> {
+  await AsyncStorage.setItem(MCP_PENDING_OAUTH_KEY, JSON.stringify(session));
+}
+
+export async function getMcpPendingOAuthSession(): Promise<Record<string, unknown> | null> {
+  const raw = await AsyncStorage.getItem(MCP_PENDING_OAUTH_KEY);
+  if (!raw) return null;
+  try {
+    return JSON.parse(raw) as Record<string, unknown>;
+  } catch {
+    return null;
+  }
+}
+
+export async function clearMcpPendingOAuthSession(): Promise<void> {
+  await AsyncStorage.removeItem(MCP_PENDING_OAUTH_KEY);
+}
+
 // Pydantic Logfire Enabled State Functions
 // Note: These use AsyncStorage, not SecureStore, so no caching is needed
 

--- a/lib/secure-storage.ts
+++ b/lib/secure-storage.ts
@@ -853,7 +853,7 @@ export async function deleteMcpExtension(id: string): Promise<void> {
   const existing = await getMcpExtensions();
   await saveMcpExtensions(existing.filter((e) => e.id !== id));
   await deleteMcpBearerToken(id);
-  await deleteMcpOAuthData(id);
+  await clearMcpAuthCredentials(id);
 }
 
 export async function saveMcpBearerToken(id: string, token: string): Promise<void> {
@@ -912,7 +912,7 @@ export async function getMcpTokenEndpoint(id: string): Promise<string | null> {
   }
 }
 
-async function deleteMcpOAuthData(id: string): Promise<void> {
+export async function clearMcpAuthCredentials(id: string): Promise<void> {
   await Promise.allSettled([
     deleteCachedValue(`${MCP_CLIENT_ID_PREFIX}${id}`),
     deleteCachedValue(`${MCP_REFRESH_TOKEN_PREFIX}${id}`),

--- a/modules/vm-webrtc/src/ToolkitManager.ts
+++ b/modules/vm-webrtc/src/ToolkitManager.ts
@@ -6,6 +6,7 @@ import { DeviceEventEmitter } from "react-native";
 import toolkitGroupsData from "../toolkits/toolkitGroups.json";
 
 import { log } from "../../../lib/logger";
+import { refreshMcpAccessToken } from "../../../lib/mcp-oauth";
 import {
   getContext7ApiKey,
   getMcpBearerToken,
@@ -20,7 +21,7 @@ import type {
   ToolkitGroups,
 } from "./VmWebrtc.types";
 import { exportToolDefinition } from "./VmWebrtc.types";
-import { MCPClient, type RequestOptions } from "./mcp_client/client";
+import { MCPClient, McpAuthError, type RequestOptions } from "./mcp_client/client";
 import type { Tool } from "./mcp_client/types";
 import {
   registerMcpTool,
@@ -30,6 +31,9 @@ import { getWrapperForGroup } from "./toolkit_functions/wrappers/ToolkitFunction
 
 // Event emitted when connector settings change
 export const CONNECTOR_SETTINGS_CHANGED_EVENT = "connector_settings_changed";
+
+// Event emitted when an MCP extension's token is expired and refresh failed
+export const MCP_REAUTH_REQUIRED_EVENT = "mcp_reauth_required";
 
 /**
  * Get the AsyncStorage key for a toolkit group using convention:
@@ -728,13 +732,81 @@ async function registerUserExtensionToolsFromCache(
         {},
         { group: groupName, toolName, url: ext.serverUrl },
       );
-      const result = await client.callTool(
-        { name: toolName, arguments: args },
-        REMOTE_TOOLKIT_DISCOVERY_OPTIONS,
-        groupName,
-      );
-      return { result: JSON.stringify(result, null, 2), updatedToolSessionContext: {} };
+      try {
+        const result = await client.callTool(
+          { name: toolName, arguments: args },
+          REMOTE_TOOLKIT_DISCOVERY_OPTIONS,
+          groupName,
+        );
+        return { result: JSON.stringify(result, null, 2), updatedToolSessionContext: {} };
+      } catch (error) {
+        if (!(error instanceof McpAuthError)) throw error;
+
+        log.info(
+          "[ToolkitManager] Tool call got 401, attempting token refresh",
+          {},
+          { name: ext.name, toolName },
+        );
+        const newToken = await refreshMcpAccessToken(ext.id, ext.name);
+        if (newToken) {
+          client.reset(newToken);
+          try {
+            const result = await client.callTool(
+              { name: toolName, arguments: args },
+              REMOTE_TOOLKIT_DISCOVERY_OPTIONS,
+              groupName,
+            );
+            return { result: JSON.stringify(result, null, 2), updatedToolSessionContext: {} };
+          } catch (retryError) {
+            if (!(retryError instanceof McpAuthError)) throw retryError;
+          }
+        }
+        DeviceEventEmitter.emit(MCP_REAUTH_REQUIRED_EVENT, { id: ext.id, name: ext.name });
+        throw new Error(`${ext.name} needs to sign in again. Open Extensions (MCP) to re-authenticate.`);
+      }
     });
+  }
+}
+
+async function fetchWithTokenRefresh(
+  ext: McpExtensionRecord,
+  client: MCPClient,
+  cacheKey: string,
+  groupName: string,
+): Promise<void> {
+  try {
+    await fetchAndCacheUserExtensionTools(ext, client, cacheKey, groupName);
+  } catch (error) {
+    if (!(error instanceof McpAuthError)) throw error;
+
+    log.info(
+      "[ToolkitManager] Got 401, attempting token refresh",
+      {},
+      { name: ext.name },
+    );
+    const newToken = await refreshMcpAccessToken(ext.id, ext.name);
+    if (newToken) {
+      client.reset(newToken);
+      try {
+        await fetchAndCacheUserExtensionTools(ext, client, cacheKey, groupName);
+        return;
+      } catch (retryError) {
+        if (!(retryError instanceof McpAuthError)) throw retryError;
+        log.warn(
+          "[ToolkitManager] Refreshed token also rejected, emitting re-auth event",
+          {},
+          { name: ext.name },
+        );
+      }
+    } else {
+      log.warn(
+        "[ToolkitManager] Token refresh failed, emitting re-auth event",
+        {},
+        { name: ext.name },
+      );
+    }
+    DeviceEventEmitter.emit(MCP_REAUTH_REQUIRED_EVENT, { id: ext.id, name: ext.name });
+    throw error;
   }
 }
 
@@ -769,7 +841,7 @@ async function loadUserMcpExtensionTools(): Promise<void> {
         await registerUserExtensionToolsFromCache(ext, client, cached.tools);
         setDynamicToolkitDefinitionsForServer(groupName, cached.tools.map((t) => t.definition));
         if (isStale) {
-          fetchAndCacheUserExtensionTools(ext, client, cacheKey, groupName).catch((error) => {
+          fetchWithTokenRefresh(ext, client, cacheKey, groupName).catch((error) => {
             log.warn(
               "[ToolkitManager] Background refresh of user extension cache failed",
               {},
@@ -778,7 +850,7 @@ async function loadUserMcpExtensionTools(): Promise<void> {
           });
         }
       } else {
-        await fetchAndCacheUserExtensionTools(ext, client, cacheKey, groupName);
+        await fetchWithTokenRefresh(ext, client, cacheKey, groupName);
       }
     } catch (error) {
       log.error(

--- a/modules/vm-webrtc/src/ToolkitManager.ts
+++ b/modules/vm-webrtc/src/ToolkitManager.ts
@@ -718,6 +718,18 @@ async function fetchAndCacheUserExtensionTools(
   );
 }
 
+const pendingTokenRefreshes = new Map<string, Promise<string | null>>();
+
+async function refreshTokenSingleFlight(ext: McpExtensionRecord): Promise<string | null> {
+  const existing = pendingTokenRefreshes.get(ext.id);
+  if (existing) return existing;
+  const promise = refreshMcpAccessToken(ext.id, ext.name).finally(() => {
+    pendingTokenRefreshes.delete(ext.id);
+  });
+  pendingTokenRefreshes.set(ext.id, promise);
+  return promise;
+}
+
 async function registerUserExtensionToolsFromCache(
   ext: McpExtensionRecord,
   client: MCPClient,
@@ -747,7 +759,7 @@ async function registerUserExtensionToolsFromCache(
           {},
           { name: ext.name, toolName },
         );
-        const newToken = await refreshMcpAccessToken(ext.id, ext.name);
+        const newToken = await refreshTokenSingleFlight(ext);
         if (newToken) {
           client.reset(newToken);
           try {
@@ -784,7 +796,7 @@ async function fetchWithTokenRefresh(
       {},
       { name: ext.name },
     );
-    const newToken = await refreshMcpAccessToken(ext.id, ext.name);
+    const newToken = await refreshTokenSingleFlight(ext);
     if (newToken) {
       client.reset(newToken);
       try {

--- a/modules/vm-webrtc/src/ToolkitManager.ts
+++ b/modules/vm-webrtc/src/ToolkitManager.ts
@@ -152,9 +152,9 @@ let toolkitGroupsPromise: Promise<ToolkitGroups> | null = null;
 async function reloadToolkitGroups(): Promise<void> {
   const startTime = Date.now();
   log.info(
-    "[ToolkitManager] Reloading toolkit groups due to connector settings change",
+    "[ToolkitManager] reloadToolkitGroups triggered",
     {},
-    {},
+    { caller: new Error().stack?.split("\n")[2]?.trim() },
   );
 
   // Clear all caches
@@ -823,6 +823,7 @@ async function fetchWithTokenRefresh(
 }
 
 async function loadUserMcpExtensionTools(): Promise<void> {
+  log.info("[ToolkitManager] loadUserMcpExtensionTools called", {}, { caller: new Error().stack?.split("\n")[2]?.trim() });
   const extensions = await getMcpExtensions().catch(() => [] as McpExtensionRecord[]);
   const enabled = extensions.filter((ext) => !ext.disabled);
 
@@ -884,6 +885,7 @@ async function loadUserMcpExtensionTools(): Promise<void> {
  * Internal function that actually fetches toolkit definitions.
  */
 async function fetchToolkitDefinitions(): Promise<ToolDefinition[]> {
+  log.info("[ToolkitManager] fetchToolkitDefinitions start", {}, { caller: new Error().stack?.split("\n")[2]?.trim() });
   dynamicToolkitDefinitionsByServer.clear();
 
   // Build static toolkit definitions if not cached

--- a/modules/vm-webrtc/src/mcp_client/client.ts
+++ b/modules/vm-webrtc/src/mcp_client/client.ts
@@ -21,6 +21,13 @@ export interface RequestOptions {
   timeout?: number;
 }
 
+export class McpAuthError extends Error {
+  constructor() {
+    super("MCP auth: 401");
+    this.name = "McpAuthError";
+  }
+}
+
 /**
  * Maximum characters allowed in MCP tool results to prevent context window overflow.
  * Results larger than this will be truncated.
@@ -43,6 +50,12 @@ export class MCPClient {
   constructor(endpoint: string, authToken?: string) {
     this.endpoint = endpoint;
     this.authToken = authToken;
+  }
+
+  reset(newToken: string): void {
+    this.authToken = newToken;
+    this.sessionId = null;
+    this.initializePromise = null;
   }
 
   /**
@@ -91,6 +104,7 @@ export class MCPClient {
       });
 
       if (!res.ok) {
+        if (res.status === 401) throw new McpAuthError();
         throw new Error(`Initialize failed: ${res.status} ${res.statusText}`);
       }
 
@@ -140,14 +154,16 @@ export class MCPClient {
         },
       );
     } catch (error) {
-      log.error(
-        "[MCPClient] Failed to initialize MCP session",
-        {},
-        {
-          endpoint: this.endpoint,
-          error: error instanceof Error ? error.message : String(error),
-        },
-      );
+      if (!(error instanceof McpAuthError)) {
+        log.error(
+          "[MCPClient] Failed to initialize MCP session",
+          {},
+          {
+            endpoint: this.endpoint,
+            error: error instanceof Error ? error.message : String(error),
+          },
+        );
+      }
       throw error;
     }
   }
@@ -353,6 +369,7 @@ export class MCPClient {
             statusText: res.statusText,
           },
         );
+        if (res.status === 401) throw new McpAuthError();
         throw new Error(`Network error: ${res.status} ${res.statusText}`);
       }
 

--- a/modules/vm-webrtc/src/mcp_client/extensions.ts
+++ b/modules/vm-webrtc/src/mcp_client/extensions.ts
@@ -1,5 +1,16 @@
 import { log } from "../../../../lib/logger";
 
+export interface McpResourceMetadata {
+  resource: string;
+  authorizationServers: string[];
+}
+
+export interface McpOAuthServerMetadata {
+  authorizationEndpoint: string;
+  tokenEndpoint: string;
+  registrationEndpoint: string | null;
+}
+
 export interface McpProbeResult {
   success: boolean;
   statusCode: number;
@@ -124,4 +135,124 @@ export async function probeMcpServer(
   );
 
   return result;
+}
+
+export async function fetchResourceMetadata(
+  resourceMetadataUrl: string,
+  connectorName?: string,
+): Promise<McpResourceMetadata> {
+  log.info(
+    "[mcp_extensions] Step 2: fetching resource metadata",
+    {},
+    { resource_metadata_url: resourceMetadataUrl, connector_name: connectorName },
+  );
+
+  const response = await fetch(resourceMetadataUrl, {
+    method: "GET",
+    headers: { Accept: "application/json" },
+  });
+
+  if (!response.ok) {
+    throw new Error(`Resource metadata fetch failed: ${response.status}`);
+  }
+
+  const json = await response.json();
+  const resource: string = json.resource ?? resourceMetadataUrl;
+  const authorizationServers: string[] = json.authorization_servers ?? [];
+
+  if (authorizationServers.length === 0) {
+    throw new Error("No authorization_servers in resource metadata");
+  }
+
+  log.info(
+    "[mcp_extensions] Step 2: got resource metadata",
+    {},
+    { resource, authorization_servers: authorizationServers, connector_name: connectorName },
+  );
+
+  return { resource, authorizationServers };
+}
+
+export async function fetchOAuthServerMetadata(
+  authServerBaseUrl: string,
+  connectorName?: string,
+): Promise<McpOAuthServerMetadata> {
+  const url = `${authServerBaseUrl.replace(/\/$/, "")}/.well-known/oauth-authorization-server`;
+  log.info(
+    "[mcp_extensions] Step 3: fetching OAuth server metadata",
+    {},
+    { url, connector_name: connectorName },
+  );
+
+  const response = await fetch(url, {
+    method: "GET",
+    headers: { Accept: "application/json" },
+  });
+
+  if (!response.ok) {
+    throw new Error(`OAuth server metadata fetch failed: ${response.status}`);
+  }
+
+  const json = await response.json();
+  const result: McpOAuthServerMetadata = {
+    authorizationEndpoint: json.authorization_endpoint,
+    tokenEndpoint: json.token_endpoint,
+    registrationEndpoint: json.registration_endpoint ?? null,
+  };
+
+  if (!result.authorizationEndpoint || !result.tokenEndpoint) {
+    throw new Error("OAuth server metadata missing authorization_endpoint or token_endpoint");
+  }
+
+  log.info(
+    "[mcp_extensions] Step 3: got OAuth server metadata",
+    {},
+    { ...result, connector_name: connectorName },
+  );
+
+  return result;
+}
+
+export async function registerOAuthClient(
+  registrationEndpoint: string,
+  redirectUri: string,
+  connectorName?: string,
+): Promise<{ clientId: string }> {
+  log.info(
+    "[mcp_extensions] Step 4: registering OAuth client",
+    {},
+    { registration_endpoint: registrationEndpoint, redirect_uri: redirectUri, connector_name: connectorName },
+  );
+
+  const response = await fetch(registrationEndpoint, {
+    method: "POST",
+    headers: { "Content-Type": "application/json", Accept: "application/json" },
+    body: JSON.stringify({
+      client_name: "Arty",
+      redirect_uris: [redirectUri],
+      grant_types: ["authorization_code", "refresh_token"],
+      response_types: ["code"],
+      token_endpoint_auth_method: "none",
+    }),
+  });
+
+  if (!response.ok) {
+    const body = await response.text().catch(() => "");
+    throw new Error(`Client registration failed: ${response.status} ${body.slice(0, 200)}`);
+  }
+
+  const json = await response.json();
+  const clientId: string = json.client_id;
+
+  if (!clientId) {
+    throw new Error("Client registration response missing client_id");
+  }
+
+  log.info(
+    "[mcp_extensions] Step 4: registered OAuth client",
+    {},
+    { client_id: clientId, connector_name: connectorName },
+  );
+
+  return { clientId };
 }

--- a/modules/vm-webrtc/src/mcp_client/extensions.ts
+++ b/modules/vm-webrtc/src/mcp_client/extensions.ts
@@ -157,9 +157,17 @@ export async function fetchResourceMetadata(
   }
 
   const json = await response.json();
-  const resource: string = json.resource ?? resourceMetadataUrl;
-  const authorizationServers: string[] = json.authorization_servers ?? [];
-
+  const resource: string = typeof json.resource === "string" ? json.resource : resourceMetadataUrl;
+  const rawServers = json.authorization_servers;
+  if (!Array.isArray(rawServers)) {
+    throw new Error("Resource metadata field 'authorization_servers' must be an array");
+  }
+  const authorizationServers: string[] = rawServers.map((s: unknown, i: number) => {
+    if (typeof s !== "string") {
+      throw new Error(`Resource metadata field 'authorization_servers[${i}]' must be a string`);
+    }
+    return s;
+  });
   if (authorizationServers.length === 0) {
     throw new Error("No authorization_servers in resource metadata");
   }
@@ -194,15 +202,20 @@ export async function fetchOAuthServerMetadata(
   }
 
   const json = await response.json();
+  if (typeof json.authorization_endpoint !== "string") {
+    throw new Error("OAuth server metadata field 'authorization_endpoint' must be a string");
+  }
+  if (typeof json.token_endpoint !== "string") {
+    throw new Error("OAuth server metadata field 'token_endpoint' must be a string");
+  }
+  if (json.registration_endpoint != null && typeof json.registration_endpoint !== "string") {
+    throw new Error("OAuth server metadata field 'registration_endpoint' must be a string");
+  }
   const result: McpOAuthServerMetadata = {
     authorizationEndpoint: json.authorization_endpoint,
     tokenEndpoint: json.token_endpoint,
     registrationEndpoint: json.registration_endpoint ?? null,
   };
-
-  if (!result.authorizationEndpoint || !result.tokenEndpoint) {
-    throw new Error("OAuth server metadata missing authorization_endpoint or token_endpoint");
-  }
 
   log.info(
     "[mcp_extensions] Step 3: got OAuth server metadata",
@@ -242,11 +255,10 @@ export async function registerOAuthClient(
   }
 
   const json = await response.json();
-  const clientId: string = json.client_id;
-
-  if (!clientId) {
-    throw new Error("Client registration response missing client_id");
+  if (typeof json.client_id !== "string" || !json.client_id) {
+    throw new Error("Client registration response field 'client_id' must be a non-empty string");
   }
+  const clientId: string = json.client_id;
 
   log.info(
     "[mcp_extensions] Step 4: registered OAuth client",

--- a/wizard.ts
+++ b/wizard.ts
@@ -267,7 +267,7 @@ async function executeChoice(choice: string): Promise<void> {
       : await executeCommand(option.command);
 
     if (exitCode === 0) {
-      console.log(`\n✅ ${option.name} completed successfully!`);
+      console.log(`\n✅ ${option.name} completed successfully! (${new Date().toLocaleTimeString()})`);
       process.exit(0);
     } else {
       console.error(`\n❌ ${option.name} failed with exit code ${exitCode}`);
@@ -290,7 +290,7 @@ async function handleFlag(flag: string): Promise<void> {
       : await executeCommand(option.command);
 
     if (exitCode === 0) {
-      console.log(`\n✅ ${option.name} completed successfully!`);
+      console.log(`\n✅ ${option.name} completed successfully! (${new Date().toLocaleTimeString()})`);
       process.exit(0);
     } else {
       console.error(`\n❌ ${option.name} failed with exit code ${exitCode}`);

--- a/wizard.ts
+++ b/wizard.ts
@@ -189,6 +189,12 @@ const BUILD_OPTIONS: BuildOption[] = [
     command: "xed ios",
     description: "Open iOS project in Xcode",
   },
+  {
+    name: "Register New Device UDID",
+    flag: "register-device",
+    command: "bunx eas device:create",
+    description: "Register a new device UDID with EAS",
+  },
 ];
 
 async function executeCommand(command: string): Promise<number> {


### PR DESCRIPTION
It's super buggy, but it works.  With supabase magic link login I often get a blank screen, need to restart the app, and then the mcp connector will work.

# How to test without deep links 

With supabase magic link auth, after you click the magic link in email, it will open your browser.  You will have to somehow get the authorization code and paste the whole deep link into the Arty screen that asks for it.  


# AI generated MCP OAuth Authentication Plan

## Overview

Implement OAuth 2.0 authentication for MCP server connections following the MCP authorization spec with PKCE and dynamic client registration.

## Steps

### Step 1 — Fetch MCP Server Metadata

Connect to the MCP server and fetch the root metadata to discover the `resource_metadata_url`.

### Step 2 — Fetch Resource Metadata

Fetch `resource_metadata_url` to retrieve the `authorization_servers` list.

### Step 3 — Probe OAuth Authorization Server

Send a request to `/.well-known/oauth-authorization-server` on the auth server to discover:
- `authorization_endpoint`
- `token_endpoint`
- `registration_endpoint`

### Step 4 — Dynamic Client Registration

POST to `registration_endpoint` to dynamically register the client and receive a `client_id`.

### Step 5 — Open In-App Browser for Authorization

Open an in-app browser to `authorization_endpoint` with:
- PKCE `code_challenge`
- `resource` param

### Step 6 — Exchange Code for Token

Handle the redirect callback, then POST to `token_endpoint` with:
- `code`
- `code_verifier`

Store the resulting access token securely.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added OAuth-based authentication for MCP connectors with a two-stage connection flow.
  * Users can now complete sign-in via browser and enter callback URLs to finalize authentication.
  * Added session expiration detection with re-authentication prompts from the extensions screen.

* **Improvements**
  * Automatic token refresh when credentials expire.
  * Enhanced status messaging during connection and sign-in stages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->