### PR TITLE
Translation: change language output during call

### DIFF
--- a/app/RealtimeTranslation.tsx
+++ b/app/RealtimeTranslation.tsx
@@ -40,6 +40,7 @@ import VmWebrtcTranslatorModule, {
   closeTranslationConnectionAsync,
   muteUnmuteOutgoingAudio,
   openTranslationConnectionAsync,
+  updateOutputLanguage,
   type TranslationTranscriptEventPayload,
 } from "../modules/vm-webrtc/src/VmWebrtcTranslatorModule";
 
@@ -378,7 +379,14 @@ export function RealtimeTranslation({
   const handleSelectLanguage = useCallback((code: string) => {
     setOutputLanguage(code);
     saveOutputLanguage(code);
-  }, []);
+    if (isSessionActive) {
+      try {
+        updateOutputLanguage(code);
+      } catch (e) {
+        log.warn("[RealtimeTranslation] updateOutputLanguage unavailable", {}, { error: e });
+      }
+    }
+  }, [isSessionActive]);
 
   const isSpeakerphone = audioOutput === "speakerphone";
 

--- a/app/RealtimeTranslation.tsx
+++ b/app/RealtimeTranslation.tsx
@@ -394,7 +394,6 @@ export function RealtimeTranslation({
     <View style={styles.content}>
       <LanguagePickerRow
         outputLanguage={outputLanguage}
-        isSessionActive={isSessionActive}
         onSelectLanguage={handleSelectLanguage}
         onOpenModal={() => setLanguageModalVisible(true)}
       />

--- a/components/realtime/LanguagePickerRow.tsx
+++ b/components/realtime/LanguagePickerRow.tsx
@@ -7,14 +7,12 @@ import {
 
 type Props = {
   outputLanguage: string;
-  isSessionActive: boolean;
   onSelectLanguage: (code: string) => void;
   onOpenModal: () => void;
 };
 
 export function LanguagePickerRow({
   outputLanguage,
-  isSessionActive,
   onSelectLanguage,
   onOpenModal,
 }: Props) {
@@ -29,11 +27,10 @@ export function LanguagePickerRow({
           return (
             <Pressable
               key={lang.code}
-              onPress={() => !isSessionActive && onSelectLanguage(lang.code)}
+              onPress={() => onSelectLanguage(lang.code)}
               style={[
                 styles.langChip,
                 isSelected && styles.langChipSelected,
-                isSessionActive && styles.langChipDisabled,
               ]}
             >
               <Text style={styles.langFlag}>{lang.flag}</Text>
@@ -49,11 +46,10 @@ export function LanguagePickerRow({
           );
         })}
         <Pressable
-          onPress={() => !isSessionActive && onOpenModal()}
+          onPress={() => onOpenModal()}
           style={[
             styles.langChip,
             styles.langChipMore,
-            isSessionActive && styles.langChipDisabled,
             !FEATURED_LANGUAGE_CODES.includes(outputLanguage) &&
               styles.langChipSelected,
           ]}
@@ -122,9 +118,6 @@ const styles = StyleSheet.create({
   },
   langChipMore: {
     backgroundColor: "#F2F2F7",
-  },
-  langChipDisabled: {
-    opacity: 0.45,
   },
   langFlag: {
     fontSize: 18,

--- a/modules/vm-webrtc/ios/OpenAIWebRTCTranslatorClient.swift
+++ b/modules/vm-webrtc/ios/OpenAIWebRTCTranslatorClient.swift
@@ -132,6 +132,23 @@ final class OpenAIWebRTCTranslatorClient: OpenAIWebRTCBase {
         return result
     }
 
+    // MARK: Language update
+
+    @MainActor
+    func updateOutputLanguage(_ language: String) {
+        let trimmed = language.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return }
+        outputLanguage = trimmed
+        logger.log(
+            "[VmWebrtc][Translator] Sending language update",
+            attributes: logAttributes(for: .info, metadata: ["role": role, "language": trimmed])
+        )
+        _ = sendEvent([
+            "type": "session.update",
+            "session": ["audio": ["output": ["language": trimmed]]]
+        ])
+    }
+
     // MARK: Virtual hook overrides
 
     override func dataChannelDidOpen() {

--- a/modules/vm-webrtc/ios/WebRTCTranslatorModule.swift
+++ b/modules/vm-webrtc/ios/WebRTCTranslatorModule.swift
@@ -125,5 +125,11 @@ public class WebRTCTranslatorModule: Module {
                 self.reverseClient.setOutgoingAudioMuted(shouldMute)
             }
         }
+
+        Function("updateOutputLanguage") { (language: String) in
+            Task { @MainActor in
+                self.primaryClient.updateOutputLanguage(language)
+            }
+        }
     }
 }

--- a/modules/vm-webrtc/src/VmWebrtcTranslatorModule.ts
+++ b/modules/vm-webrtc/src/VmWebrtcTranslatorModule.ts
@@ -39,6 +39,7 @@ declare class VmWebrtcTranslatorModule extends NativeModule<TranslatorModuleEven
   ): Promise<OpenAIConnectionState>;
   closeTranslationConnectionAsync(): Promise<OpenAIConnectionState>;
   muteUnmuteOutgoingAudio(shouldMute: boolean): void;
+  updateOutputLanguage(language: string): void;
 }
 
 const makeUnavailableError = () =>
@@ -82,6 +83,12 @@ export const muteUnmuteOutgoingAudio = (shouldMute: boolean): void => {
   if (!module) throw makeUnavailableError();
   log.debug(`[${MODULE_NAME}] muteUnmuteOutgoingAudio`, {}, { shouldMute });
   module.muteUnmuteOutgoingAudio(shouldMute);
+};
+
+export const updateOutputLanguage = (language: string): void => {
+  if (!module) throw makeUnavailableError();
+  log.debug(`[${MODULE_NAME}] updateOutputLanguage`, {}, { language });
+  module.updateOutputLanguage(language);
 };
 
 export default module ?? ({} as VmWebrtcTranslatorModule);


### PR DESCRIPTION
Since https://github.com/tleyden/arty/issues/133 isn't working yet, this workaround will allow people to have bidirectional conversations by taking turns and manually switching languages.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * You can now change the translation output language while a translation session is active. Switch your output language in real-time without interrupting or restarting your session, giving you greater flexibility to adapt to changing communication needs as they arise.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tleyden/arty/pull/136)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->