### PR TITLE
MCP OAuth2 with static client ID and PKCE

### DIFF
--- a/components/settings/McpConnectorConfig.tsx
+++ b/components/settings/McpConnectorConfig.tsx
@@ -17,10 +17,16 @@ import * as Clipboard from "expo-clipboard";
 import { probeMcpServer } from "../../modules/vm-webrtc/src/mcp_client/extensions";
 import {
   addMcpExtension,
+  clearMcpAuthCredentials,
+  deleteMcpClientSecret,
   deleteMcpBearerToken,
+  getMcpAuthMode,
   getMcpBearerToken,
+  getMcpClientId,
+  getMcpClientSecret,
   getMcpExtensions,
   getMcpRefreshToken,
+  saveMcpAuthMode,
   saveMcpBearerToken,
   toNormalizedName,
   uniqueNormalizedName,
@@ -30,9 +36,17 @@ import {
   completeMcpOAuthFromCallbackUrl,
   performMcpOAuthFlow,
   type McpOAuthPendingState,
+  type StaticOAuthCredentials,
 } from "../../lib/mcp-oauth";
 import { CONNECTOR_SETTINGS_CHANGED_EVENT } from "../../modules/vm-webrtc/src/ToolkitManager";
 import { log } from "../../lib/logger";
+import {
+  buildStaticOAuthCredentials,
+  deriveMcpConnectorAuthState,
+  validateMcpConnectorForm,
+  type McpConnectorAuthMethod,
+  type McpStoredAuthMode,
+} from "./mcpConnectorAuthConfig";
 
 export interface McpConnectorConfigProps {
   visible: boolean;
@@ -63,32 +77,82 @@ export const McpConnectorConfig: React.FC<McpConnectorConfigProps> = ({
   const [tokenVisible, setTokenVisible] = useState(false);
   const [copyFeedback, setCopyFeedback] = useState(false);
   const [hasOAuthToken, setHasOAuthToken] = useState(false);
+  const [authMethod, setAuthMethod] = useState<McpConnectorAuthMethod>("auto");
+  const [staticClientId, setStaticClientId] = useState("");
+  const [staticClientSecret, setStaticClientSecret] = useState("");
+  const [staticAuthEndpoint, setStaticAuthEndpoint] = useState("");
+  const [staticTokenEndpoint, setStaticTokenEndpoint] = useState("");
+  const [staticScopes, setStaticScopes] = useState("");
+  const [staticSecretVisible, setStaticSecretVisible] = useState(false);
   const [pendingOAuth, setPendingOAuth] = useState<McpOAuthPendingState | null>(null);
   const [pendingExtensionId, setPendingExtensionId] = useState<string | null>(null);
+  const [pendingAuthMode, setPendingAuthMode] = useState<McpStoredAuthMode>(null);
   const [callbackUrl, setCallbackUrl] = useState("");
   const [callbackError, setCallbackError] = useState("");
   const [keyboardPadding, setKeyboardPadding] = useState(0);
 
   useEffect(() => {
+    let cancelled = false;
     if (visible && existingExtension) {
       setName(existingExtension.name);
       setServerUrl(existingExtension.serverUrl);
       setNormalizedNamePreview(existingExtension.normalizedName ?? toNormalizedName(existingExtension.name));
+      setStaticAuthEndpoint("");
+      setStaticTokenEndpoint("");
+      setStaticScopes("");
+      setStaticSecretVisible(false);
+      setPendingOAuth(null);
+      setPendingExtensionId(null);
+      setPendingAuthMode(null);
+      setCallbackUrl("");
+      setCallbackError("");
       Promise.all([
         getMcpBearerToken(existingExtension.id),
         getMcpRefreshToken(existingExtension.id),
-      ]).then(([token, refreshToken]) => {
-        if (refreshToken) {
-          setHasOAuthToken(true);
-        } else if (token) {
-          setBearerToken(token);
-          setAdvancedExpanded(true);
+        getMcpAuthMode(existingExtension.id),
+        getMcpClientId(existingExtension.id),
+        getMcpClientSecret(existingExtension.id),
+      ]).then(([token, refreshToken, storedAuthMode, clientId, clientSecret]) => {
+        if (cancelled) {
+          return;
         }
+        const derived = deriveMcpConnectorAuthState({
+          token,
+          refreshToken,
+          authMode: (storedAuthMode ?? existingExtension.authMode ?? null) as McpStoredAuthMode,
+          clientId,
+          clientSecret,
+        });
+        setHasOAuthToken(derived.hasOAuthToken);
+        setAuthMethod(derived.authMethod);
+        setAdvancedExpanded(derived.advancedExpanded);
+        setBearerToken(derived.bearerToken);
+        setStaticClientId(derived.staticClientId);
+        setStaticClientSecret(derived.staticClientSecret);
       });
     } else if (visible) {
+      setName("");
+      setServerUrl("");
+      setBearerToken("");
       setNormalizedNamePreview("");
       setHasOAuthToken(false);
+      setAdvancedExpanded(false);
+      setAuthMethod("auto");
+      setStaticClientId("");
+      setStaticClientSecret("");
+      setStaticAuthEndpoint("");
+      setStaticTokenEndpoint("");
+      setStaticScopes("");
+      setStaticSecretVisible(false);
+      setPendingOAuth(null);
+      setPendingExtensionId(null);
+      setPendingAuthMode(null);
+      setCallbackUrl("");
+      setCallbackError("");
     }
+    return () => {
+      cancelled = true;
+    };
   }, [visible, existingExtension]);
 
   useEffect(() => {
@@ -132,18 +196,53 @@ export const McpConnectorConfig: React.FC<McpConnectorConfigProps> = ({
   const persistExtension = async (
     id: string,
     manualToken?: string,
-    options?: { preserveExistingToken?: boolean },
+    options?: {
+      preserveExistingToken?: boolean;
+      authMode?: "dcr" | "static" | "bearer";
+    },
   ) => {
-    log.info("[mcp_connector] persistExtension start", {}, { id, isEditing, hasManualToken: !!manualToken, preserveExistingToken: options?.preserveExistingToken });
+    log.info(
+      "[mcp_connector] persistExtension start",
+      {},
+      {
+        id,
+        isEditing,
+        hasManualToken: !!manualToken,
+        preserveExistingToken: options?.preserveExistingToken,
+        authMode: options?.authMode,
+      },
+    );
     const allExtensions = await getMcpExtensions();
     const normalizedName = uniqueNormalizedName(toNormalizedName(name), allExtensions, existingExtension?.id);
-    const record: McpExtensionRecord = { id, name, normalizedName, serverUrl };
+    const record: McpExtensionRecord = {
+      id,
+      name,
+      normalizedName,
+      serverUrl,
+      authMode: options?.authMode,
+    };
     await addMcpExtension(record);
-    if (manualToken) {
+
+    if (options?.authMode === "bearer" && manualToken) {
       await saveMcpBearerToken(id, manualToken);
-    } else if (!options?.preserveExistingToken) {
+      await clearMcpAuthCredentials(id);
+      await saveMcpAuthMode(id, "bearer");
+    } else if (options?.authMode === "dcr") {
+      if (!options.preserveExistingToken) {
+        await deleteMcpBearerToken(id);
+      }
+      await deleteMcpClientSecret(id);
+      await saveMcpAuthMode(id, "dcr");
+    } else if (options?.authMode === "static") {
+      if (!options.preserveExistingToken) {
+        await deleteMcpBearerToken(id);
+      }
+      await saveMcpAuthMode(id, "static");
+    } else {
       await deleteMcpBearerToken(id);
+      await clearMcpAuthCredentials(id);
     }
+
     DeviceEventEmitter.emit(CONNECTOR_SETTINGS_CHANGED_EVENT);
     log.info("[mcp_connector] calling onSave", {}, { id });
     onSave?.(record);
@@ -162,12 +261,69 @@ export const McpConnectorConfig: React.FC<McpConnectorConfigProps> = ({
     setIsConnecting(true);
     setConnectingLabel("Connecting…");
     try {
+      const validationError = validateMcpConnectorForm({
+        name,
+        serverUrl,
+        authMethod,
+        staticClientId,
+        staticAuthorizationEndpoint: staticAuthEndpoint,
+        staticTokenEndpoint,
+      });
+      if (validationError) {
+        Alert.alert("Missing Field", validationError, [{ text: "OK" }]);
+        return;
+      }
+
+      if (authMethod === "static") {
+        const id = existingExtension?.id ?? `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+        setConnectingLabel("Opening sign-in…");
+
+        const staticCredentials: StaticOAuthCredentials = buildStaticOAuthCredentials({
+          clientId: staticClientId,
+          clientSecret: staticClientSecret,
+          authorizationEndpoint: staticAuthEndpoint,
+          tokenEndpoint: staticTokenEndpoint,
+          scopes: staticScopes,
+        });
+
+        try {
+          onBeforeBrowserOpen?.();
+          const oauthResult = await performMcpOAuthFlow(
+            id,
+            "",
+            name,
+            undefined,
+            staticCredentials,
+          );
+          log.info("[mcp_connector] Static OAuth flow returned", {}, { oauthResult_type: oauthResult.type });
+          if (oauthResult.type === "success") {
+            await persistExtension(id, undefined, {
+              preserveExistingToken: true,
+              authMode: "static",
+            });
+          } else {
+            setPendingOAuth(oauthResult.pendingState);
+            setPendingExtensionId(id);
+            setPendingAuthMode("static");
+            onNeedsManualCallback?.();
+          }
+        } catch (oauthError: any) {
+          log.error("[mcp_connector] Static OAuth error caught", {}, { message: oauthError?.message });
+          Alert.alert(
+            "Authentication Failed",
+            oauthError?.message ?? "OAuth sign-in failed.",
+            [{ text: "OK" }],
+          );
+        }
+        return;
+      }
+
       const token = bearerToken.trim() || undefined;
       const result = await probeMcpServer(serverUrl, token, name);
 
       if (result.success) {
         const id = existingExtension?.id ?? `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
-        await persistExtension(id, token);
+        await persistExtension(id, token, { authMode: token ? "bearer" : undefined });
       } else if (result.statusCode === 401 && result.resourceMetadataUrl) {
         const id = existingExtension?.id ?? `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
         setConnectingLabel("Opening sign-in…");
@@ -179,10 +335,14 @@ export const McpConnectorConfig: React.FC<McpConnectorConfigProps> = ({
           const oauthResult = await performMcpOAuthFlow(id, result.resourceMetadataUrl, name, { serverUrl, normalizedName });
           log.info("[mcp_connector] OAuth flow returned", {}, { oauthResult_type: oauthResult.type });
           if (oauthResult.type === "success") {
-            await persistExtension(id, undefined, { preserveExistingToken: true });
+            await persistExtension(id, undefined, {
+              preserveExistingToken: true,
+              authMode: "dcr",
+            });
           } else {
             setPendingOAuth(oauthResult.pendingState);
             setPendingExtensionId(id);
+            setPendingAuthMode("dcr");
             onNeedsManualCallback?.();
           }
         } catch (oauthError: any) {
@@ -217,7 +377,10 @@ export const McpConnectorConfig: React.FC<McpConnectorConfigProps> = ({
     setConnectingLabel("Completing sign-in…");
     try {
       await completeMcpOAuthFromCallbackUrl(callbackUrl.trim(), pendingOAuth);
-      await persistExtension(pendingExtensionId, undefined, { preserveExistingToken: true });
+      await persistExtension(pendingExtensionId, undefined, {
+        preserveExistingToken: true,
+        authMode: pendingAuthMode === "static" || pendingAuthMode === "dcr" ? pendingAuthMode : undefined,
+      });
     } catch (err: any) {
       setCallbackError(err?.message ?? "Failed to complete sign-in. Check the URL and try again.");
     } finally {
@@ -235,8 +398,16 @@ export const McpConnectorConfig: React.FC<McpConnectorConfigProps> = ({
     setAdvancedExpanded(false);
     setTokenVisible(false);
     setHasOAuthToken(false);
+    setAuthMethod("auto");
+    setStaticClientId("");
+    setStaticClientSecret("");
+    setStaticAuthEndpoint("");
+    setStaticTokenEndpoint("");
+    setStaticScopes("");
+    setStaticSecretVisible(false);
     setPendingOAuth(null);
     setPendingExtensionId(null);
+    setPendingAuthMode(null);
     setCallbackUrl("");
     setCallbackError("");
     onClose();
@@ -363,63 +534,208 @@ export const McpConnectorConfig: React.FC<McpConnectorConfigProps> = ({
 
               {advancedExpanded && (
                 <View style={styles.advancedSection}>
-                  <Text style={styles.label}>Bearer Token</Text>
-
-                  <View style={styles.tokenInputRow}>
-                    <TextInput
-                      style={[styles.input, styles.tokenInput]}
-                      value={bearerToken}
-                      onChangeText={handleTokenChange}
-                      placeholder="Optional JWT or access token..."
-                      placeholderTextColor="#AEAEB2"
-                      autoCapitalize="none"
-                      autoCorrect={false}
-                      secureTextEntry={!tokenVisible}
-                      multiline={false}
-                    />
-                    <Pressable
-                      style={({ pressed }) => [
-                        styles.tokenIconButton,
-                        pressed && styles.tokenIconButtonPressed,
-                      ]}
-                      onPress={() => setTokenVisible((v) => !v)}
-                    >
-                      <Text style={styles.tokenIconText}>
-                        {tokenVisible ? "🙈" : "👁️"}
-                      </Text>
-                    </Pressable>
+                  <View style={styles.section}>
+                    <Text style={styles.label}>OAuth Method</Text>
+                    <View style={styles.segmentControl}>
+                      <Pressable
+                        style={[
+                          styles.segment,
+                          authMethod === "auto" && styles.segmentActive,
+                        ]}
+                        onPress={() => {
+                          setAuthMethod("auto");
+                          setAdvancedExpanded(true);
+                        }}
+                      >
+                        <Text
+                          style={[
+                            styles.segmentText,
+                            authMethod === "auto" && styles.segmentTextActive,
+                          ]}
+                        >
+                          Auto (DCR)
+                        </Text>
+                      </Pressable>
+                      <Pressable
+                        style={[
+                          styles.segment,
+                          authMethod === "static" && styles.segmentActive,
+                        ]}
+                        onPress={() => {
+                          setAuthMethod("static");
+                          setAdvancedExpanded(true);
+                        }}
+                      >
+                        <Text
+                          style={[
+                            styles.segmentText,
+                            authMethod === "static" && styles.segmentTextActive,
+                          ]}
+                        >
+                          Static Credentials
+                        </Text>
+                      </Pressable>
+                    </View>
+                    <Text style={styles.hint}>
+                      {authMethod === "auto"
+                        ? "Automatically discover OAuth endpoints and register a public client."
+                        : "Use an existing OAuth client ID and optional client secret with manually entered endpoints."}
+                    </Text>
                   </View>
 
-                  <View style={styles.tokenActions}>
-                    <Pressable
-                      style={({ pressed }) => [
-                        styles.tokenActionButton,
-                        pressed && styles.tokenActionButtonPressed,
-                      ]}
-                      onPress={handlePaste}
-                    >
-                      <Text style={styles.tokenActionText}>Paste</Text>
-                    </Pressable>
-                    <Pressable
-                      style={({ pressed }) => [
-                        styles.tokenActionButton,
-                        !bearerToken && styles.tokenActionButtonDisabled,
-                        pressed && styles.tokenActionButtonPressed,
-                      ]}
-                      onPress={handleCopy}
-                      disabled={!bearerToken}
-                    >
-                      <Text style={styles.tokenActionText}>
-                        {copyFeedback ? "Copied!" : "Copy"}
-                      </Text>
-                    </Pressable>
-                  </View>
+                  {authMethod === "static" ? (
+                    <>
+                      <View style={styles.section}>
+                        <Text style={styles.label}>Client ID *</Text>
+                        <TextInput
+                          style={styles.input}
+                          value={staticClientId}
+                          onChangeText={setStaticClientId}
+                          placeholder="your-client-id"
+                          placeholderTextColor="#AEAEB2"
+                          autoCapitalize="none"
+                          autoCorrect={false}
+                        />
+                      </View>
 
-                  <Text style={styles.hint}>
-                    Sent as{" "}
-                    <Text style={styles.hintMono}>Authorization: Bearer …</Text> on
-                    every request. Newlines are stripped automatically.
-                  </Text>
+                      <View style={styles.section}>
+                        <Text style={styles.label}>Client Secret</Text>
+                        <View style={styles.passwordContainer}>
+                          <TextInput
+                            style={[styles.input, styles.passwordInput]}
+                            value={staticClientSecret}
+                            onChangeText={setStaticClientSecret}
+                            placeholder="Optional for confidential clients"
+                            placeholderTextColor="#AEAEB2"
+                            autoCapitalize="none"
+                            autoCorrect={false}
+                            secureTextEntry={!staticSecretVisible}
+                          />
+                          <Pressable
+                            style={({ pressed }) => [
+                              styles.inlineActionButton,
+                              pressed && styles.inlineActionButtonPressed,
+                            ]}
+                            onPress={() => setStaticSecretVisible((value) => !value)}
+                          >
+                            <Text style={styles.inlineActionText}>
+                              {staticSecretVisible ? "Hide" : "Show"}
+                            </Text>
+                          </Pressable>
+                        </View>
+                        <Text style={styles.hint}>
+                          Leave blank for public clients. Add a secret for confidential clients using `client_secret_post`.
+                        </Text>
+                      </View>
+
+                      <View style={styles.section}>
+                        <Text style={styles.label}>Authorization Endpoint *</Text>
+                        <TextInput
+                          style={styles.input}
+                          value={staticAuthEndpoint}
+                          onChangeText={setStaticAuthEndpoint}
+                          placeholder="https://provider.com/oauth/authorize"
+                          placeholderTextColor="#AEAEB2"
+                          autoCapitalize="none"
+                          autoCorrect={false}
+                          keyboardType="url"
+                        />
+                      </View>
+
+                      <View style={styles.section}>
+                        <Text style={styles.label}>Token Endpoint *</Text>
+                        <TextInput
+                          style={styles.input}
+                          value={staticTokenEndpoint}
+                          onChangeText={setStaticTokenEndpoint}
+                          placeholder="https://provider.com/oauth/token"
+                          placeholderTextColor="#AEAEB2"
+                          autoCapitalize="none"
+                          autoCorrect={false}
+                          keyboardType="url"
+                        />
+                        <Text style={styles.hint}>
+                          Static endpoints are not persisted for display. Re-enter them here when you need to re-authenticate.
+                        </Text>
+                      </View>
+
+                      <View style={styles.section}>
+                        <Text style={styles.label}>Scopes</Text>
+                        <TextInput
+                          style={styles.input}
+                          value={staticScopes}
+                          onChangeText={setStaticScopes}
+                          placeholder="openid, profile, email"
+                          placeholderTextColor="#AEAEB2"
+                          autoCapitalize="none"
+                          autoCorrect={false}
+                        />
+                        <Text style={styles.hint}>
+                          Comma-separated scopes requested during authorization.
+                        </Text>
+                      </View>
+                    </>
+                  ) : (
+                    <>
+                      <Text style={styles.label}>Bearer Token</Text>
+
+                      <View style={styles.tokenInputRow}>
+                        <TextInput
+                          style={[styles.input, styles.tokenInput]}
+                          value={bearerToken}
+                          onChangeText={handleTokenChange}
+                          placeholder="Optional JWT or access token..."
+                          placeholderTextColor="#AEAEB2"
+                          autoCapitalize="none"
+                          autoCorrect={false}
+                          secureTextEntry={!tokenVisible}
+                          multiline={false}
+                        />
+                        <Pressable
+                          style={({ pressed }) => [
+                            styles.tokenIconButton,
+                            pressed && styles.tokenIconButtonPressed,
+                          ]}
+                          onPress={() => setTokenVisible((v) => !v)}
+                        >
+                          <Text style={styles.tokenIconText}>
+                            {tokenVisible ? "🙈" : "👁️"}
+                          </Text>
+                        </Pressable>
+                      </View>
+
+                      <View style={styles.tokenActions}>
+                        <Pressable
+                          style={({ pressed }) => [
+                            styles.tokenActionButton,
+                            pressed && styles.tokenActionButtonPressed,
+                          ]}
+                          onPress={handlePaste}
+                        >
+                          <Text style={styles.tokenActionText}>Paste</Text>
+                        </Pressable>
+                        <Pressable
+                          style={({ pressed }) => [
+                            styles.tokenActionButton,
+                            !bearerToken && styles.tokenActionButtonDisabled,
+                            pressed && styles.tokenActionButtonPressed,
+                          ]}
+                          onPress={handleCopy}
+                          disabled={!bearerToken}
+                        >
+                          <Text style={styles.tokenActionText}>
+                            {copyFeedback ? "Copied!" : "Copy"}
+                          </Text>
+                        </Pressable>
+                      </View>
+
+                      <Text style={styles.hint}>
+                        Sent as{" "}
+                        <Text style={styles.hintMono}>Authorization: Bearer ...</Text> on
+                        every request. Newlines are stripped automatically.
+                      </Text>
+                    </>
+                  )}
                 </View>
               )}
             </>
@@ -559,6 +875,57 @@ const styles = StyleSheet.create({
   },
   advancedSection: {
     marginBottom: 24,
+  },
+  segmentControl: {
+    flexDirection: "row",
+    backgroundColor: "#EAEAEE",
+    borderRadius: 12,
+    padding: 4,
+  },
+  segment: {
+    flex: 1,
+    paddingVertical: 10,
+    paddingHorizontal: 12,
+    alignItems: "center",
+    borderRadius: 10,
+  },
+  segmentActive: {
+    backgroundColor: "#FFFFFF",
+    shadowColor: "#000000",
+    shadowOffset: { width: 0, height: 1 },
+    shadowOpacity: 0.08,
+    shadowRadius: 2,
+    elevation: 1,
+  },
+  segmentText: {
+    fontSize: 14,
+    fontWeight: "600",
+    color: "#636366",
+  },
+  segmentTextActive: {
+    color: "#1C1C1E",
+  },
+  passwordContainer: {
+    position: "relative",
+  },
+  passwordInput: {
+    paddingRight: 76,
+  },
+  inlineActionButton: {
+    position: "absolute",
+    right: 10,
+    top: 8,
+    bottom: 8,
+    justifyContent: "center",
+    paddingHorizontal: 10,
+  },
+  inlineActionButtonPressed: {
+    opacity: 0.6,
+  },
+  inlineActionText: {
+    fontSize: 13,
+    fontWeight: "600",
+    color: "#0A84FF",
   },
   tokenInputRow: {
     flexDirection: "row",

--- a/components/settings/McpConnectorConfig.tsx
+++ b/components/settings/McpConnectorConfig.tsx
@@ -43,6 +43,7 @@ import { log } from "../../lib/logger";
 import {
   buildStaticOAuthCredentials,
   deriveMcpConnectorAuthState,
+  sanitizeMcpConnectorForm,
   validateMcpConnectorForm,
   type McpConnectorAuthMethod,
   type McpStoredAuthMode,
@@ -186,6 +187,10 @@ export const McpConnectorConfig: React.FC<McpConnectorConfigProps> = ({
 
   const persistExtension = async (
     id: string,
+    sanitizedForm: {
+      name: string;
+      serverUrl: string;
+    },
     manualToken?: string,
     options?: {
       preserveExistingToken?: boolean;
@@ -204,12 +209,16 @@ export const McpConnectorConfig: React.FC<McpConnectorConfigProps> = ({
       },
     );
     const allExtensions = await getMcpExtensions();
-    const normalizedName = uniqueNormalizedName(toNormalizedName(name), allExtensions, existingExtension?.id);
+    const normalizedName = uniqueNormalizedName(
+      toNormalizedName(sanitizedForm.name),
+      allExtensions,
+      existingExtension?.id,
+    );
     const record: McpExtensionRecord = {
       id,
-      name,
+      name: sanitizedForm.name,
       normalizedName,
-      serverUrl,
+      serverUrl: sanitizedForm.serverUrl,
       authMode: options?.authMode,
     };
     await addMcpExtension(record);
@@ -252,11 +261,18 @@ export const McpConnectorConfig: React.FC<McpConnectorConfigProps> = ({
     setIsConnecting(true);
     setConnectingLabel("Connecting…");
     try {
-      const validationError = validateMcpConnectorForm({
+      const sanitizedForm = sanitizeMcpConnectorForm({
         name,
         serverUrl,
-        authMethod,
+        bearerToken,
         staticClientId,
+        staticClientSecret,
+      });
+      const validationError = validateMcpConnectorForm({
+        name: sanitizedForm.name,
+        serverUrl: sanitizedForm.serverUrl,
+        authMethod,
+        staticClientId: sanitizedForm.staticClientId,
       });
       if (validationError) {
         Alert.alert("Missing Field", validationError, [{ text: "OK" }]);
@@ -267,7 +283,11 @@ export const McpConnectorConfig: React.FC<McpConnectorConfigProps> = ({
         const id = existingExtension?.id ?? `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
 
         // Probe the server to discover OAuth endpoints, same as the auto/DCR flow.
-        const probeResult = await probeMcpServer(serverUrl, undefined, name);
+        const probeResult = await probeMcpServer(
+          sanitizedForm.serverUrl,
+          undefined,
+          sanitizedForm.name,
+        );
         if (probeResult.statusCode !== 401 || !probeResult.resourceMetadataUrl) {
           const detail = probeResult.error ?? `Server returned ${probeResult.statusCode}`;
           Alert.alert("Connection Failed", detail, [{ text: "OK" }]);
@@ -276,8 +296,8 @@ export const McpConnectorConfig: React.FC<McpConnectorConfigProps> = ({
 
         setConnectingLabel("Opening sign-in…");
         const staticCredentials: StaticOAuthCredentials = buildStaticOAuthCredentials({
-          clientId: staticClientId,
-          clientSecret: staticClientSecret,
+          clientId: sanitizedForm.staticClientId,
+          clientSecret: sanitizedForm.staticClientSecret,
         });
 
         try {
@@ -285,13 +305,13 @@ export const McpConnectorConfig: React.FC<McpConnectorConfigProps> = ({
           const oauthResult = await performMcpOAuthFlow(
             id,
             probeResult.resourceMetadataUrl,
-            name,
+            sanitizedForm.name,
             undefined,
             staticCredentials,
           );
           log.info("[mcp_connector] Static OAuth flow returned", {}, { oauthResult_type: oauthResult.type });
           if (oauthResult.type === "success") {
-            await persistExtension(id, undefined, {
+            await persistExtension(id, sanitizedForm, undefined, {
               preserveExistingToken: true,
               authMode: "static",
             });
@@ -312,24 +332,45 @@ export const McpConnectorConfig: React.FC<McpConnectorConfigProps> = ({
         return;
       }
 
-      const token = bearerToken.trim() || undefined;
-      const result = await probeMcpServer(serverUrl, token, name);
+      const token = sanitizedForm.bearerToken || undefined;
+      const result = await probeMcpServer(sanitizedForm.serverUrl, token, sanitizedForm.name);
 
       if (result.success) {
         const id = existingExtension?.id ?? `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
-        await persistExtension(id, token, { authMode: token ? "bearer" : undefined });
+        await persistExtension(id, sanitizedForm, token, { authMode: token ? "bearer" : undefined });
       } else if (result.statusCode === 401 && result.resourceMetadataUrl) {
         const id = existingExtension?.id ?? `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
         setConnectingLabel("Opening sign-in…");
         const allExtensions = await getMcpExtensions();
-        const normalizedName = uniqueNormalizedName(toNormalizedName(name), allExtensions, existingExtension?.id);
-        log.info("[mcp_connector] entering OAuth branch", {}, { id, serverUrl, normalizedName, resourceMetadataUrl: result.resourceMetadataUrl });
+        const normalizedName = uniqueNormalizedName(
+          toNormalizedName(sanitizedForm.name),
+          allExtensions,
+          existingExtension?.id,
+        );
+        log.info(
+          "[mcp_connector] entering OAuth branch",
+          {},
+          {
+            id,
+            serverUrl: sanitizedForm.serverUrl,
+            normalizedName,
+            resourceMetadataUrl: result.resourceMetadataUrl,
+          },
+        );
         try {
           onBeforeBrowserOpen?.();
-          const oauthResult = await performMcpOAuthFlow(id, result.resourceMetadataUrl, name, { serverUrl, normalizedName });
+          const oauthResult = await performMcpOAuthFlow(
+            id,
+            result.resourceMetadataUrl,
+            sanitizedForm.name,
+            {
+              serverUrl: sanitizedForm.serverUrl,
+              normalizedName,
+            },
+          );
           log.info("[mcp_connector] OAuth flow returned", {}, { oauthResult_type: oauthResult.type });
           if (oauthResult.type === "success") {
-            await persistExtension(id, undefined, {
+            await persistExtension(id, sanitizedForm, undefined, {
               preserveExistingToken: true,
               authMode: "dcr",
             });
@@ -370,8 +411,15 @@ export const McpConnectorConfig: React.FC<McpConnectorConfigProps> = ({
     setIsConnecting(true);
     setConnectingLabel("Completing sign-in…");
     try {
+      const sanitizedForm = sanitizeMcpConnectorForm({
+        name,
+        serverUrl,
+        bearerToken,
+        staticClientId,
+        staticClientSecret,
+      });
       await completeMcpOAuthFromCallbackUrl(callbackUrl.trim(), pendingOAuth);
-      await persistExtension(pendingExtensionId, undefined, {
+      await persistExtension(pendingExtensionId, sanitizedForm, undefined, {
         preserveExistingToken: true,
         authMode: pendingAuthMode === "static" || pendingAuthMode === "dcr" ? pendingAuthMode : undefined,
       });

--- a/components/settings/McpConnectorConfig.tsx
+++ b/components/settings/McpConnectorConfig.tsx
@@ -80,9 +80,6 @@ export const McpConnectorConfig: React.FC<McpConnectorConfigProps> = ({
   const [authMethod, setAuthMethod] = useState<McpConnectorAuthMethod>("auto");
   const [staticClientId, setStaticClientId] = useState("");
   const [staticClientSecret, setStaticClientSecret] = useState("");
-  const [staticAuthEndpoint, setStaticAuthEndpoint] = useState("");
-  const [staticTokenEndpoint, setStaticTokenEndpoint] = useState("");
-  const [staticScopes, setStaticScopes] = useState("");
   const [staticSecretVisible, setStaticSecretVisible] = useState(false);
   const [pendingOAuth, setPendingOAuth] = useState<McpOAuthPendingState | null>(null);
   const [pendingExtensionId, setPendingExtensionId] = useState<string | null>(null);
@@ -97,9 +94,6 @@ export const McpConnectorConfig: React.FC<McpConnectorConfigProps> = ({
       setName(existingExtension.name);
       setServerUrl(existingExtension.serverUrl);
       setNormalizedNamePreview(existingExtension.normalizedName ?? toNormalizedName(existingExtension.name));
-      setStaticAuthEndpoint("");
-      setStaticTokenEndpoint("");
-      setStaticScopes("");
       setStaticSecretVisible(false);
       setPendingOAuth(null);
       setPendingExtensionId(null);
@@ -140,9 +134,6 @@ export const McpConnectorConfig: React.FC<McpConnectorConfigProps> = ({
       setAuthMethod("auto");
       setStaticClientId("");
       setStaticClientSecret("");
-      setStaticAuthEndpoint("");
-      setStaticTokenEndpoint("");
-      setStaticScopes("");
       setStaticSecretVisible(false);
       setPendingOAuth(null);
       setPendingExtensionId(null);
@@ -266,8 +257,6 @@ export const McpConnectorConfig: React.FC<McpConnectorConfigProps> = ({
         serverUrl,
         authMethod,
         staticClientId,
-        staticAuthorizationEndpoint: staticAuthEndpoint,
-        staticTokenEndpoint,
       });
       if (validationError) {
         Alert.alert("Missing Field", validationError, [{ text: "OK" }]);
@@ -276,21 +265,26 @@ export const McpConnectorConfig: React.FC<McpConnectorConfigProps> = ({
 
       if (authMethod === "static") {
         const id = existingExtension?.id ?? `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
-        setConnectingLabel("Opening sign-in…");
 
+        // Probe the server to discover OAuth endpoints, same as the auto/DCR flow.
+        const probeResult = await probeMcpServer(serverUrl, undefined, name);
+        if (probeResult.statusCode !== 401 || !probeResult.resourceMetadataUrl) {
+          const detail = probeResult.error ?? `Server returned ${probeResult.statusCode}`;
+          Alert.alert("Connection Failed", detail, [{ text: "OK" }]);
+          return;
+        }
+
+        setConnectingLabel("Opening sign-in…");
         const staticCredentials: StaticOAuthCredentials = buildStaticOAuthCredentials({
           clientId: staticClientId,
           clientSecret: staticClientSecret,
-          authorizationEndpoint: staticAuthEndpoint,
-          tokenEndpoint: staticTokenEndpoint,
-          scopes: staticScopes,
         });
 
         try {
           onBeforeBrowserOpen?.();
           const oauthResult = await performMcpOAuthFlow(
             id,
-            "",
+            probeResult.resourceMetadataUrl,
             name,
             undefined,
             staticCredentials,
@@ -401,9 +395,6 @@ export const McpConnectorConfig: React.FC<McpConnectorConfigProps> = ({
     setAuthMethod("auto");
     setStaticClientId("");
     setStaticClientSecret("");
-    setStaticAuthEndpoint("");
-    setStaticTokenEndpoint("");
-    setStaticScopes("");
     setStaticSecretVisible(false);
     setPendingOAuth(null);
     setPendingExtensionId(null);
@@ -579,7 +570,7 @@ export const McpConnectorConfig: React.FC<McpConnectorConfigProps> = ({
                     <Text style={styles.hint}>
                       {authMethod === "auto"
                         ? "Automatically discover OAuth endpoints and register a public client."
-                        : "Use an existing OAuth client ID and optional client secret with manually entered endpoints."}
+                        : "Use an existing OAuth client ID and optional client secret. Endpoints are auto-discovered from the MCP server."}
                     </Text>
                   </View>
 
@@ -628,52 +619,6 @@ export const McpConnectorConfig: React.FC<McpConnectorConfigProps> = ({
                         </Text>
                       </View>
 
-                      <View style={styles.section}>
-                        <Text style={styles.label}>Authorization Endpoint *</Text>
-                        <TextInput
-                          style={styles.input}
-                          value={staticAuthEndpoint}
-                          onChangeText={setStaticAuthEndpoint}
-                          placeholder="https://provider.com/oauth/authorize"
-                          placeholderTextColor="#AEAEB2"
-                          autoCapitalize="none"
-                          autoCorrect={false}
-                          keyboardType="url"
-                        />
-                      </View>
-
-                      <View style={styles.section}>
-                        <Text style={styles.label}>Token Endpoint *</Text>
-                        <TextInput
-                          style={styles.input}
-                          value={staticTokenEndpoint}
-                          onChangeText={setStaticTokenEndpoint}
-                          placeholder="https://provider.com/oauth/token"
-                          placeholderTextColor="#AEAEB2"
-                          autoCapitalize="none"
-                          autoCorrect={false}
-                          keyboardType="url"
-                        />
-                        <Text style={styles.hint}>
-                          Static endpoints are not persisted for display. Re-enter them here when you need to re-authenticate.
-                        </Text>
-                      </View>
-
-                      <View style={styles.section}>
-                        <Text style={styles.label}>Scopes</Text>
-                        <TextInput
-                          style={styles.input}
-                          value={staticScopes}
-                          onChangeText={setStaticScopes}
-                          placeholder="openid, profile, email"
-                          placeholderTextColor="#AEAEB2"
-                          autoCapitalize="none"
-                          autoCorrect={false}
-                        />
-                        <Text style={styles.hint}>
-                          Comma-separated scopes requested during authorization.
-                        </Text>
-                      </View>
                     </>
                   ) : (
                     <>

--- a/components/settings/__tests__/mcpConnectorAuthConfig.test.ts
+++ b/components/settings/__tests__/mcpConnectorAuthConfig.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  buildStaticOAuthCredentials,
+  deriveMcpConnectorAuthState,
+  validateMcpConnectorForm,
+} from "../mcpConnectorAuthConfig";
+
+describe("deriveMcpConnectorAuthState", () => {
+  test("hydrates static auth fields from stored static credentials", () => {
+    expect(
+      deriveMcpConnectorAuthState({
+        token: null,
+        refreshToken: "refresh-token",
+        authMode: "static",
+        clientId: "client-id",
+        clientSecret: "client-secret",
+      }),
+    ).toEqual({
+      authMethod: "static",
+      advancedExpanded: true,
+      bearerToken: "",
+      hasOAuthToken: true,
+      staticClientId: "client-id",
+      staticClientSecret: "client-secret",
+    });
+  });
+
+  test("keeps bearer token mode in advanced section for manual tokens", () => {
+    expect(
+      deriveMcpConnectorAuthState({
+        token: "bearer-token",
+        refreshToken: null,
+        authMode: "bearer",
+        clientId: null,
+        clientSecret: null,
+      }),
+    ).toEqual({
+      authMethod: "auto",
+      advancedExpanded: true,
+      bearerToken: "bearer-token",
+      hasOAuthToken: false,
+      staticClientId: "",
+      staticClientSecret: "",
+    });
+  });
+});
+
+describe("buildStaticOAuthCredentials", () => {
+  test("trims endpoints and splits comma separated scopes", () => {
+    expect(
+      buildStaticOAuthCredentials({
+        clientId: "  client-id  ",
+        clientSecret: "   ",
+        authorizationEndpoint: " https://provider.example.com/authorize ",
+        tokenEndpoint: " https://provider.example.com/token ",
+        scopes: "openid, profile , email",
+      }),
+    ).toEqual({
+      clientId: "client-id",
+      authorizationEndpoint: "https://provider.example.com/authorize",
+      tokenEndpoint: "https://provider.example.com/token",
+      scopes: ["openid", "profile", "email"],
+    });
+  });
+});
+
+describe("validateMcpConnectorForm", () => {
+  test("requires full static OAuth inputs in static mode", () => {
+    expect(
+      validateMcpConnectorForm({
+        name: "Static Connector",
+        serverUrl: "https://mcp.example.com",
+        authMethod: "static",
+        staticClientId: "",
+        staticAuthorizationEndpoint: "",
+        staticTokenEndpoint: "",
+      }),
+    ).toBe("Client ID is required for static OAuth.");
+  });
+});

--- a/components/settings/__tests__/mcpConnectorAuthConfig.test.ts
+++ b/components/settings/__tests__/mcpConnectorAuthConfig.test.ts
@@ -47,35 +47,50 @@ describe("deriveMcpConnectorAuthState", () => {
 });
 
 describe("buildStaticOAuthCredentials", () => {
-  test("trims endpoints and splits comma separated scopes", () => {
+  test("trims client id and omits blank secret", () => {
     expect(
       buildStaticOAuthCredentials({
         clientId: "  client-id  ",
         clientSecret: "   ",
-        authorizationEndpoint: " https://provider.example.com/authorize ",
-        tokenEndpoint: " https://provider.example.com/token ",
-        scopes: "openid, profile , email",
       }),
     ).toEqual({
       clientId: "client-id",
-      authorizationEndpoint: "https://provider.example.com/authorize",
-      tokenEndpoint: "https://provider.example.com/token",
-      scopes: ["openid", "profile", "email"],
+    });
+  });
+
+  test("includes client secret when provided", () => {
+    expect(
+      buildStaticOAuthCredentials({
+        clientId: "client-id",
+        clientSecret: "my-secret",
+      }),
+    ).toEqual({
+      clientId: "client-id",
+      clientSecret: "my-secret",
     });
   });
 });
 
 describe("validateMcpConnectorForm", () => {
-  test("requires full static OAuth inputs in static mode", () => {
+  test("requires client ID in static mode", () => {
     expect(
       validateMcpConnectorForm({
         name: "Static Connector",
         serverUrl: "https://mcp.example.com",
         authMethod: "static",
         staticClientId: "",
-        staticAuthorizationEndpoint: "",
-        staticTokenEndpoint: "",
       }),
     ).toBe("Client ID is required for static OAuth.");
+  });
+
+  test("passes with only client ID in static mode", () => {
+    expect(
+      validateMcpConnectorForm({
+        name: "Static Connector",
+        serverUrl: "https://mcp.example.com",
+        authMethod: "static",
+        staticClientId: "my-client-id",
+      }),
+    ).toBeNull();
   });
 });

--- a/components/settings/__tests__/mcpConnectorAuthConfig.test.ts
+++ b/components/settings/__tests__/mcpConnectorAuthConfig.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, test } from "bun:test";
 import {
   buildStaticOAuthCredentials,
   deriveMcpConnectorAuthState,
+  sanitizeMcpConnectorForm,
   validateMcpConnectorForm,
 } from "../mcpConnectorAuthConfig";
 
@@ -92,5 +93,25 @@ describe("validateMcpConnectorForm", () => {
         staticClientId: "my-client-id",
       }),
     ).toBeNull();
+  });
+});
+
+describe("sanitizeMcpConnectorForm", () => {
+  test("trims leading and trailing whitespace from connector fields", () => {
+    expect(
+      sanitizeMcpConnectorForm({
+        name: "  Brain3  ",
+        serverUrl: " https://mcp.example.com/path ",
+        bearerToken: "  bearer-token  ",
+        staticClientId: "  client-id  ",
+        staticClientSecret: "  client-secret  ",
+      }),
+    ).toEqual({
+      name: "Brain3",
+      serverUrl: "https://mcp.example.com/path",
+      bearerToken: "bearer-token",
+      staticClientId: "client-id",
+      staticClientSecret: "client-secret",
+    });
   });
 });

--- a/components/settings/mcpConnectorAuthConfig.ts
+++ b/components/settings/mcpConnectorAuthConfig.ts
@@ -1,0 +1,103 @@
+import type { StaticOAuthCredentials } from "../../lib/mcp-oauth";
+
+export type McpConnectorAuthMethod = "auto" | "static";
+export type McpStoredAuthMode = "dcr" | "static" | "bearer" | null;
+
+type DerivedMcpConnectorAuthStateInput = {
+  token: string | null;
+  refreshToken: string | null;
+  authMode: McpStoredAuthMode;
+  clientId: string | null;
+  clientSecret: string | null;
+};
+
+export type DerivedMcpConnectorAuthState = {
+  authMethod: McpConnectorAuthMethod;
+  advancedExpanded: boolean;
+  bearerToken: string;
+  hasOAuthToken: boolean;
+  staticClientId: string;
+  staticClientSecret: string;
+};
+
+type StaticOAuthCredentialInput = {
+  clientId: string;
+  clientSecret: string;
+  authorizationEndpoint: string;
+  tokenEndpoint: string;
+  scopes: string;
+};
+
+type ValidateMcpConnectorFormInput = {
+  name: string;
+  serverUrl: string;
+  authMethod: McpConnectorAuthMethod;
+  staticClientId: string;
+  staticAuthorizationEndpoint: string;
+  staticTokenEndpoint: string;
+};
+
+export function deriveMcpConnectorAuthState(
+  input: DerivedMcpConnectorAuthStateInput,
+): DerivedMcpConnectorAuthState {
+  const isStatic = input.authMode === "static";
+  const isOAuth = isStatic || input.authMode === "dcr" || (!!input.refreshToken && input.authMode !== "bearer");
+
+  if (isStatic) {
+    return {
+      authMethod: "static",
+      advancedExpanded: true,
+      bearerToken: "",
+      hasOAuthToken: !!(input.token || input.refreshToken || input.clientId),
+      staticClientId: input.clientId ?? "",
+      staticClientSecret: input.clientSecret ?? "",
+    };
+  }
+
+  return {
+    authMethod: "auto",
+    advancedExpanded: !!input.token && !isOAuth,
+    bearerToken: isOAuth ? "" : input.token ?? "",
+    hasOAuthToken: isOAuth,
+    staticClientId: "",
+    staticClientSecret: "",
+  };
+}
+
+export function buildStaticOAuthCredentials(
+  input: StaticOAuthCredentialInput,
+): StaticOAuthCredentials {
+  const scopes = input.scopes
+    .split(",")
+    .map((scope) => scope.trim())
+    .filter(Boolean);
+
+  return {
+    clientId: input.clientId.trim(),
+    clientSecret: input.clientSecret.trim() || undefined,
+    authorizationEndpoint: input.authorizationEndpoint.trim(),
+    tokenEndpoint: input.tokenEndpoint.trim(),
+    scopes: scopes.length > 0 ? scopes : undefined,
+  };
+}
+
+export function validateMcpConnectorForm(
+  input: ValidateMcpConnectorFormInput,
+): string | null {
+  if (!input.name.trim()) {
+    return "Name is required.";
+  }
+  if (!input.serverUrl.trim()) {
+    return "MCP Server URL is required.";
+  }
+  if (input.authMethod !== "static") {
+    return null;
+  }
+  if (!input.staticClientId.trim()) {
+    return "Client ID is required for static OAuth.";
+  }
+  if (!input.staticAuthorizationEndpoint.trim() || !input.staticTokenEndpoint.trim()) {
+    return "Authorization and Token endpoints are required.";
+  }
+  return null;
+}

--- a/components/settings/mcpConnectorAuthConfig.ts
+++ b/components/settings/mcpConnectorAuthConfig.ts
@@ -32,6 +32,22 @@ type ValidateMcpConnectorFormInput = {
   staticClientId: string;
 };
 
+type SanitizeMcpConnectorFormInput = {
+  name: string;
+  serverUrl: string;
+  bearerToken: string;
+  staticClientId: string;
+  staticClientSecret: string;
+};
+
+export type SanitizedMcpConnectorForm = {
+  name: string;
+  serverUrl: string;
+  bearerToken: string;
+  staticClientId: string;
+  staticClientSecret: string;
+};
+
 export function deriveMcpConnectorAuthState(
   input: DerivedMcpConnectorAuthStateInput,
 ): DerivedMcpConnectorAuthState {
@@ -65,6 +81,18 @@ export function buildStaticOAuthCredentials(
   return {
     clientId: input.clientId.trim(),
     clientSecret: input.clientSecret.trim() || undefined,
+  };
+}
+
+export function sanitizeMcpConnectorForm(
+  input: SanitizeMcpConnectorFormInput,
+): SanitizedMcpConnectorForm {
+  return {
+    name: input.name.trim(),
+    serverUrl: input.serverUrl.trim(),
+    bearerToken: input.bearerToken.trim(),
+    staticClientId: input.staticClientId.trim(),
+    staticClientSecret: input.staticClientSecret.trim(),
   };
 }
 

--- a/components/settings/mcpConnectorAuthConfig.ts
+++ b/components/settings/mcpConnectorAuthConfig.ts
@@ -23,9 +23,6 @@ export type DerivedMcpConnectorAuthState = {
 type StaticOAuthCredentialInput = {
   clientId: string;
   clientSecret: string;
-  authorizationEndpoint: string;
-  tokenEndpoint: string;
-  scopes: string;
 };
 
 type ValidateMcpConnectorFormInput = {
@@ -33,8 +30,6 @@ type ValidateMcpConnectorFormInput = {
   serverUrl: string;
   authMethod: McpConnectorAuthMethod;
   staticClientId: string;
-  staticAuthorizationEndpoint: string;
-  staticTokenEndpoint: string;
 };
 
 export function deriveMcpConnectorAuthState(
@@ -67,17 +62,9 @@ export function deriveMcpConnectorAuthState(
 export function buildStaticOAuthCredentials(
   input: StaticOAuthCredentialInput,
 ): StaticOAuthCredentials {
-  const scopes = input.scopes
-    .split(",")
-    .map((scope) => scope.trim())
-    .filter(Boolean);
-
   return {
     clientId: input.clientId.trim(),
     clientSecret: input.clientSecret.trim() || undefined,
-    authorizationEndpoint: input.authorizationEndpoint.trim(),
-    tokenEndpoint: input.tokenEndpoint.trim(),
-    scopes: scopes.length > 0 ? scopes : undefined,
   };
 }
 
@@ -90,14 +77,8 @@ export function validateMcpConnectorForm(
   if (!input.serverUrl.trim()) {
     return "MCP Server URL is required.";
   }
-  if (input.authMethod !== "static") {
-    return null;
-  }
-  if (!input.staticClientId.trim()) {
+  if (input.authMethod === "static" && !input.staticClientId.trim()) {
     return "Client ID is required for static OAuth.";
-  }
-  if (!input.staticAuthorizationEndpoint.trim() || !input.staticTokenEndpoint.trim()) {
-    return "Authorization and Token endpoints are required.";
   }
   return null;
 }

--- a/docs/OAUTH_STATIC_CLIENT_IMPLEMENTATION_PLAN.md
+++ b/docs/OAUTH_STATIC_CLIENT_IMPLEMENTATION_PLAN.md
@@ -1,0 +1,1291 @@
+# OAuth2 Static Client Credentials Implementation Plan
+
+## Overview
+
+This document provides a detailed implementation plan for adding static client ID and client secret support to the MCP OAuth2 client. Currently, the system only supports Dynamic Client Registration (DCR). This enhancement will allow users to configure pre-existing OAuth2 client credentials.
+
+---
+
+## Current State Analysis
+
+### Existing Capabilities
+
+**Dynamic Client Registration (DCR)** ✅
+- Fully implemented in `lib/mcp-oauth.ts` and `modules/vm-webrtc/src/mcp_client/extensions.ts`
+- OAuth discovery via `/.well-known/oauth-authorization-server`
+- Automatic client registration via `registration_endpoint`
+- PKCE-based authorization code flow
+- Refresh token support
+- Uses `token_endpoint_auth_method: "none"` (public client)
+
+**Manual Bearer Tokens** ✅
+- Users can provide pre-existing bearer tokens
+- No OAuth flow required
+- Stored securely per extension
+
+**NOT Supported (Yet)** ❌
+- Static OAuth2 client credentials (client_id + optional client_secret)
+- Manual OAuth endpoint configuration
+- Confidential client authentication (`client_secret_post`)
+
+### Current Storage Schema
+
+Per-extension secure storage:
+```
+MCP_TOKEN_PREFIX + id          → access/bearer token
+MCP_CLIENT_ID_PREFIX + id      → dynamically registered client_id
+MCP_REFRESH_TOKEN_PREFIX + id  → refresh token
+MCP_TOKEN_ENDPOINT_PREFIX + id → token endpoint URL
+```
+
+Extension metadata (AsyncStorage):
+```typescript
+interface McpExtensionRecord {
+  id: string;
+  name: string;
+  normalizedName: string;
+  serverUrl: string;
+  disabled?: boolean;
+}
+```
+
+---
+
+## Requirements Summary
+
+1. Support static client_id and optional client_secret
+2. Support `token_endpoint_auth_method` of:
+   - `"none"` (public client with PKCE only)
+   - `"client_secret_post"` (confidential client)
+3. Skip server probe when using static mode (go directly to OAuth flow)
+4. Maintain full backwards compatibility with existing DCR-based connectors
+5. NO CIMD support (deferred)
+
+---
+
+## Implementation Plan
+
+### Phase 1: Storage Layer Enhancement
+
+**File:** `lib/secure-storage.ts`
+
+#### 1.1 Add Storage Constants
+
+Add these constants near line 818 (after existing MCP constants):
+
+```typescript
+const MCP_CLIENT_SECRET_PREFIX = "VIBEMACHINE_MCP_CLIENT_SECRET_";
+const MCP_AUTH_MODE_PREFIX = "VIBEMACHINE_MCP_AUTH_MODE_";
+```
+
+#### 1.2 Update McpExtensionRecord Interface
+
+Update the interface (line 775) to track auth mode:
+
+```typescript
+export interface McpExtensionRecord {
+  id: string;
+  name: string;
+  normalizedName: string;
+  serverUrl: string;
+  disabled?: boolean;
+  authMode?: 'dcr' | 'static' | 'bearer'; // NEW: Track authentication type
+}
+```
+
+#### 1.3 Add Client Secret Storage Functions
+
+Add after `getMcpClientId()` function (around line 889):
+
+```typescript
+export async function saveMcpClientSecret(id: string, secret: string): Promise<void> {
+  await setCachedValue(`${MCP_CLIENT_SECRET_PREFIX}${id}`, secret);
+}
+
+export async function getMcpClientSecret(id: string): Promise<string | null> {
+  try {
+    return await getCachedValue(`${MCP_CLIENT_SECRET_PREFIX}${id}`);
+  } catch {
+    return null;
+  }
+}
+
+export async function deleteMcpClientSecret(id: string): Promise<void> {
+  try {
+    await deleteCachedValue(`${MCP_CLIENT_SECRET_PREFIX}${id}`);
+  } catch {
+    // secret may not exist
+  }
+}
+```
+
+#### 1.4 Add Auth Mode Storage Functions
+
+Add after client secret functions:
+
+```typescript
+export async function saveMcpAuthMode(id: string, mode: 'dcr' | 'static' | 'bearer'): Promise<void> {
+  await setCachedValue(`${MCP_AUTH_MODE_PREFIX}${id}`, mode);
+}
+
+export async function getMcpAuthMode(id: string): Promise<'dcr' | 'static' | 'bearer' | null> {
+  try {
+    const mode = await getCachedValue(`${MCP_AUTH_MODE_PREFIX}${id}`);
+    if (mode === 'dcr' || mode === 'static' || mode === 'bearer') {
+      return mode;
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
+```
+
+#### 1.5 Update clearMcpAuthCredentials()
+
+Modify function (line 915) to also clear client secret and auth mode:
+
+```typescript
+export async function clearMcpAuthCredentials(id: string): Promise<void> {
+  await Promise.allSettled([
+    deleteCachedValue(`${MCP_CLIENT_ID_PREFIX}${id}`),
+    deleteCachedValue(`${MCP_REFRESH_TOKEN_PREFIX}${id}`),
+    deleteCachedValue(`${MCP_TOKEN_ENDPOINT_PREFIX}${id}`),
+    deleteCachedValue(`${MCP_CLIENT_SECRET_PREFIX}${id}`),      // NEW
+    deleteCachedValue(`${MCP_AUTH_MODE_PREFIX}${id}`),           // NEW
+  ]);
+}
+```
+
+#### 1.6 Update clearAllStoredSecrets()
+
+Add client secret and auth mode keys to the cleanup list (around line 1006):
+
+```typescript
+for (const ext of mcpExtensions) {
+  secureStoreKeys.push(
+    `${MCP_TOKEN_PREFIX}${ext.id}`,
+    `${MCP_CLIENT_ID_PREFIX}${ext.id}`,
+    `${MCP_REFRESH_TOKEN_PREFIX}${ext.id}`,
+    `${MCP_TOKEN_ENDPOINT_PREFIX}${ext.id}`,
+    `${MCP_CLIENT_SECRET_PREFIX}${ext.id}`,    // NEW
+    `${MCP_AUTH_MODE_PREFIX}${ext.id}`,        // NEW
+  );
+}
+```
+
+---
+
+### Phase 2: OAuth Flow Enhancement
+
+#### 2.1 Update `lib/mcp-oauth.ts`
+
+##### 2.1.1 Add Static Credentials Type
+
+Add near the top of the file (after existing interfaces, around line 28):
+
+```typescript
+export interface StaticOAuthCredentials {
+  clientId: string;
+  clientSecret?: string;
+  authorizationEndpoint: string;
+  tokenEndpoint: string;
+  scopes?: string[];
+}
+```
+
+##### 2.1.2 Update performMcpOAuthFlow() Signature
+
+Modify function signature (line 34):
+
+```typescript
+export async function performMcpOAuthFlow(
+  extensionId: string,
+  resourceMetadataUrl: string,
+  connectorName?: string,
+  extensionInfo?: { serverUrl: string; normalizedName: string },
+  staticCredentials?: StaticOAuthCredentials,  // NEW parameter
+): Promise<McpOAuthFlowResult>
+```
+
+##### 2.1.3 Add Static OAuth Flow Branch
+
+Replace the content of `performMcpOAuthFlow()` with logic that branches based on whether `staticCredentials` is provided:
+
+```typescript
+export async function performMcpOAuthFlow(
+  extensionId: string,
+  resourceMetadataUrl: string,
+  connectorName?: string,
+  extensionInfo?: { serverUrl: string; normalizedName: string },
+  staticCredentials?: StaticOAuthCredentials,
+): Promise<McpOAuthFlowResult> {
+  
+  // NEW: Branch for static credentials
+  if (staticCredentials) {
+    log.info(
+      "[mcp_oauth] Starting OAuth flow with static credentials",
+      {},
+      { extension_id: extensionId, connector_name: connectorName },
+    );
+    
+    return performStaticOAuthFlow(
+      extensionId,
+      staticCredentials,
+      connectorName,
+    );
+  }
+  
+  // EXISTING: DCR flow continues below
+  log.info(
+    "[mcp_oauth] Starting OAuth flow with DCR",
+    {},
+    { extension_id: extensionId, connector_name: connectorName },
+  );
+
+  const resourceMetadata = await fetchResourceMetadata(resourceMetadataUrl, connectorName);
+  const authServerUrl = resourceMetadata.authorizationServers[0];
+  const oauthMeta = await fetchOAuthServerMetadata(authServerUrl, connectorName);
+
+  const redirectUri = AuthSession.makeRedirectUri({
+    scheme: "vibemachine",
+    path: "mcp-oauth-callback",
+  });
+
+  let clientId = await getMcpClientId(extensionId);
+  if (!clientId) {
+    if (!oauthMeta.registrationEndpoint) {
+      throw new Error(
+        "Server requires OAuth but has no registration_endpoint and no cached client_id",
+      );
+    }
+    const reg = await registerOAuthClient(
+      oauthMeta.registrationEndpoint,
+      redirectUri,
+      connectorName,
+    );
+    clientId = reg.clientId;
+    await saveMcpClientId(extensionId, clientId);
+  }
+
+  const discovery = {
+    authorizationEndpoint: oauthMeta.authorizationEndpoint,
+    tokenEndpoint: oauthMeta.tokenEndpoint,
+  };
+
+  const request = new AuthSession.AuthRequest({
+    clientId,
+    responseType: AuthSession.ResponseType.Code,
+    redirectUri,
+    scopes: [],
+    usePKCE: true,
+    extraParams: { resource: resourceMetadata.resource },
+  });
+
+  await request.makeAuthUrlAsync(discovery);
+
+  const pendingState: McpOAuthPendingState = {
+    extensionId,
+    codeVerifier: request.codeVerifier ?? "",
+    redirectUri,
+    clientId,
+    tokenEndpoint: oauthMeta.tokenEndpoint,
+    extensionName: connectorName ?? "",
+    extensionServerUrl: extensionInfo?.serverUrl ?? "",
+    extensionNormalizedName: extensionInfo?.normalizedName ?? "",
+  };
+
+  log.info(
+    "[mcp_oauth] Opening browser for authorization",
+    {},
+    { connector_name: connectorName },
+  );
+
+  const result = await request.promptAsync(discovery);
+
+  log.info(
+    "[mcp_oauth] promptAsync returned",
+    {},
+    {
+      result_type: result.type,
+      params: result.type === "success" ? result.params : undefined,
+      error: (result as any).error ?? undefined,
+      connector_name: connectorName,
+    },
+  );
+
+  if (result.type === "success" && result.params.code) {
+    log.info(
+      "[mcp_oauth] Exchanging code for token",
+      {},
+      { connector_name: connectorName },
+    );
+    const tokens = await exchangeAndStore(
+      result.params.code,
+      clientId,
+      redirectUri,
+      request.codeVerifier ?? "",
+      oauthMeta.tokenEndpoint,
+      extensionId,
+      connectorName,
+      undefined, // clientSecret not used in DCR flow
+    );
+    return { type: "success", ...tokens };
+  }
+
+  if (result.type === "error") {
+    const detail = (result as any).error_description ?? (result as any).error ?? JSON.stringify((result as any).params ?? result);
+    log.error(
+      "[mcp_oauth] OAuth server returned an error",
+      {},
+      { connector_name: connectorName, result },
+    );
+    throw new Error(`OAuth error: ${detail}`);
+  }
+
+  log.info(
+    "[mcp_oauth] Browser closed without redirect, returning manual callback state",
+    {},
+    { connector_name: connectorName, result_type: result.type },
+  );
+  return { type: "needs_manual_callback", pendingState };
+}
+```
+
+##### 2.1.4 Add performStaticOAuthFlow() Function
+
+Add new function after `performMcpOAuthFlow()`:
+
+```typescript
+async function performStaticOAuthFlow(
+  extensionId: string,
+  credentials: StaticOAuthCredentials,
+  connectorName?: string,
+): Promise<McpOAuthFlowResult> {
+  
+  const redirectUri = AuthSession.makeRedirectUri({
+    scheme: "vibemachine",
+    path: "mcp-oauth-callback",
+  });
+
+  // Save static credentials
+  await saveMcpClientId(extensionId, credentials.clientId);
+  if (credentials.clientSecret) {
+    await saveMcpClientSecret(extensionId, credentials.clientSecret);
+  }
+  await saveMcpTokenEndpoint(extensionId, credentials.tokenEndpoint);
+  await saveMcpAuthMode(extensionId, 'static');
+
+  const discovery = {
+    authorizationEndpoint: credentials.authorizationEndpoint,
+    tokenEndpoint: credentials.tokenEndpoint,
+  };
+
+  const scopes = credentials.scopes ?? [];
+  const usePKCE = !credentials.clientSecret; // Use PKCE only if no client secret
+
+  const request = new AuthSession.AuthRequest({
+    clientId: credentials.clientId,
+    responseType: AuthSession.ResponseType.Code,
+    redirectUri,
+    scopes,
+    usePKCE,
+    extraParams: {},
+  });
+
+  await request.makeAuthUrlAsync(discovery);
+
+  const pendingState: McpOAuthPendingState = {
+    extensionId,
+    codeVerifier: request.codeVerifier ?? "",
+    redirectUri,
+    clientId: credentials.clientId,
+    tokenEndpoint: credentials.tokenEndpoint,
+    extensionName: connectorName ?? "",
+    extensionServerUrl: "", // Not applicable for static mode
+    extensionNormalizedName: "", // Not applicable for static mode
+  };
+
+  log.info(
+    "[mcp_oauth] Opening browser for static OAuth authorization",
+    {},
+    { connector_name: connectorName },
+  );
+
+  const result = await request.promptAsync(discovery);
+
+  log.info(
+    "[mcp_oauth] Static OAuth promptAsync returned",
+    {},
+    {
+      result_type: result.type,
+      connector_name: connectorName,
+    },
+  );
+
+  if (result.type === "success" && result.params.code) {
+    log.info(
+      "[mcp_oauth] Exchanging code for token (static)",
+      {},
+      { connector_name: connectorName },
+    );
+    const tokens = await exchangeAndStore(
+      result.params.code,
+      credentials.clientId,
+      redirectUri,
+      request.codeVerifier ?? "",
+      credentials.tokenEndpoint,
+      extensionId,
+      connectorName,
+      credentials.clientSecret, // Include client secret if provided
+    );
+    return { type: "success", ...tokens };
+  }
+
+  if (result.type === "error") {
+    const detail = (result as any).error_description ?? (result as any).error ?? JSON.stringify((result as any).params ?? result);
+    log.error(
+      "[mcp_oauth] Static OAuth error",
+      {},
+      { connector_name: connectorName, result },
+    );
+    throw new Error(`OAuth error: ${detail}`);
+  }
+
+  log.info(
+    "[mcp_oauth] Browser closed, returning manual callback state",
+    {},
+    { connector_name: connectorName, result_type: result.type },
+  );
+  return { type: "needs_manual_callback", pendingState };
+}
+```
+
+**Important:** Don't forget to add the import at the top:
+```typescript
+import {
+  getMcpClientId,
+  getMcpClientSecret,        // NEW
+  getMcpRefreshToken,
+  getMcpTokenEndpoint,
+  saveMcpBearerToken,
+  saveMcpClientId,
+  saveMcpClientSecret,        // NEW
+  saveMcpRefreshToken,
+  saveMcpTokenEndpoint,
+  saveMcpAuthMode,            // NEW
+  getMcpAuthMode,             // NEW (for refresh logic)
+} from "./secure-storage";
+```
+
+##### 2.1.5 Update exchangeAndStore() Function
+
+Modify function signature and implementation (line 184):
+
+```typescript
+async function exchangeAndStore(
+  code: string,
+  clientId: string,
+  redirectUri: string,
+  codeVerifier: string,
+  tokenEndpoint: string,
+  extensionId: string,
+  connectorName?: string,
+  clientSecret?: string,  // NEW parameter
+): Promise<{ accessToken: string; refreshToken?: string }> {
+  
+  const exchangeConfig: any = {
+    code,
+    clientId,
+    redirectUri,
+  };
+
+  // Add client secret for confidential clients (client_secret_post method)
+  if (clientSecret) {
+    exchangeConfig.clientSecret = clientSecret;
+  }
+
+  // Add PKCE verifier for public clients or when using PKCE
+  if (codeVerifier) {
+    exchangeConfig.extraParams = { code_verifier: codeVerifier };
+  }
+
+  const tokenResponse = await AuthSession.exchangeCodeAsync(
+    exchangeConfig,
+    { tokenEndpoint },
+  );
+
+  await saveMcpBearerToken(extensionId, tokenResponse.accessToken);
+  await saveMcpTokenEndpoint(extensionId, tokenEndpoint);
+  if (tokenResponse.refreshToken) {
+    await saveMcpRefreshToken(extensionId, tokenResponse.refreshToken);
+  }
+
+  log.info(
+    "[mcp_oauth] OAuth flow complete",
+    {},
+    { 
+      connector_name: connectorName, 
+      has_refresh_token: !!tokenResponse.refreshToken,
+      used_client_secret: !!clientSecret,
+    },
+  );
+
+  return {
+    accessToken: tokenResponse.accessToken,
+    refreshToken: tokenResponse.refreshToken ?? undefined,
+  };
+}
+```
+
+##### 2.1.6 Update refreshMcpAccessToken() Function
+
+Modify function (line 221) to support client secrets:
+
+```typescript
+export async function refreshMcpAccessToken(
+  extensionId: string,
+  connectorName?: string,
+): Promise<string | null> {
+  const [refreshToken, tokenEndpoint, clientId, clientSecret] = await Promise.all([
+    getMcpRefreshToken(extensionId),
+    getMcpTokenEndpoint(extensionId),
+    getMcpClientId(extensionId),
+    getMcpClientSecret(extensionId),  // NEW
+  ]);
+
+  if (!refreshToken || !tokenEndpoint || !clientId) return null;
+
+  log.info(
+    "[mcp_oauth] Refreshing access token",
+    {},
+    { 
+      extension_id: extensionId, 
+      connector_name: connectorName,
+      has_client_secret: !!clientSecret,
+    },
+  );
+
+  try {
+    const refreshConfig: any = {
+      clientId,
+      refreshToken,
+    };
+
+    // Include client secret for confidential clients
+    if (clientSecret) {
+      refreshConfig.clientSecret = clientSecret;
+    }
+
+    const tokenResponse = await AuthSession.refreshAsync(
+      refreshConfig,
+      { tokenEndpoint },
+    );
+
+    await saveMcpBearerToken(extensionId, tokenResponse.accessToken);
+    if (tokenResponse.refreshToken) {
+      await saveMcpRefreshToken(extensionId, tokenResponse.refreshToken);
+    }
+
+    log.info(
+      "[mcp_oauth] Token refresh succeeded", 
+      {}, 
+      { connector_name: connectorName },
+    );
+    return tokenResponse.accessToken;
+  } catch (err) {
+    log.warn(
+      "[mcp_oauth] Token refresh failed",
+      {},
+      { 
+        connector_name: connectorName, 
+        error: err instanceof Error ? err.message : String(err),
+      },
+    );
+    return null;
+  }
+}
+```
+
+##### 2.1.7 Update completeMcpOAuthFromCallbackUrl()
+
+This function needs to handle retrieving the client secret if it was stored (for static mode):
+
+```typescript
+export async function completeMcpOAuthFromCallbackUrl(
+  callbackUrl: string,
+  pendingState: McpOAuthPendingState,
+): Promise<{ accessToken: string; refreshToken?: string }> {
+  const questionIdx = callbackUrl.indexOf("?");
+  if (questionIdx === -1) {
+    throw new Error("No authorization code found in that URL.");
+  }
+  const params = new URLSearchParams(callbackUrl.slice(questionIdx + 1));
+  const code = params.get("code");
+  if (!code) {
+    throw new Error("No authorization code found in that URL.");
+  }
+
+  log.info(
+    "[mcp_oauth] Completing OAuth from pasted callback URL",
+    {},
+    { extension_id: pendingState.extensionId },
+  );
+
+  // Retrieve client secret if this is a static mode flow
+  const clientSecret = await getMcpClientSecret(pendingState.extensionId);
+
+  return exchangeAndStore(
+    code,
+    pendingState.clientId,
+    pendingState.redirectUri,
+    pendingState.codeVerifier,
+    pendingState.tokenEndpoint,
+    pendingState.extensionId,
+    undefined,
+    clientSecret,  // NEW: pass client secret if available
+  );
+}
+```
+
+---
+
+### Phase 3: UI Enhancement
+
+**File:** `components/settings/McpConnectorConfig.tsx`
+
+#### 3.1 Add Import for New Storage Functions
+
+Update imports (around line 18):
+
+```typescript
+import {
+  addMcpExtension,
+  deleteMcpBearerToken,
+  getMcpBearerToken,
+  getMcpExtensions,
+  getMcpRefreshToken,
+  saveMcpBearerToken,
+  toNormalizedName,
+  uniqueNormalizedName,
+  type McpExtensionRecord,
+  getMcpClientId,           // NEW
+  getMcpClientSecret,       // NEW
+  getMcpAuthMode,           // NEW
+  saveMcpAuthMode,          // NEW
+} from "../../lib/secure-storage";
+```
+
+Also update mcp-oauth import:
+
+```typescript
+import {
+  completeMcpOAuthFromCallbackUrl,
+  performMcpOAuthFlow,
+  type McpOAuthPendingState,
+  type StaticOAuthCredentials,  // NEW
+} from "../../lib/mcp-oauth";
+```
+
+#### 3.2 Add New State Variables
+
+Add these state variables after existing state declarations (around line 70):
+
+```typescript
+const [authMethod, setAuthMethod] = useState<'auto' | 'static'>('auto');
+const [staticClientId, setStaticClientId] = useState('');
+const [staticClientSecret, setStaticClientSecret] = useState('');
+const [staticAuthEndpoint, setStaticAuthEndpoint] = useState('');
+const [staticTokenEndpoint, setStaticTokenEndpoint] = useState('');
+const [staticScopes, setStaticScopes] = useState('');
+const [staticSecretVisible, setStaticSecretVisible] = useState(false);
+```
+
+#### 3.3 Update Load Logic (useEffect)
+
+Modify the existing useEffect that loads extension data (around line 72) to also load static credentials:
+
+```typescript
+useEffect(() => {
+  if (visible && existingExtension) {
+    setName(existingExtension.name);
+    setServerUrl(existingExtension.serverUrl);
+    setNormalizedNamePreview(existingExtension.normalizedName ?? toNormalizedName(existingExtension.name));
+    
+    Promise.all([
+      getMcpBearerToken(existingExtension.id),
+      getMcpRefreshToken(existingExtension.id),
+      getMcpAuthMode(existingExtension.id),        // NEW
+      getMcpClientId(existingExtension.id),        // NEW
+      getMcpClientSecret(existingExtension.id),    // NEW
+    ]).then(([token, refreshToken, authMode, clientId, clientSecret]) => {
+      
+      // Detect auth method based on stored data
+      if (authMode === 'static') {
+        setAuthMethod('static');
+        setStaticClientId(clientId ?? '');
+        setStaticClientSecret(clientSecret ?? '');
+        // Note: We don't store endpoints separately for display,
+        // they're only used during OAuth flow. Could add if needed.
+      } else if (authMode === 'dcr') {
+        setAuthMethod('auto');
+      } else if (refreshToken) {
+        // Legacy detection: has refresh token = OAuth was used
+        setHasOAuthToken(true);
+        setAuthMethod('auto');
+      } else if (token) {
+        // Has bearer token only = manual token mode
+        setBearerToken(token);
+        setAdvancedExpanded(true);
+      }
+    });
+  } else if (visible) {
+    setNormalizedNamePreview("");
+    setHasOAuthToken(false);
+    setAuthMethod('auto');
+    setStaticClientId('');
+    setStaticClientSecret('');
+    setStaticAuthEndpoint('');
+    setStaticTokenEndpoint('');
+    setStaticScopes('');
+  }
+}, [visible, existingExtension]);
+```
+
+#### 3.4 Update persistExtension Function
+
+Add auth mode parameter and save it (around line 132):
+
+```typescript
+const persistExtension = async (
+  id: string,
+  manualToken?: string,
+  options?: { preserveExistingToken?: boolean; authMode?: 'dcr' | 'static' | 'bearer' },
+) => {
+  log.info("[mcp_connector] persistExtension start", {}, { id, isEditing, hasManualToken: !!manualToken, preserveExistingToken: options?.preserveExistingToken, authMode: options?.authMode });
+  const allExtensions = await getMcpExtensions();
+  const normalizedName = uniqueNormalizedName(toNormalizedName(name), allExtensions, existingExtension?.id);
+  const record: McpExtensionRecord = { 
+    id, 
+    name, 
+    normalizedName, 
+    serverUrl,
+    authMode: options?.authMode,  // NEW
+  };
+  await addMcpExtension(record);
+  if (manualToken) {
+    await saveMcpBearerToken(id, manualToken);
+    if (options?.authMode) {
+      await saveMcpAuthMode(id, options.authMode);
+    }
+  } else if (!options?.preserveExistingToken) {
+    await deleteMcpBearerToken(id);
+  }
+  if (options?.authMode) {
+    await saveMcpAuthMode(id, options.authMode);
+  }
+  DeviceEventEmitter.emit(CONNECTOR_SETTINGS_CHANGED_EVENT);
+  log.info("[mcp_connector] calling onSave", {}, { id });
+  onSave?.(record);
+  log.info("[mcp_connector] calling resetAndClose", {}, { id });
+  resetAndClose();
+  Alert.alert(
+    isEditing ? "Saved" : "Connected Successfully",
+    isEditing
+      ? "Extension updated."
+      : "Extension added. You can update its config anytime from the Extensions (MCP) screen.",
+    [{ text: "OK" }],
+  );
+};
+```
+
+#### 3.5 Update handleSave Function
+
+Replace the existing `handleSave` function (around line 161) to branch on auth method:
+
+```typescript
+const handleSave = async () => {
+  setIsConnecting(true);
+  setConnectingLabel("Connecting…");
+  try {
+    // NEW: Static credentials mode
+    if (authMethod === 'static') {
+      // Validate required fields
+      if (!staticClientId.trim()) {
+        Alert.alert("Missing Field", "Client ID is required for static OAuth.", [{ text: "OK" }]);
+        return;
+      }
+      if (!staticAuthEndpoint.trim() || !staticTokenEndpoint.trim()) {
+        Alert.alert("Missing Fields", "Authorization and Token endpoints are required.", [{ text: "OK" }]);
+        return;
+      }
+
+      const id = existingExtension?.id ?? `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+      setConnectingLabel("Opening sign-in…");
+
+      const staticCredentials: StaticOAuthCredentials = {
+        clientId: staticClientId.trim(),
+        clientSecret: staticClientSecret.trim() || undefined,
+        authorizationEndpoint: staticAuthEndpoint.trim(),
+        tokenEndpoint: staticTokenEndpoint.trim(),
+        scopes: staticScopes.trim() ? staticScopes.trim().split(',').map(s => s.trim()) : undefined,
+      };
+
+      try {
+        onBeforeBrowserOpen?.();
+        const oauthResult = await performMcpOAuthFlow(
+          id,
+          '', // resourceMetadataUrl not used for static mode
+          name,
+          undefined, // extensionInfo not used for static mode
+          staticCredentials,
+        );
+
+        log.info("[mcp_connector] Static OAuth flow returned", {}, { oauthResult_type: oauthResult.type });
+
+        if (oauthResult.type === "success") {
+          await persistExtension(id, undefined, { preserveExistingToken: true, authMode: 'static' });
+        } else {
+          setPendingOAuth(oauthResult.pendingState);
+          setPendingExtensionId(id);
+          onNeedsManualCallback?.();
+        }
+      } catch (oauthError: any) {
+        log.error("[mcp_connector] Static OAuth error caught", {}, { message: oauthError?.message });
+        Alert.alert(
+          "Authentication Failed",
+          oauthError?.message ?? "OAuth sign-in failed.",
+          [{ text: "OK" }],
+        );
+      }
+      return;
+    }
+
+    // EXISTING: Auto (DCR) mode
+    const token = bearerToken.trim() || undefined;
+    const result = await probeMcpServer(serverUrl, token, name);
+
+    if (result.success) {
+      const id = existingExtension?.id ?? `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+      await persistExtension(id, token, { authMode: token ? 'bearer' : undefined });
+    } else if (result.statusCode === 401 && result.resourceMetadataUrl) {
+      const id = existingExtension?.id ?? `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+      setConnectingLabel("Opening sign-in…");
+      const allExtensions = await getMcpExtensions();
+      const normalizedName = uniqueNormalizedName(toNormalizedName(name), allExtensions, existingExtension?.id);
+      log.info("[mcp_connector] entering OAuth branch", {}, { id, serverUrl, normalizedName, resourceMetadataUrl: result.resourceMetadataUrl });
+      try {
+        onBeforeBrowserOpen?.();
+        const oauthResult = await performMcpOAuthFlow(id, result.resourceMetadataUrl, name, { serverUrl, normalizedName });
+        log.info("[mcp_connector] OAuth flow returned", {}, { oauthResult_type: oauthResult.type });
+        if (oauthResult.type === "success") {
+          await persistExtension(id, undefined, { preserveExistingToken: true, authMode: 'dcr' });
+        } else {
+          setPendingOAuth(oauthResult.pendingState);
+          setPendingExtensionId(id);
+          onNeedsManualCallback?.();
+        }
+      } catch (oauthError: any) {
+        log.error("[mcp_connector] oauthError caught", {}, { message: oauthError?.message });
+        Alert.alert(
+          "Authentication Failed",
+          oauthError?.message ?? "OAuth sign-in failed.",
+          [{ text: "OK" }],
+        );
+      }
+    } else if (result.statusCode === 401) {
+      Alert.alert(
+        "Authentication Required",
+        "This server requires a Bearer token. Enter it in the Advanced section.",
+        [{ text: "OK" }],
+      );
+    } else {
+      const detail = result.error ?? `Server returned ${result.statusCode}`;
+      Alert.alert("Connection Failed", detail, [{ text: "OK" }]);
+    }
+  } finally {
+    log.info("[mcp_connector] handleSave finally — clearing isConnecting");
+    setIsConnecting(false);
+    setConnectingLabel("Connecting…");
+  }
+};
+```
+
+#### 3.6 Update resetAndClose Function
+
+Add new fields to reset (around line 229):
+
+```typescript
+const resetAndClose = () => {
+  log.info("[mcp_connector] resetAndClose");
+  setName("");
+  setServerUrl("");
+  setBearerToken("");
+  setNormalizedNamePreview("");
+  setAdvancedExpanded(false);
+  setTokenVisible(false);
+  setHasOAuthToken(false);
+  setPendingOAuth(null);
+  setPendingExtensionId(null);
+  setCallbackUrl("");
+  setCallbackError("");
+  setAuthMethod('auto');           // NEW
+  setStaticClientId('');           // NEW
+  setStaticClientSecret('');       // NEW
+  setStaticAuthEndpoint('');       // NEW
+  setStaticTokenEndpoint('');      // NEW
+  setStaticScopes('');             // NEW
+  setStaticSecretVisible(false);   // NEW
+  onClose();
+};
+```
+
+#### 3.7 Add UI Components for Static OAuth
+
+Find the "Advanced" section in the JSX (search for "Advanced" text, around line 400+). Add a new section BEFORE the bearer token section:
+
+```tsx
+{/* OAuth Configuration Method */}
+<View style={styles.section}>
+  <Text style={styles.label}>OAuth Method</Text>
+  <View style={styles.segmentControl}>
+    <Pressable
+      style={[
+        styles.segment,
+        authMethod === 'auto' && styles.segmentActive,
+      ]}
+      onPress={() => setAuthMethod('auto')}
+    >
+      <Text
+        style={[
+          styles.segmentText,
+          authMethod === 'auto' && styles.segmentTextActive,
+        ]}
+      >
+        Auto (DCR)
+      </Text>
+    </Pressable>
+    <Pressable
+      style={[
+        styles.segment,
+        authMethod === 'static' && styles.segmentActive,
+      ]}
+      onPress={() => setAuthMethod('static')}
+    >
+      <Text
+        style={[
+          styles.segmentText,
+          authMethod === 'static' && styles.segmentTextActive,
+        ]}
+      >
+        Static Credentials
+      </Text>
+    </Pressable>
+  </View>
+  <Text style={styles.hint}>
+    {authMethod === 'auto'
+      ? "Automatically discover OAuth endpoints and register client (Dynamic Client Registration)."
+      : "Use pre-existing OAuth client credentials with manually configured endpoints."}
+  </Text>
+</View>
+
+{/* Static OAuth Fields (only shown when authMethod === 'static') */}
+{authMethod === 'static' && (
+  <>
+    <View style={styles.section}>
+      <Text style={styles.label}>Client ID *</Text>
+      <TextInput
+        style={styles.input}
+        value={staticClientId}
+        onChangeText={setStaticClientId}
+        placeholder="your-client-id"
+        autoCapitalize="none"
+        autoCorrect={false}
+      />
+    </View>
+
+    <View style={styles.section}>
+      <Text style={styles.label}>Client Secret (optional)</Text>
+      <View style={styles.passwordContainer}>
+        <TextInput
+          style={[styles.input, styles.passwordInput]}
+          value={staticClientSecret}
+          onChangeText={setStaticClientSecret}
+          placeholder="Optional for confidential clients"
+          secureTextEntry={!staticSecretVisible}
+          autoCapitalize="none"
+          autoCorrect={false}
+        />
+        <Pressable
+          style={styles.eyeButton}
+          onPress={() => setStaticSecretVisible(!staticSecretVisible)}
+        >
+          <Text style={styles.eyeButtonText}>
+            {staticSecretVisible ? "👁️" : "👁️‍🗨️"}
+          </Text>
+        </Pressable>
+      </View>
+      <Text style={styles.hint}>
+        Leave blank for public clients (uses PKCE only). Provide for confidential clients.
+      </Text>
+    </View>
+
+    <View style={styles.section}>
+      <Text style={styles.label}>Authorization Endpoint *</Text>
+      <TextInput
+        style={styles.input}
+        value={staticAuthEndpoint}
+        onChangeText={setStaticAuthEndpoint}
+        placeholder="https://provider.com/oauth/authorize"
+        autoCapitalize="none"
+        autoCorrect={false}
+        keyboardType="url"
+      />
+    </View>
+
+    <View style={styles.section}>
+      <Text style={styles.label}>Token Endpoint *</Text>
+      <TextInput
+        style={styles.input}
+        value={staticTokenEndpoint}
+        onChangeText={setStaticTokenEndpoint}
+        placeholder="https://provider.com/oauth/token"
+        autoCapitalize="none"
+        autoCorrect={false}
+        keyboardType="url"
+      />
+    </View>
+
+    <View style={styles.section}>
+      <Text style={styles.label}>Scopes (optional)</Text>
+      <TextInput
+        style={styles.input}
+        value={staticScopes}
+        onChangeText={setStaticScopes}
+        placeholder="read, write, openid"
+        autoCapitalize="none"
+        autoCorrect={false}
+      />
+      <Text style={styles.hint}>
+        Comma-separated list of OAuth scopes to request.
+      </Text>
+    </View>
+  </>
+)}
+
+{/* Existing Bearer Token section (only shown when authMethod === 'auto') */}
+{authMethod === 'auto' && (
+  // ... existing bearer token UI ...
+)}
+```
+
+#### 3.8 Add Styles
+
+Add these styles to the StyleSheet (around line 600+):
+
+```typescript
+segmentControl: {
+  flexDirection: "row",
+  backgroundColor: "#f0f0f0",
+  borderRadius: 8,
+  padding: 2,
+},
+segment: {
+  flex: 1,
+  paddingVertical: 8,
+  paddingHorizontal: 12,
+  alignItems: "center",
+  borderRadius: 6,
+},
+segmentActive: {
+  backgroundColor: "#fff",
+  shadowColor: "#000",
+  shadowOffset: { width: 0, height: 1 },
+  shadowOpacity: 0.1,
+  shadowRadius: 2,
+  elevation: 2,
+},
+segmentText: {
+  fontSize: 14,
+  color: "#666",
+  fontWeight: "500",
+},
+segmentTextActive: {
+  color: "#000",
+  fontWeight: "600",
+},
+passwordContainer: {
+  position: "relative",
+},
+passwordInput: {
+  paddingRight: 50,
+},
+eyeButton: {
+  position: "absolute",
+  right: 12,
+  top: 12,
+  padding: 4,
+},
+eyeButtonText: {
+  fontSize: 20,
+},
+```
+
+---
+
+### Phase 4: Testing & Validation
+
+#### 4.1 Test Scenarios
+
+Create test cases for the following scenarios:
+
+**Test 1: DCR Flow (Regression Test)**
+- Create new MCP connector with server that supports DCR
+- Verify auto-discovery works
+- Verify client registration happens
+- Verify OAuth flow completes
+- Verify tokens are stored correctly
+- Verify connector works after setup
+
+**Test 2: Static Public Client (PKCE)**
+- Create new connector with auth method = "Static Credentials"
+- Provide: client_id, auth endpoint, token endpoint (NO secret)
+- Verify PKCE is used
+- Verify OAuth flow completes
+- Verify tokens work
+- Test token refresh
+
+**Test 3: Static Confidential Client (with Secret)**
+- Create connector with static credentials
+- Provide: client_id, client_secret, endpoints
+- Verify client_secret is included in token exchange
+- Verify tokens work
+- Test token refresh with secret
+
+**Test 4: Mixed Connectors**
+- Have 2-3 connectors: one DCR, one static public, one static confidential
+- Verify they all work independently
+- Verify token refresh works for each
+
+**Test 5: Edit Existing Connector**
+- Create connector with DCR
+- Edit it and switch to static mode
+- Verify old credentials are cleared
+- Verify new flow works
+- Test reverse (static → DCR)
+
+**Test 6: Manual Callback (Browser Dismissed)**
+- Start OAuth flow (DCR or static)
+- Dismiss browser before completing
+- Verify manual paste UI appears
+- Paste valid callback URL
+- Verify flow completes
+
+**Test 7: Error Handling**
+- Invalid endpoints
+- Wrong client credentials
+- Network errors during OAuth
+- Token refresh failures
+
+#### 4.2 Validation Checklist
+
+Before considering complete, verify:
+
+- [ ] No TypeScript errors
+- [ ] All existing DCR connectors continue working
+- [ ] Static mode skips server probe (no unnecessary network call)
+- [ ] Client secrets stored in secure keychain (not AsyncStorage)
+- [ ] Sensitive data (secrets, tokens) never logged
+- [ ] UI clearly distinguishes between auth methods
+- [ ] Form validation prevents saving incomplete config
+- [ ] Token refresh works for both DCR and static modes
+- [ ] Clearing/deleting connector removes all stored credentials
+- [ ] No memory leaks or state issues when switching between modes
+
+---
+
+## Implementation Checklist
+
+Use this checklist to track progress:
+
+### Phase 1: Storage
+- [ ] Add storage constants
+- [ ] Update `McpExtensionRecord` interface
+- [ ] Add client secret storage functions
+- [ ] Add auth mode storage functions
+- [ ] Update `clearMcpAuthCredentials()`
+- [ ] Update `clearAllStoredSecrets()`
+
+### Phase 2: OAuth Logic
+- [ ] Add `StaticOAuthCredentials` interface
+- [ ] Update `performMcpOAuthFlow()` signature
+- [ ] Add static credentials branch
+- [ ] Implement `performStaticOAuthFlow()`
+- [ ] Update `exchangeAndStore()` for client secrets
+- [ ] Update `refreshMcpAccessToken()` for client secrets
+- [ ] Update `completeMcpOAuthFromCallbackUrl()`
+- [ ] Add all necessary imports
+
+### Phase 3: UI
+- [ ] Update imports
+- [ ] Add state variables
+- [ ] Update load logic (useEffect)
+- [ ] Update `persistExtension()` 
+- [ ] Update `handleSave()`
+- [ ] Update `resetAndClose()`
+- [ ] Add OAuth method selector UI
+- [ ] Add static credentials input fields
+- [ ] Add conditional rendering logic
+- [ ] Add styles
+
+### Phase 4: Testing
+- [ ] Test DCR flow (regression)
+- [ ] Test static public client
+- [ ] Test static confidential client
+- [ ] Test mixed connectors
+- [ ] Test editing connectors
+- [ ] Test manual callback flow
+- [ ] Test error handling
+- [ ] Run validation checklist
+
+---
+
+## Notes for Implementation
+
+### Security Considerations
+
+1. **Never log sensitive data**: Client secrets, tokens, and authorization codes should never appear in logs
+2. **Use secure storage**: All secrets must use `setCachedValue` which uses iOS Keychain
+3. **Sanitize logs**: When logging, use `[REDACTED]` for sensitive fields
+4. **Clear on delete**: When deleting a connector, ensure ALL credentials are removed
+
+### Common Pitfalls
+
+1. **Don't use PKCE with client_secret**: If client secret is provided, PKCE is optional (set `usePKCE: false`)
+2. **Token endpoint auth method**: expo-auth-session uses `client_secret_post` by default when `clientSecret` is provided
+3. **Scope formatting**: Scopes should be an array, not a space-separated string
+4. **Redirect URI**: Must be consistent across registration, authorization, and token exchange
+
+### Expo AuthSession Reference
+
+Key methods being used:
+- `AuthSession.makeRedirectUri()` - generates redirect URI
+- `AuthSession.AuthRequest` - builds authorization request
+- `AuthSession.exchangeCodeAsync()` - exchanges code for tokens
+- `AuthSession.refreshAsync()` - refreshes access token
+
+Documentation: https://docs.expo.dev/versions/latest/sdk/auth-session/
+
+---
+
+## Questions or Issues?
+
+If you encounter issues during implementation:
+
+1. Check the expo-auth-session documentation
+2. Verify all imports are correct
+3. Check logs for error details (search for `[mcp_oauth]` and `[mcp_extensions]`)
+4. Test with a known working OAuth provider first (e.g., Google, GitHub)
+5. Use a tool like OAuth Debugger to validate OAuth flow independently
+
+Good luck! 🚀

--- a/docs/OAUTH_STATIC_CLIENT_IMPLEMENTATION_PLAN.md
+++ b/docs/OAUTH_STATIC_CLIENT_IMPLEMENTATION_PLAN.md
@@ -2,1290 +2,151 @@
 
 ## Overview
 
-This document provides a detailed implementation plan for adding static client ID and client secret support to the MCP OAuth2 client. Currently, the system only supports Dynamic Client Registration (DCR). This enhancement will allow users to configure pre-existing OAuth2 client credentials.
+This document describes the design and implementation of static client ID/secret support in the MCP OAuth2 client. The key insight: static mode uses the **same OAuth endpoint discovery** as DCR — it just skips dynamic client registration and uses the pre-provided `client_id` instead.
+
+This matches how other AI clients (Claude Desktop, Cursor, etc.) work: users only need to provide the MCP server URL, client ID, and optional client secret. The app discovers auth/token endpoints automatically.
 
 ---
 
-## Current State Analysis
+## Design Principle: Discovery-First
 
-### Existing Capabilities
+**Wrong approach (old plan):** Ask users for auth endpoint, token endpoint, and scopes.
 
-**Dynamic Client Registration (DCR)** ✅
-- Fully implemented in `lib/mcp-oauth.ts` and `modules/vm-webrtc/src/mcp_client/extensions.ts`
-- OAuth discovery via `/.well-known/oauth-authorization-server`
-- Automatic client registration via `registration_endpoint`
-- PKCE-based authorization code flow
-- Refresh token support
-- Uses `token_endpoint_auth_method: "none"` (public client)
+**Correct approach (current implementation):** Both DCR and static modes share the same discovery flow:
+1. Probe MCP server → get `401` with `resource_metadata_url`
+2. Fetch resource metadata → get `authorization_servers`
+3. Fetch `/.well-known/oauth-authorization-server` → get `authorization_endpoint` and `token_endpoint`
 
-**Manual Bearer Tokens** ✅
-- Users can provide pre-existing bearer tokens
-- No OAuth flow required
-- Stored securely per extension
-
-**NOT Supported (Yet)** ❌
-- Static OAuth2 client credentials (client_id + optional client_secret)
-- Manual OAuth endpoint configuration
-- Confidential client authentication (`client_secret_post`)
-
-### Current Storage Schema
-
-Per-extension secure storage:
-```
-MCP_TOKEN_PREFIX + id          → access/bearer token
-MCP_CLIENT_ID_PREFIX + id      → dynamically registered client_id
-MCP_REFRESH_TOKEN_PREFIX + id  → refresh token
-MCP_TOKEN_ENDPOINT_PREFIX + id → token endpoint URL
-```
-
-Extension metadata (AsyncStorage):
-```typescript
-interface McpExtensionRecord {
-  id: string;
-  name: string;
-  normalizedName: string;
-  serverUrl: string;
-  disabled?: boolean;
-}
-```
+The only difference between DCR and static:
+- **DCR:** Register a new public client at `registration_endpoint`, get back a `client_id`
+- **Static:** Skip registration, use the provided `client_id` (and optional `client_secret`)
 
 ---
 
-## Requirements Summary
+## What Users Provide
 
-1. Support static client_id and optional client_secret
-2. Support `token_endpoint_auth_method` of:
-   - `"none"` (public client with PKCE only)
-   - `"client_secret_post"` (confidential client)
-3. Skip server probe when using static mode (go directly to OAuth flow)
-4. Maintain full backwards compatibility with existing DCR-based connectors
-5. NO CIMD support (deferred)
+| Field | Required | Notes |
+|-------|----------|-------|
+| MCP Server URL | ✅ | Already on the main form |
+| Client ID | ✅ | Shown in static mode |
+| Client Secret | optional | For confidential clients; omit for public clients (PKCE only) |
 
----
-
-## Implementation Plan
-
-### Phase 1: Storage Layer Enhancement
-
-**File:** `lib/secure-storage.ts`
-
-#### 1.1 Add Storage Constants
-
-Add these constants near line 818 (after existing MCP constants):
-
-```typescript
-const MCP_CLIENT_SECRET_PREFIX = "VIBEMACHINE_MCP_CLIENT_SECRET_";
-const MCP_AUTH_MODE_PREFIX = "VIBEMACHINE_MCP_AUTH_MODE_";
-```
-
-#### 1.2 Update McpExtensionRecord Interface
-
-Update the interface (line 775) to track auth mode:
-
-```typescript
-export interface McpExtensionRecord {
-  id: string;
-  name: string;
-  normalizedName: string;
-  serverUrl: string;
-  disabled?: boolean;
-  authMode?: 'dcr' | 'static' | 'bearer'; // NEW: Track authentication type
-}
-```
-
-#### 1.3 Add Client Secret Storage Functions
-
-Add after `getMcpClientId()` function (around line 889):
-
-```typescript
-export async function saveMcpClientSecret(id: string, secret: string): Promise<void> {
-  await setCachedValue(`${MCP_CLIENT_SECRET_PREFIX}${id}`, secret);
-}
-
-export async function getMcpClientSecret(id: string): Promise<string | null> {
-  try {
-    return await getCachedValue(`${MCP_CLIENT_SECRET_PREFIX}${id}`);
-  } catch {
-    return null;
-  }
-}
-
-export async function deleteMcpClientSecret(id: string): Promise<void> {
-  try {
-    await deleteCachedValue(`${MCP_CLIENT_SECRET_PREFIX}${id}`);
-  } catch {
-    // secret may not exist
-  }
-}
-```
-
-#### 1.4 Add Auth Mode Storage Functions
-
-Add after client secret functions:
-
-```typescript
-export async function saveMcpAuthMode(id: string, mode: 'dcr' | 'static' | 'bearer'): Promise<void> {
-  await setCachedValue(`${MCP_AUTH_MODE_PREFIX}${id}`, mode);
-}
-
-export async function getMcpAuthMode(id: string): Promise<'dcr' | 'static' | 'bearer' | null> {
-  try {
-    const mode = await getCachedValue(`${MCP_AUTH_MODE_PREFIX}${id}`);
-    if (mode === 'dcr' || mode === 'static' || mode === 'bearer') {
-      return mode;
-    }
-    return null;
-  } catch {
-    return null;
-  }
-}
-```
-
-#### 1.5 Update clearMcpAuthCredentials()
-
-Modify function (line 915) to also clear client secret and auth mode:
-
-```typescript
-export async function clearMcpAuthCredentials(id: string): Promise<void> {
-  await Promise.allSettled([
-    deleteCachedValue(`${MCP_CLIENT_ID_PREFIX}${id}`),
-    deleteCachedValue(`${MCP_REFRESH_TOKEN_PREFIX}${id}`),
-    deleteCachedValue(`${MCP_TOKEN_ENDPOINT_PREFIX}${id}`),
-    deleteCachedValue(`${MCP_CLIENT_SECRET_PREFIX}${id}`),      // NEW
-    deleteCachedValue(`${MCP_AUTH_MODE_PREFIX}${id}`),           // NEW
-  ]);
-}
-```
-
-#### 1.6 Update clearAllStoredSecrets()
-
-Add client secret and auth mode keys to the cleanup list (around line 1006):
-
-```typescript
-for (const ext of mcpExtensions) {
-  secureStoreKeys.push(
-    `${MCP_TOKEN_PREFIX}${ext.id}`,
-    `${MCP_CLIENT_ID_PREFIX}${ext.id}`,
-    `${MCP_REFRESH_TOKEN_PREFIX}${ext.id}`,
-    `${MCP_TOKEN_ENDPOINT_PREFIX}${ext.id}`,
-    `${MCP_CLIENT_SECRET_PREFIX}${ext.id}`,    // NEW
-    `${MCP_AUTH_MODE_PREFIX}${ext.id}`,        // NEW
-  );
-}
-```
+Auth/token endpoints, scopes — all auto-discovered. Users never see them.
 
 ---
 
-### Phase 2: OAuth Flow Enhancement
+## Architecture
 
-#### 2.1 Update `lib/mcp-oauth.ts`
-
-##### 2.1.1 Add Static Credentials Type
-
-Add near the top of the file (after existing interfaces, around line 28):
+### `StaticOAuthCredentials` interface (`lib/mcp-oauth.ts`)
 
 ```typescript
 export interface StaticOAuthCredentials {
   clientId: string;
-  clientSecret?: string;
-  authorizationEndpoint: string;
-  tokenEndpoint: string;
-  scopes?: string[];
+  clientSecret?: string;  // omit for public clients
 }
 ```
 
-##### 2.1.2 Update performMcpOAuthFlow() Signature
+### `performMcpOAuthFlow()` — unified flow
 
-Modify function signature (line 34):
+Both DCR and static call the same discovery steps. The `staticCredentials` parameter controls which client credential path is taken:
 
-```typescript
-export async function performMcpOAuthFlow(
-  extensionId: string,
-  resourceMetadataUrl: string,
-  connectorName?: string,
-  extensionInfo?: { serverUrl: string; normalizedName: string },
-  staticCredentials?: StaticOAuthCredentials,  // NEW parameter
-): Promise<McpOAuthFlowResult>
+```
+performMcpOAuthFlow(extensionId, resourceMetadataUrl, ..., staticCredentials?)
+  ├── fetchResourceMetadata(resourceMetadataUrl)       ← shared
+  ├── fetchOAuthServerMetadata(authServerUrl)          ← shared
+  ├── if staticCredentials:
+  │     clientId = staticCredentials.clientId          ← use provided
+  │     clientSecret = staticCredentials.clientSecret
+  │     saveMcpAuthMode("static")
+  └── else (DCR):
+        clientId = cached || register new client       ← register
+        saveMcpAuthMode("dcr")
+  └── AuthSession.AuthRequest + promptAsync            ← shared
+  └── exchangeAndStore(code, ..., clientSecret?)       ← shared
 ```
 
-##### 2.1.3 Add Static OAuth Flow Branch
+### `handleSave()` static branch (`McpConnectorConfig.tsx`)
 
-Replace the content of `performMcpOAuthFlow()` with logic that branches based on whether `staticCredentials` is provided:
-
-```typescript
-export async function performMcpOAuthFlow(
-  extensionId: string,
-  resourceMetadataUrl: string,
-  connectorName?: string,
-  extensionInfo?: { serverUrl: string; normalizedName: string },
-  staticCredentials?: StaticOAuthCredentials,
-): Promise<McpOAuthFlowResult> {
-  
-  // NEW: Branch for static credentials
-  if (staticCredentials) {
-    log.info(
-      "[mcp_oauth] Starting OAuth flow with static credentials",
-      {},
-      { extension_id: extensionId, connector_name: connectorName },
-    );
-    
-    return performStaticOAuthFlow(
-      extensionId,
-      staticCredentials,
-      connectorName,
-    );
-  }
-  
-  // EXISTING: DCR flow continues below
-  log.info(
-    "[mcp_oauth] Starting OAuth flow with DCR",
-    {},
-    { extension_id: extensionId, connector_name: connectorName },
-  );
-
-  const resourceMetadata = await fetchResourceMetadata(resourceMetadataUrl, connectorName);
-  const authServerUrl = resourceMetadata.authorizationServers[0];
-  const oauthMeta = await fetchOAuthServerMetadata(authServerUrl, connectorName);
-
-  const redirectUri = AuthSession.makeRedirectUri({
-    scheme: "vibemachine",
-    path: "mcp-oauth-callback",
-  });
-
-  let clientId = await getMcpClientId(extensionId);
-  if (!clientId) {
-    if (!oauthMeta.registrationEndpoint) {
-      throw new Error(
-        "Server requires OAuth but has no registration_endpoint and no cached client_id",
-      );
-    }
-    const reg = await registerOAuthClient(
-      oauthMeta.registrationEndpoint,
-      redirectUri,
-      connectorName,
-    );
-    clientId = reg.clientId;
-    await saveMcpClientId(extensionId, clientId);
-  }
-
-  const discovery = {
-    authorizationEndpoint: oauthMeta.authorizationEndpoint,
-    tokenEndpoint: oauthMeta.tokenEndpoint,
-  };
-
-  const request = new AuthSession.AuthRequest({
-    clientId,
-    responseType: AuthSession.ResponseType.Code,
-    redirectUri,
-    scopes: [],
-    usePKCE: true,
-    extraParams: { resource: resourceMetadata.resource },
-  });
-
-  await request.makeAuthUrlAsync(discovery);
-
-  const pendingState: McpOAuthPendingState = {
-    extensionId,
-    codeVerifier: request.codeVerifier ?? "",
-    redirectUri,
-    clientId,
-    tokenEndpoint: oauthMeta.tokenEndpoint,
-    extensionName: connectorName ?? "",
-    extensionServerUrl: extensionInfo?.serverUrl ?? "",
-    extensionNormalizedName: extensionInfo?.normalizedName ?? "",
-  };
-
-  log.info(
-    "[mcp_oauth] Opening browser for authorization",
-    {},
-    { connector_name: connectorName },
-  );
-
-  const result = await request.promptAsync(discovery);
-
-  log.info(
-    "[mcp_oauth] promptAsync returned",
-    {},
-    {
-      result_type: result.type,
-      params: result.type === "success" ? result.params : undefined,
-      error: (result as any).error ?? undefined,
-      connector_name: connectorName,
-    },
-  );
-
-  if (result.type === "success" && result.params.code) {
-    log.info(
-      "[mcp_oauth] Exchanging code for token",
-      {},
-      { connector_name: connectorName },
-    );
-    const tokens = await exchangeAndStore(
-      result.params.code,
-      clientId,
-      redirectUri,
-      request.codeVerifier ?? "",
-      oauthMeta.tokenEndpoint,
-      extensionId,
-      connectorName,
-      undefined, // clientSecret not used in DCR flow
-    );
-    return { type: "success", ...tokens };
-  }
-
-  if (result.type === "error") {
-    const detail = (result as any).error_description ?? (result as any).error ?? JSON.stringify((result as any).params ?? result);
-    log.error(
-      "[mcp_oauth] OAuth server returned an error",
-      {},
-      { connector_name: connectorName, result },
-    );
-    throw new Error(`OAuth error: ${detail}`);
-  }
-
-  log.info(
-    "[mcp_oauth] Browser closed without redirect, returning manual callback state",
-    {},
-    { connector_name: connectorName, result_type: result.type },
-  );
-  return { type: "needs_manual_callback", pendingState };
-}
+```
+1. probeMcpServer(serverUrl) → 401 + resourceMetadataUrl
+2. performMcpOAuthFlow(id, resourceMetadataUrl, ..., { clientId, clientSecret })
 ```
 
-##### 2.1.4 Add performStaticOAuthFlow() Function
+No separate probe needed for DCR — that already happens in the existing `result.statusCode === 401` branch.
 
-Add new function after `performMcpOAuthFlow()`:
+---
 
-```typescript
-async function performStaticOAuthFlow(
-  extensionId: string,
-  credentials: StaticOAuthCredentials,
-  connectorName?: string,
-): Promise<McpOAuthFlowResult> {
-  
-  const redirectUri = AuthSession.makeRedirectUri({
-    scheme: "vibemachine",
-    path: "mcp-oauth-callback",
-  });
+## Storage
 
-  // Save static credentials
-  await saveMcpClientId(extensionId, credentials.clientId);
-  if (credentials.clientSecret) {
-    await saveMcpClientSecret(extensionId, credentials.clientSecret);
-  }
-  await saveMcpTokenEndpoint(extensionId, credentials.tokenEndpoint);
-  await saveMcpAuthMode(extensionId, 'static');
+Per-extension secure storage (unchanged from DCR, just `auth_mode` differs):
 
-  const discovery = {
-    authorizationEndpoint: credentials.authorizationEndpoint,
-    tokenEndpoint: credentials.tokenEndpoint,
-  };
-
-  const scopes = credentials.scopes ?? [];
-  const usePKCE = !credentials.clientSecret; // Use PKCE only if no client secret
-
-  const request = new AuthSession.AuthRequest({
-    clientId: credentials.clientId,
-    responseType: AuthSession.ResponseType.Code,
-    redirectUri,
-    scopes,
-    usePKCE,
-    extraParams: {},
-  });
-
-  await request.makeAuthUrlAsync(discovery);
-
-  const pendingState: McpOAuthPendingState = {
-    extensionId,
-    codeVerifier: request.codeVerifier ?? "",
-    redirectUri,
-    clientId: credentials.clientId,
-    tokenEndpoint: credentials.tokenEndpoint,
-    extensionName: connectorName ?? "",
-    extensionServerUrl: "", // Not applicable for static mode
-    extensionNormalizedName: "", // Not applicable for static mode
-  };
-
-  log.info(
-    "[mcp_oauth] Opening browser for static OAuth authorization",
-    {},
-    { connector_name: connectorName },
-  );
-
-  const result = await request.promptAsync(discovery);
-
-  log.info(
-    "[mcp_oauth] Static OAuth promptAsync returned",
-    {},
-    {
-      result_type: result.type,
-      connector_name: connectorName,
-    },
-  );
-
-  if (result.type === "success" && result.params.code) {
-    log.info(
-      "[mcp_oauth] Exchanging code for token (static)",
-      {},
-      { connector_name: connectorName },
-    );
-    const tokens = await exchangeAndStore(
-      result.params.code,
-      credentials.clientId,
-      redirectUri,
-      request.codeVerifier ?? "",
-      credentials.tokenEndpoint,
-      extensionId,
-      connectorName,
-      credentials.clientSecret, // Include client secret if provided
-    );
-    return { type: "success", ...tokens };
-  }
-
-  if (result.type === "error") {
-    const detail = (result as any).error_description ?? (result as any).error ?? JSON.stringify((result as any).params ?? result);
-    log.error(
-      "[mcp_oauth] Static OAuth error",
-      {},
-      { connector_name: connectorName, result },
-    );
-    throw new Error(`OAuth error: ${detail}`);
-  }
-
-  log.info(
-    "[mcp_oauth] Browser closed, returning manual callback state",
-    {},
-    { connector_name: connectorName, result_type: result.type },
-  );
-  return { type: "needs_manual_callback", pendingState };
-}
 ```
-
-**Important:** Don't forget to add the import at the top:
-```typescript
-import {
-  getMcpClientId,
-  getMcpClientSecret,        // NEW
-  getMcpRefreshToken,
-  getMcpTokenEndpoint,
-  saveMcpBearerToken,
-  saveMcpClientId,
-  saveMcpClientSecret,        // NEW
-  saveMcpRefreshToken,
-  saveMcpTokenEndpoint,
-  saveMcpAuthMode,            // NEW
-  getMcpAuthMode,             // NEW (for refresh logic)
-} from "./secure-storage";
-```
-
-##### 2.1.5 Update exchangeAndStore() Function
-
-Modify function signature and implementation (line 184):
-
-```typescript
-async function exchangeAndStore(
-  code: string,
-  clientId: string,
-  redirectUri: string,
-  codeVerifier: string,
-  tokenEndpoint: string,
-  extensionId: string,
-  connectorName?: string,
-  clientSecret?: string,  // NEW parameter
-): Promise<{ accessToken: string; refreshToken?: string }> {
-  
-  const exchangeConfig: any = {
-    code,
-    clientId,
-    redirectUri,
-  };
-
-  // Add client secret for confidential clients (client_secret_post method)
-  if (clientSecret) {
-    exchangeConfig.clientSecret = clientSecret;
-  }
-
-  // Add PKCE verifier for public clients or when using PKCE
-  if (codeVerifier) {
-    exchangeConfig.extraParams = { code_verifier: codeVerifier };
-  }
-
-  const tokenResponse = await AuthSession.exchangeCodeAsync(
-    exchangeConfig,
-    { tokenEndpoint },
-  );
-
-  await saveMcpBearerToken(extensionId, tokenResponse.accessToken);
-  await saveMcpTokenEndpoint(extensionId, tokenEndpoint);
-  if (tokenResponse.refreshToken) {
-    await saveMcpRefreshToken(extensionId, tokenResponse.refreshToken);
-  }
-
-  log.info(
-    "[mcp_oauth] OAuth flow complete",
-    {},
-    { 
-      connector_name: connectorName, 
-      has_refresh_token: !!tokenResponse.refreshToken,
-      used_client_secret: !!clientSecret,
-    },
-  );
-
-  return {
-    accessToken: tokenResponse.accessToken,
-    refreshToken: tokenResponse.refreshToken ?? undefined,
-  };
-}
-```
-
-##### 2.1.6 Update refreshMcpAccessToken() Function
-
-Modify function (line 221) to support client secrets:
-
-```typescript
-export async function refreshMcpAccessToken(
-  extensionId: string,
-  connectorName?: string,
-): Promise<string | null> {
-  const [refreshToken, tokenEndpoint, clientId, clientSecret] = await Promise.all([
-    getMcpRefreshToken(extensionId),
-    getMcpTokenEndpoint(extensionId),
-    getMcpClientId(extensionId),
-    getMcpClientSecret(extensionId),  // NEW
-  ]);
-
-  if (!refreshToken || !tokenEndpoint || !clientId) return null;
-
-  log.info(
-    "[mcp_oauth] Refreshing access token",
-    {},
-    { 
-      extension_id: extensionId, 
-      connector_name: connectorName,
-      has_client_secret: !!clientSecret,
-    },
-  );
-
-  try {
-    const refreshConfig: any = {
-      clientId,
-      refreshToken,
-    };
-
-    // Include client secret for confidential clients
-    if (clientSecret) {
-      refreshConfig.clientSecret = clientSecret;
-    }
-
-    const tokenResponse = await AuthSession.refreshAsync(
-      refreshConfig,
-      { tokenEndpoint },
-    );
-
-    await saveMcpBearerToken(extensionId, tokenResponse.accessToken);
-    if (tokenResponse.refreshToken) {
-      await saveMcpRefreshToken(extensionId, tokenResponse.refreshToken);
-    }
-
-    log.info(
-      "[mcp_oauth] Token refresh succeeded", 
-      {}, 
-      { connector_name: connectorName },
-    );
-    return tokenResponse.accessToken;
-  } catch (err) {
-    log.warn(
-      "[mcp_oauth] Token refresh failed",
-      {},
-      { 
-        connector_name: connectorName, 
-        error: err instanceof Error ? err.message : String(err),
-      },
-    );
-    return null;
-  }
-}
-```
-
-##### 2.1.7 Update completeMcpOAuthFromCallbackUrl()
-
-This function needs to handle retrieving the client secret if it was stored (for static mode):
-
-```typescript
-export async function completeMcpOAuthFromCallbackUrl(
-  callbackUrl: string,
-  pendingState: McpOAuthPendingState,
-): Promise<{ accessToken: string; refreshToken?: string }> {
-  const questionIdx = callbackUrl.indexOf("?");
-  if (questionIdx === -1) {
-    throw new Error("No authorization code found in that URL.");
-  }
-  const params = new URLSearchParams(callbackUrl.slice(questionIdx + 1));
-  const code = params.get("code");
-  if (!code) {
-    throw new Error("No authorization code found in that URL.");
-  }
-
-  log.info(
-    "[mcp_oauth] Completing OAuth from pasted callback URL",
-    {},
-    { extension_id: pendingState.extensionId },
-  );
-
-  // Retrieve client secret if this is a static mode flow
-  const clientSecret = await getMcpClientSecret(pendingState.extensionId);
-
-  return exchangeAndStore(
-    code,
-    pendingState.clientId,
-    pendingState.redirectUri,
-    pendingState.codeVerifier,
-    pendingState.tokenEndpoint,
-    pendingState.extensionId,
-    undefined,
-    clientSecret,  // NEW: pass client secret if available
-  );
-}
+MCP_TOKEN_PREFIX + id          → access/bearer token
+MCP_CLIENT_ID_PREFIX + id      → client_id (static: provided; dcr: registered)
+MCP_CLIENT_SECRET_PREFIX + id  → client_secret (static only; dcr: never stored)
+MCP_REFRESH_TOKEN_PREFIX + id  → refresh token
+MCP_TOKEN_ENDPOINT_PREFIX + id → discovered token endpoint
+MCP_AUTH_MODE_PREFIX + id      → "static" | "dcr" | "bearer"
 ```
 
 ---
 
-### Phase 3: UI Enhancement
+## Implementation Status
 
-**File:** `components/settings/McpConnectorConfig.tsx`
+### Phase 1: Storage Layer ✅ Complete
+- `MCP_CLIENT_SECRET_PREFIX` / `MCP_AUTH_MODE_PREFIX` constants added
+- `McpExtensionRecord.authMode` field added
+- `saveMcpClientSecret` / `getMcpClientSecret` / `deleteMcpClientSecret` implemented
+- `saveMcpAuthMode` / `getMcpAuthMode` implemented
+- `clearMcpAuthCredentials()` clears client secret and auth mode
+- `clearAllStoredSecrets()` includes new keys
 
-#### 3.1 Add Import for New Storage Functions
+### Phase 2: OAuth Flow ✅ Complete
+- `StaticOAuthCredentials` — only `clientId` + optional `clientSecret` (no endpoints)
+- `performMcpOAuthFlow()` — unified function; both modes share discovery
+- `exchangeAndStore()` — handles optional `clientSecret`
+- `refreshMcpAccessToken()` — retrieves and uses stored client secret
+- `completeMcpOAuthFromCallbackUrl()` — retrieves client secret for manual callback
 
-Update imports (around line 18):
-
-```typescript
-import {
-  addMcpExtension,
-  deleteMcpBearerToken,
-  getMcpBearerToken,
-  getMcpExtensions,
-  getMcpRefreshToken,
-  saveMcpBearerToken,
-  toNormalizedName,
-  uniqueNormalizedName,
-  type McpExtensionRecord,
-  getMcpClientId,           // NEW
-  getMcpClientSecret,       // NEW
-  getMcpAuthMode,           // NEW
-  saveMcpAuthMode,          // NEW
-} from "../../lib/secure-storage";
-```
-
-Also update mcp-oauth import:
-
-```typescript
-import {
-  completeMcpOAuthFromCallbackUrl,
-  performMcpOAuthFlow,
-  type McpOAuthPendingState,
-  type StaticOAuthCredentials,  // NEW
-} from "../../lib/mcp-oauth";
-```
-
-#### 3.2 Add New State Variables
-
-Add these state variables after existing state declarations (around line 70):
-
-```typescript
-const [authMethod, setAuthMethod] = useState<'auto' | 'static'>('auto');
-const [staticClientId, setStaticClientId] = useState('');
-const [staticClientSecret, setStaticClientSecret] = useState('');
-const [staticAuthEndpoint, setStaticAuthEndpoint] = useState('');
-const [staticTokenEndpoint, setStaticTokenEndpoint] = useState('');
-const [staticScopes, setStaticScopes] = useState('');
-const [staticSecretVisible, setStaticSecretVisible] = useState(false);
-```
-
-#### 3.3 Update Load Logic (useEffect)
-
-Modify the existing useEffect that loads extension data (around line 72) to also load static credentials:
-
-```typescript
-useEffect(() => {
-  if (visible && existingExtension) {
-    setName(existingExtension.name);
-    setServerUrl(existingExtension.serverUrl);
-    setNormalizedNamePreview(existingExtension.normalizedName ?? toNormalizedName(existingExtension.name));
-    
-    Promise.all([
-      getMcpBearerToken(existingExtension.id),
-      getMcpRefreshToken(existingExtension.id),
-      getMcpAuthMode(existingExtension.id),        // NEW
-      getMcpClientId(existingExtension.id),        // NEW
-      getMcpClientSecret(existingExtension.id),    // NEW
-    ]).then(([token, refreshToken, authMode, clientId, clientSecret]) => {
-      
-      // Detect auth method based on stored data
-      if (authMode === 'static') {
-        setAuthMethod('static');
-        setStaticClientId(clientId ?? '');
-        setStaticClientSecret(clientSecret ?? '');
-        // Note: We don't store endpoints separately for display,
-        // they're only used during OAuth flow. Could add if needed.
-      } else if (authMode === 'dcr') {
-        setAuthMethod('auto');
-      } else if (refreshToken) {
-        // Legacy detection: has refresh token = OAuth was used
-        setHasOAuthToken(true);
-        setAuthMethod('auto');
-      } else if (token) {
-        // Has bearer token only = manual token mode
-        setBearerToken(token);
-        setAdvancedExpanded(true);
-      }
-    });
-  } else if (visible) {
-    setNormalizedNamePreview("");
-    setHasOAuthToken(false);
-    setAuthMethod('auto');
-    setStaticClientId('');
-    setStaticClientSecret('');
-    setStaticAuthEndpoint('');
-    setStaticTokenEndpoint('');
-    setStaticScopes('');
-  }
-}, [visible, existingExtension]);
-```
-
-#### 3.4 Update persistExtension Function
-
-Add auth mode parameter and save it (around line 132):
-
-```typescript
-const persistExtension = async (
-  id: string,
-  manualToken?: string,
-  options?: { preserveExistingToken?: boolean; authMode?: 'dcr' | 'static' | 'bearer' },
-) => {
-  log.info("[mcp_connector] persistExtension start", {}, { id, isEditing, hasManualToken: !!manualToken, preserveExistingToken: options?.preserveExistingToken, authMode: options?.authMode });
-  const allExtensions = await getMcpExtensions();
-  const normalizedName = uniqueNormalizedName(toNormalizedName(name), allExtensions, existingExtension?.id);
-  const record: McpExtensionRecord = { 
-    id, 
-    name, 
-    normalizedName, 
-    serverUrl,
-    authMode: options?.authMode,  // NEW
-  };
-  await addMcpExtension(record);
-  if (manualToken) {
-    await saveMcpBearerToken(id, manualToken);
-    if (options?.authMode) {
-      await saveMcpAuthMode(id, options.authMode);
-    }
-  } else if (!options?.preserveExistingToken) {
-    await deleteMcpBearerToken(id);
-  }
-  if (options?.authMode) {
-    await saveMcpAuthMode(id, options.authMode);
-  }
-  DeviceEventEmitter.emit(CONNECTOR_SETTINGS_CHANGED_EVENT);
-  log.info("[mcp_connector] calling onSave", {}, { id });
-  onSave?.(record);
-  log.info("[mcp_connector] calling resetAndClose", {}, { id });
-  resetAndClose();
-  Alert.alert(
-    isEditing ? "Saved" : "Connected Successfully",
-    isEditing
-      ? "Extension updated."
-      : "Extension added. You can update its config anytime from the Extensions (MCP) screen.",
-    [{ text: "OK" }],
-  );
-};
-```
-
-#### 3.5 Update handleSave Function
-
-Replace the existing `handleSave` function (around line 161) to branch on auth method:
-
-```typescript
-const handleSave = async () => {
-  setIsConnecting(true);
-  setConnectingLabel("Connecting…");
-  try {
-    // NEW: Static credentials mode
-    if (authMethod === 'static') {
-      // Validate required fields
-      if (!staticClientId.trim()) {
-        Alert.alert("Missing Field", "Client ID is required for static OAuth.", [{ text: "OK" }]);
-        return;
-      }
-      if (!staticAuthEndpoint.trim() || !staticTokenEndpoint.trim()) {
-        Alert.alert("Missing Fields", "Authorization and Token endpoints are required.", [{ text: "OK" }]);
-        return;
-      }
-
-      const id = existingExtension?.id ?? `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
-      setConnectingLabel("Opening sign-in…");
-
-      const staticCredentials: StaticOAuthCredentials = {
-        clientId: staticClientId.trim(),
-        clientSecret: staticClientSecret.trim() || undefined,
-        authorizationEndpoint: staticAuthEndpoint.trim(),
-        tokenEndpoint: staticTokenEndpoint.trim(),
-        scopes: staticScopes.trim() ? staticScopes.trim().split(',').map(s => s.trim()) : undefined,
-      };
-
-      try {
-        onBeforeBrowserOpen?.();
-        const oauthResult = await performMcpOAuthFlow(
-          id,
-          '', // resourceMetadataUrl not used for static mode
-          name,
-          undefined, // extensionInfo not used for static mode
-          staticCredentials,
-        );
-
-        log.info("[mcp_connector] Static OAuth flow returned", {}, { oauthResult_type: oauthResult.type });
-
-        if (oauthResult.type === "success") {
-          await persistExtension(id, undefined, { preserveExistingToken: true, authMode: 'static' });
-        } else {
-          setPendingOAuth(oauthResult.pendingState);
-          setPendingExtensionId(id);
-          onNeedsManualCallback?.();
-        }
-      } catch (oauthError: any) {
-        log.error("[mcp_connector] Static OAuth error caught", {}, { message: oauthError?.message });
-        Alert.alert(
-          "Authentication Failed",
-          oauthError?.message ?? "OAuth sign-in failed.",
-          [{ text: "OK" }],
-        );
-      }
-      return;
-    }
-
-    // EXISTING: Auto (DCR) mode
-    const token = bearerToken.trim() || undefined;
-    const result = await probeMcpServer(serverUrl, token, name);
-
-    if (result.success) {
-      const id = existingExtension?.id ?? `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
-      await persistExtension(id, token, { authMode: token ? 'bearer' : undefined });
-    } else if (result.statusCode === 401 && result.resourceMetadataUrl) {
-      const id = existingExtension?.id ?? `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
-      setConnectingLabel("Opening sign-in…");
-      const allExtensions = await getMcpExtensions();
-      const normalizedName = uniqueNormalizedName(toNormalizedName(name), allExtensions, existingExtension?.id);
-      log.info("[mcp_connector] entering OAuth branch", {}, { id, serverUrl, normalizedName, resourceMetadataUrl: result.resourceMetadataUrl });
-      try {
-        onBeforeBrowserOpen?.();
-        const oauthResult = await performMcpOAuthFlow(id, result.resourceMetadataUrl, name, { serverUrl, normalizedName });
-        log.info("[mcp_connector] OAuth flow returned", {}, { oauthResult_type: oauthResult.type });
-        if (oauthResult.type === "success") {
-          await persistExtension(id, undefined, { preserveExistingToken: true, authMode: 'dcr' });
-        } else {
-          setPendingOAuth(oauthResult.pendingState);
-          setPendingExtensionId(id);
-          onNeedsManualCallback?.();
-        }
-      } catch (oauthError: any) {
-        log.error("[mcp_connector] oauthError caught", {}, { message: oauthError?.message });
-        Alert.alert(
-          "Authentication Failed",
-          oauthError?.message ?? "OAuth sign-in failed.",
-          [{ text: "OK" }],
-        );
-      }
-    } else if (result.statusCode === 401) {
-      Alert.alert(
-        "Authentication Required",
-        "This server requires a Bearer token. Enter it in the Advanced section.",
-        [{ text: "OK" }],
-      );
-    } else {
-      const detail = result.error ?? `Server returned ${result.statusCode}`;
-      Alert.alert("Connection Failed", detail, [{ text: "OK" }]);
-    }
-  } finally {
-    log.info("[mcp_connector] handleSave finally — clearing isConnecting");
-    setIsConnecting(false);
-    setConnectingLabel("Connecting…");
-  }
-};
-```
-
-#### 3.6 Update resetAndClose Function
-
-Add new fields to reset (around line 229):
-
-```typescript
-const resetAndClose = () => {
-  log.info("[mcp_connector] resetAndClose");
-  setName("");
-  setServerUrl("");
-  setBearerToken("");
-  setNormalizedNamePreview("");
-  setAdvancedExpanded(false);
-  setTokenVisible(false);
-  setHasOAuthToken(false);
-  setPendingOAuth(null);
-  setPendingExtensionId(null);
-  setCallbackUrl("");
-  setCallbackError("");
-  setAuthMethod('auto');           // NEW
-  setStaticClientId('');           // NEW
-  setStaticClientSecret('');       // NEW
-  setStaticAuthEndpoint('');       // NEW
-  setStaticTokenEndpoint('');      // NEW
-  setStaticScopes('');             // NEW
-  setStaticSecretVisible(false);   // NEW
-  onClose();
-};
-```
-
-#### 3.7 Add UI Components for Static OAuth
-
-Find the "Advanced" section in the JSX (search for "Advanced" text, around line 400+). Add a new section BEFORE the bearer token section:
-
-```tsx
-{/* OAuth Configuration Method */}
-<View style={styles.section}>
-  <Text style={styles.label}>OAuth Method</Text>
-  <View style={styles.segmentControl}>
-    <Pressable
-      style={[
-        styles.segment,
-        authMethod === 'auto' && styles.segmentActive,
-      ]}
-      onPress={() => setAuthMethod('auto')}
-    >
-      <Text
-        style={[
-          styles.segmentText,
-          authMethod === 'auto' && styles.segmentTextActive,
-        ]}
-      >
-        Auto (DCR)
-      </Text>
-    </Pressable>
-    <Pressable
-      style={[
-        styles.segment,
-        authMethod === 'static' && styles.segmentActive,
-      ]}
-      onPress={() => setAuthMethod('static')}
-    >
-      <Text
-        style={[
-          styles.segmentText,
-          authMethod === 'static' && styles.segmentTextActive,
-        ]}
-      >
-        Static Credentials
-      </Text>
-    </Pressable>
-  </View>
-  <Text style={styles.hint}>
-    {authMethod === 'auto'
-      ? "Automatically discover OAuth endpoints and register client (Dynamic Client Registration)."
-      : "Use pre-existing OAuth client credentials with manually configured endpoints."}
-  </Text>
-</View>
-
-{/* Static OAuth Fields (only shown when authMethod === 'static') */}
-{authMethod === 'static' && (
-  <>
-    <View style={styles.section}>
-      <Text style={styles.label}>Client ID *</Text>
-      <TextInput
-        style={styles.input}
-        value={staticClientId}
-        onChangeText={setStaticClientId}
-        placeholder="your-client-id"
-        autoCapitalize="none"
-        autoCorrect={false}
-      />
-    </View>
-
-    <View style={styles.section}>
-      <Text style={styles.label}>Client Secret (optional)</Text>
-      <View style={styles.passwordContainer}>
-        <TextInput
-          style={[styles.input, styles.passwordInput]}
-          value={staticClientSecret}
-          onChangeText={setStaticClientSecret}
-          placeholder="Optional for confidential clients"
-          secureTextEntry={!staticSecretVisible}
-          autoCapitalize="none"
-          autoCorrect={false}
-        />
-        <Pressable
-          style={styles.eyeButton}
-          onPress={() => setStaticSecretVisible(!staticSecretVisible)}
-        >
-          <Text style={styles.eyeButtonText}>
-            {staticSecretVisible ? "👁️" : "👁️‍🗨️"}
-          </Text>
-        </Pressable>
-      </View>
-      <Text style={styles.hint}>
-        Leave blank for public clients (uses PKCE only). Provide for confidential clients.
-      </Text>
-    </View>
-
-    <View style={styles.section}>
-      <Text style={styles.label}>Authorization Endpoint *</Text>
-      <TextInput
-        style={styles.input}
-        value={staticAuthEndpoint}
-        onChangeText={setStaticAuthEndpoint}
-        placeholder="https://provider.com/oauth/authorize"
-        autoCapitalize="none"
-        autoCorrect={false}
-        keyboardType="url"
-      />
-    </View>
-
-    <View style={styles.section}>
-      <Text style={styles.label}>Token Endpoint *</Text>
-      <TextInput
-        style={styles.input}
-        value={staticTokenEndpoint}
-        onChangeText={setStaticTokenEndpoint}
-        placeholder="https://provider.com/oauth/token"
-        autoCapitalize="none"
-        autoCorrect={false}
-        keyboardType="url"
-      />
-    </View>
-
-    <View style={styles.section}>
-      <Text style={styles.label}>Scopes (optional)</Text>
-      <TextInput
-        style={styles.input}
-        value={staticScopes}
-        onChangeText={setStaticScopes}
-        placeholder="read, write, openid"
-        autoCapitalize="none"
-        autoCorrect={false}
-      />
-      <Text style={styles.hint}>
-        Comma-separated list of OAuth scopes to request.
-      </Text>
-    </View>
-  </>
-)}
-
-{/* Existing Bearer Token section (only shown when authMethod === 'auto') */}
-{authMethod === 'auto' && (
-  // ... existing bearer token UI ...
-)}
-```
-
-#### 3.8 Add Styles
-
-Add these styles to the StyleSheet (around line 600+):
-
-```typescript
-segmentControl: {
-  flexDirection: "row",
-  backgroundColor: "#f0f0f0",
-  borderRadius: 8,
-  padding: 2,
-},
-segment: {
-  flex: 1,
-  paddingVertical: 8,
-  paddingHorizontal: 12,
-  alignItems: "center",
-  borderRadius: 6,
-},
-segmentActive: {
-  backgroundColor: "#fff",
-  shadowColor: "#000",
-  shadowOffset: { width: 0, height: 1 },
-  shadowOpacity: 0.1,
-  shadowRadius: 2,
-  elevation: 2,
-},
-segmentText: {
-  fontSize: 14,
-  color: "#666",
-  fontWeight: "500",
-},
-segmentTextActive: {
-  color: "#000",
-  fontWeight: "600",
-},
-passwordContainer: {
-  position: "relative",
-},
-passwordInput: {
-  paddingRight: 50,
-},
-eyeButton: {
-  position: "absolute",
-  right: 12,
-  top: 12,
-  padding: 4,
-},
-eyeButtonText: {
-  fontSize: 20,
-},
-```
+### Phase 3: UI ✅ Complete
+- **Static mode fields:** Client ID + Client Secret only (no endpoint/scope inputs)
+- **Hint text:** "Endpoints are auto-discovered from the MCP server"
+- `handleSave()` static branch: probes server first, then calls `performMcpOAuthFlow`
+- `validateMcpConnectorForm()`: only requires `clientId` in static mode
+- `buildStaticOAuthCredentials()`: builds `{ clientId, clientSecret? }` only
+- Auth mode toggle: "Auto (DCR)" vs "Static Credentials"
 
 ---
 
-### Phase 4: Testing & Validation
+## Test Scenarios
 
-#### 4.1 Test Scenarios
+### Static Public Client (PKCE, no secret)
+1. User enters: MCP server URL, Client ID
+2. App probes server → discovers endpoints automatically
+3. OAuth flow with PKCE (no client secret)
+4. Token stored and connector works
 
-Create test cases for the following scenarios:
+### Static Confidential Client (with secret)
+1. User enters: MCP server URL, Client ID, Client Secret
+2. App probes server → discovers endpoints automatically
+3. OAuth flow using `client_secret_post` (no PKCE)
+4. Secret stored in keychain, used for refresh
 
-**Test 1: DCR Flow (Regression Test)**
-- Create new MCP connector with server that supports DCR
-- Verify auto-discovery works
-- Verify client registration happens
-- Verify OAuth flow completes
-- Verify tokens are stored correctly
-- Verify connector works after setup
+### DCR Flow (regression)
+- Unchanged from before: no static credentials provided
+- Server must support `registration_endpoint`
 
-**Test 2: Static Public Client (PKCE)**
-- Create new connector with auth method = "Static Credentials"
-- Provide: client_id, auth endpoint, token endpoint (NO secret)
-- Verify PKCE is used
-- Verify OAuth flow completes
-- Verify tokens work
-- Test token refresh
+### Edit existing static connector
+- Re-opening shows Client ID and Client Secret pre-filled
+- Saving re-runs OAuth with existing credentials
 
-**Test 3: Static Confidential Client (with Secret)**
-- Create connector with static credentials
-- Provide: client_id, client_secret, endpoints
-- Verify client_secret is included in token exchange
-- Verify tokens work
-- Test token refresh with secret
-
-**Test 4: Mixed Connectors**
-- Have 2-3 connectors: one DCR, one static public, one static confidential
-- Verify they all work independently
-- Verify token refresh works for each
-
-**Test 5: Edit Existing Connector**
-- Create connector with DCR
-- Edit it and switch to static mode
-- Verify old credentials are cleared
-- Verify new flow works
-- Test reverse (static → DCR)
-
-**Test 6: Manual Callback (Browser Dismissed)**
-- Start OAuth flow (DCR or static)
-- Dismiss browser before completing
-- Verify manual paste UI appears
-- Paste valid callback URL
-- Verify flow completes
-
-**Test 7: Error Handling**
-- Invalid endpoints
-- Wrong client credentials
-- Network errors during OAuth
-- Token refresh failures
-
-#### 4.2 Validation Checklist
-
-Before considering complete, verify:
-
-- [ ] No TypeScript errors
-- [ ] All existing DCR connectors continue working
-- [ ] Static mode skips server probe (no unnecessary network call)
-- [ ] Client secrets stored in secure keychain (not AsyncStorage)
-- [ ] Sensitive data (secrets, tokens) never logged
-- [ ] UI clearly distinguishes between auth methods
-- [ ] Form validation prevents saving incomplete config
-- [ ] Token refresh works for both DCR and static modes
-- [ ] Clearing/deleting connector removes all stored credentials
-- [ ] No memory leaks or state issues when switching between modes
+### Manual callback (browser dismissed)
+- Works for both DCR and static; client secret retrieved from storage for token exchange
 
 ---
 
-## Implementation Checklist
+## Notes
 
-Use this checklist to track progress:
-
-### Phase 1: Storage
-- [ ] Add storage constants
-- [ ] Update `McpExtensionRecord` interface
-- [ ] Add client secret storage functions
-- [ ] Add auth mode storage functions
-- [ ] Update `clearMcpAuthCredentials()`
-- [ ] Update `clearAllStoredSecrets()`
-
-### Phase 2: OAuth Logic
-- [ ] Add `StaticOAuthCredentials` interface
-- [ ] Update `performMcpOAuthFlow()` signature
-- [ ] Add static credentials branch
-- [ ] Implement `performStaticOAuthFlow()`
-- [ ] Update `exchangeAndStore()` for client secrets
-- [ ] Update `refreshMcpAccessToken()` for client secrets
-- [ ] Update `completeMcpOAuthFromCallbackUrl()`
-- [ ] Add all necessary imports
-
-### Phase 3: UI
-- [ ] Update imports
-- [ ] Add state variables
-- [ ] Update load logic (useEffect)
-- [ ] Update `persistExtension()` 
-- [ ] Update `handleSave()`
-- [ ] Update `resetAndClose()`
-- [ ] Add OAuth method selector UI
-- [ ] Add static credentials input fields
-- [ ] Add conditional rendering logic
-- [ ] Add styles
-
-### Phase 4: Testing
-- [ ] Test DCR flow (regression)
-- [ ] Test static public client
-- [ ] Test static confidential client
-- [ ] Test mixed connectors
-- [ ] Test editing connectors
-- [ ] Test manual callback flow
-- [ ] Test error handling
-- [ ] Run validation checklist
-
----
-
-## Notes for Implementation
-
-### Security Considerations
-
-1. **Never log sensitive data**: Client secrets, tokens, and authorization codes should never appear in logs
-2. **Use secure storage**: All secrets must use `setCachedValue` which uses iOS Keychain
-3. **Sanitize logs**: When logging, use `[REDACTED]` for sensitive fields
-4. **Clear on delete**: When deleting a connector, ensure ALL credentials are removed
-
-### Common Pitfalls
-
-1. **Don't use PKCE with client_secret**: If client secret is provided, PKCE is optional (set `usePKCE: false`)
-2. **Token endpoint auth method**: expo-auth-session uses `client_secret_post` by default when `clientSecret` is provided
-3. **Scope formatting**: Scopes should be an array, not a space-separated string
-4. **Redirect URI**: Must be consistent across registration, authorization, and token exchange
-
-### Expo AuthSession Reference
-
-Key methods being used:
-- `AuthSession.makeRedirectUri()` - generates redirect URI
-- `AuthSession.AuthRequest` - builds authorization request
-- `AuthSession.exchangeCodeAsync()` - exchanges code for tokens
-- `AuthSession.refreshAsync()` - refreshes access token
-
-Documentation: https://docs.expo.dev/versions/latest/sdk/auth-session/
-
----
-
-## Questions or Issues?
-
-If you encounter issues during implementation:
-
-1. Check the expo-auth-session documentation
-2. Verify all imports are correct
-3. Check logs for error details (search for `[mcp_oauth]` and `[mcp_extensions]`)
-4. Test with a known working OAuth provider first (e.g., Google, GitHub)
-5. Use a tool like OAuth Debugger to validate OAuth flow independently
-
-Good luck! 🚀
+- **PKCE strategy:** `usePKCE = !clientSecret` — public clients always use PKCE; confidential clients skip it (some servers don't support both simultaneously)
+- **Scopes:** Not configurable by user; MCP servers advertise required scopes via the OAuth flow itself
+- **Endpoint persistence:** Token endpoint is stored for refresh token use; auth endpoint is re-discovered each time the user re-authenticates (by probing the server)

--- a/docs/superpowers/plans/2026-06-25-mcp-static-oauth-pkce.md
+++ b/docs/superpowers/plans/2026-06-25-mcp-static-oauth-pkce.md
@@ -1,0 +1,258 @@
+# MCP Static OAuth PKCE Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make MCP OAuth use PKCE by default for static client ID and client secret authorization-code flows.
+
+**Architecture:** Keep OAuth flow ownership in `lib/mcp-oauth.ts`, where Expo AuthSession already creates the authorization request and stores the in-memory `codeVerifier` in `McpOAuthPendingState`. Change the static secret flow so the authorization request always enables PKCE, while token exchange and refresh still include the static client secret when one is configured.
+
+**Tech Stack:** Expo AuthSession, Expo React Native, Bun test, TypeScript.
+
+---
+
+## File Structure
+
+- Modify `lib/__tests__/mcp-oauth.test.ts`: update the current static-client test from "disables PKCE" to "requires PKCE", and add manual callback coverage that proves `code_verifier` is sent even when a static client secret is restored.
+- Modify `lib/mcp-oauth.ts`: change the `AuthSession.AuthRequest` configuration so MCP OAuth always sets `usePKCE: true`.
+- No UI files need to change. `components/settings/McpConnectorConfig.tsx` already passes static client credentials into `performMcpOAuthFlow`, and `pendingOAuth` is held in React state only.
+- No storage migration is needed. The code verifier remains transient: it is generated per auth request, copied into `McpOAuthPendingState` for the active manual callback flow, and cleared by existing modal reset paths.
+
+---
+
+### Task 1: Update Static OAuth Tests For PKCE
+
+**Files:**
+- Modify: `lib/__tests__/mcp-oauth.test.ts`
+- Test: `lib/__tests__/mcp-oauth.test.ts`
+
+- [ ] **Step 1: Replace the static secret test with PKCE expectations**
+
+In `lib/__tests__/mcp-oauth.test.ts`, replace the first `performMcpOAuthFlow` test with this version:
+
+```ts
+  test("uses PKCE for static client secrets and still sends the secret during token exchange", async () => {
+    const result = await (oauthModule.performMcpOAuthFlow as any)(
+      "extension-1",
+      "https://resource.example.com/.well-known/oauth-protected-resource",
+      "Static Connector",
+      undefined,
+      {
+        clientId: "static-client-id",
+        clientSecret: "static-client-secret",
+      },
+    );
+
+    expect(result).toEqual({
+      type: "success",
+      accessToken: "access-token",
+      refreshToken: "refresh-token",
+    });
+    expect(authState.lastAuthRequestConfig).toMatchObject({
+      clientId: "static-client-id",
+      scopes: [],
+      usePKCE: true,
+      extraParams: { resource: "https://resource.example.com" },
+    });
+    expect(authState.exchangeCalls[0]).toMatchObject({
+      code: "auth-code",
+      clientId: "static-client-id",
+      clientSecret: "static-client-secret",
+      tokenEndpoint: "https://auth.example.com/token",
+      extraParams: { code_verifier: "generated-code-verifier" },
+    });
+    expect(secureState.savedClientIds).toContainEqual({
+      id: "extension-1",
+      clientId: "static-client-id",
+    });
+    expect(secureState.savedClientSecrets).toContainEqual({
+      id: "extension-1",
+      clientSecret: "static-client-secret",
+    });
+    expect(secureState.savedAuthModes).toContainEqual({
+      id: "extension-1",
+      mode: "static",
+    });
+  });
+```
+
+- [ ] **Step 2: Update manual callback coverage to include the verifier**
+
+In the `restores static client secrets for manual callback completion` test, change the pending state `codeVerifier` from an empty string to a real value:
+
+```ts
+        codeVerifier: "manual-code-verifier",
+```
+
+Then update the assertion to require `code_verifier` as well as `clientSecret`:
+
+```ts
+    expect(authState.exchangeCalls[0]).toMatchObject({
+      code: "manual-code",
+      clientId: "static-client-id",
+      clientSecret: "stored-static-secret",
+      extraParams: { code_verifier: "manual-code-verifier" },
+    });
+```
+
+- [ ] **Step 3: Run the tests and verify the expected failure**
+
+Run:
+
+```bash
+bun test lib/__tests__/mcp-oauth.test.ts
+```
+
+Expected before implementation:
+
+```text
+FAIL: expected usePKCE to be true
+```
+
+The exact Bun diff can vary, but the failure must show that static client secret auth is still building the request with `usePKCE: false`.
+
+- [ ] **Step 4: Commit the failing test**
+
+```bash
+git add lib/__tests__/mcp-oauth.test.ts
+git commit -m "test: require pkce for static mcp oauth"
+```
+
+---
+
+### Task 2: Enable PKCE For All MCP OAuth Authorization Requests
+
+**Files:**
+- Modify: `lib/mcp-oauth.ts`
+- Test: `lib/__tests__/mcp-oauth.test.ts`
+
+- [ ] **Step 1: Change the AuthRequest PKCE option**
+
+In `lib/mcp-oauth.ts`, find the `new AuthSession.AuthRequest` call inside `performMcpOAuthFlow` and change `usePKCE` to `true`:
+
+```ts
+  const request = new AuthSession.AuthRequest({
+    clientId,
+    responseType: AuthSession.ResponseType.Code,
+    redirectUri,
+    scopes: [],
+    usePKCE: true,
+    extraParams: { resource: resourceMetadata.resource },
+  });
+```
+
+This keeps Expo AuthSession responsible for generating `code_verifier`, deriving the S256 `code_challenge`, and adding `code_challenge_method=S256` to the authorization URL.
+
+- [ ] **Step 2: Keep token exchange behavior unchanged**
+
+Leave `exchangeAndStore` in `lib/mcp-oauth.ts` with both existing branches intact:
+
+```ts
+  if (clientSecret) {
+    exchangeConfig.clientSecret = clientSecret;
+  }
+  if (codeVerifier) {
+    exchangeConfig.extraParams = { code_verifier: codeVerifier };
+  }
+```
+
+This is the required combination for static client ID plus secret plus PKCE: the static secret authenticates the client at the token endpoint, and the code verifier proves continuity with the authorization request.
+
+- [ ] **Step 3: Run the focused OAuth tests**
+
+Run:
+
+```bash
+bun test lib/__tests__/mcp-oauth.test.ts
+```
+
+Expected:
+
+```text
+3 pass
+0 fail
+```
+
+- [ ] **Step 4: Commit the implementation**
+
+```bash
+git add lib/mcp-oauth.ts lib/__tests__/mcp-oauth.test.ts
+git commit -m "fix: enable pkce for static mcp oauth"
+```
+
+---
+
+### Task 3: Verify Connector Form Tests Still Pass
+
+**Files:**
+- Test: `components/settings/__tests__/mcpConnectorAuthConfig.test.ts`
+- Test: `lib/__tests__/mcp-oauth.test.ts`
+
+- [ ] **Step 1: Run MCP connector config tests**
+
+Run:
+
+```bash
+bun test components/settings/__tests__/mcpConnectorAuthConfig.test.ts
+```
+
+Expected:
+
+```text
+7 pass
+0 fail
+```
+
+- [ ] **Step 2: Run MCP OAuth tests again**
+
+Run:
+
+```bash
+bun test lib/__tests__/mcp-oauth.test.ts
+```
+
+Expected:
+
+```text
+3 pass
+0 fail
+```
+
+- [ ] **Step 3: Run TypeScript verification**
+
+Run:
+
+```bash
+./node_modules/.bin/tsc --noEmit --pretty false
+```
+
+Expected: command exits with status `0` and prints no TypeScript errors.
+
+- [ ] **Step 4: Confirm no verification artifacts changed**
+
+Run:
+
+```bash
+git diff -- lib/mcp-oauth.ts lib/__tests__/mcp-oauth.test.ts components/settings/__tests__/mcpConnectorAuthConfig.test.ts
+```
+
+Expected: the diff contains only the intentional changes from Task 1 and Task 2. No snapshots, generated files, lockfiles, or formatting-only changes should appear.
+
+---
+
+## Manual QA
+
+- [ ] Add or edit an MCP connector with static OAuth selected.
+- [ ] Enter a static client ID and static client secret.
+- [ ] Start sign-in.
+- [ ] Confirm the authorization URL is accepted by the server and no longer returns `code_challenge required`.
+- [ ] Complete the OAuth callback.
+- [ ] Confirm the connector is saved and subsequent MCP probing uses the stored bearer token.
+- [ ] Trigger a refresh-token path after the access token expires, if practical, and confirm refresh still succeeds with the stored static client secret.
+
+---
+
+## Self-Review
+
+- Spec coverage: The plan covers PKCE generation, `code_challenge` transmission through Expo AuthSession, `code_verifier` token exchange, static client secret retention, manual callback completion, and refresh behavior.
+- Placeholder scan: No `TBD`, `TODO`, "add appropriate", or unspecified test steps remain.
+- Type consistency: The plan uses existing names from `lib/mcp-oauth.ts`: `performMcpOAuthFlow`, `completeMcpOAuthFromCallbackUrl`, `McpOAuthPendingState`, `exchangeAndStore`, `StaticOAuthCredentials`, and `clientSecret`.

--- a/lib/__tests__/mcp-oauth.test.ts
+++ b/lib/__tests__/mcp-oauth.test.ts
@@ -146,18 +146,15 @@ beforeEach(() => {
 });
 
 describe("performMcpOAuthFlow", () => {
-  test("uses static credentials without probing resource metadata and disables PKCE for confidential clients", async () => {
+  test("uses PKCE for static client secrets and still sends the secret during token exchange", async () => {
     const result = await (oauthModule.performMcpOAuthFlow as any)(
       "extension-1",
-      "",
+      "https://resource.example.com/.well-known/oauth-protected-resource",
       "Static Connector",
       undefined,
       {
         clientId: "static-client-id",
         clientSecret: "static-client-secret",
-        authorizationEndpoint: "https://provider.example.com/authorize",
-        tokenEndpoint: "https://provider.example.com/token",
-        scopes: ["openid", "profile"],
       },
     );
 
@@ -168,13 +165,16 @@ describe("performMcpOAuthFlow", () => {
     });
     expect(authState.lastAuthRequestConfig).toMatchObject({
       clientId: "static-client-id",
-      scopes: ["openid", "profile"],
-      usePKCE: false,
+      scopes: [],
+      usePKCE: true,
+      extraParams: { resource: "https://resource.example.com" },
     });
     expect(authState.exchangeCalls[0]).toMatchObject({
+      code: "auth-code",
       clientId: "static-client-id",
       clientSecret: "static-client-secret",
-      tokenEndpoint: "https://provider.example.com/token",
+      tokenEndpoint: "https://auth.example.com/token",
+      extraParams: { code_verifier: "generated-code-verifier" },
     });
     expect(secureState.savedClientIds).toContainEqual({
       id: "extension-1",
@@ -197,7 +197,7 @@ describe("performMcpOAuthFlow", () => {
       "vibemachine://mcp-oauth-callback?code=manual-code",
       {
         extensionId: "extension-2",
-        codeVerifier: "",
+        codeVerifier: "manual-code-verifier",
         redirectUri: "vibemachine://mcp-oauth-callback",
         clientId: "static-client-id",
         tokenEndpoint: "https://provider.example.com/token",
@@ -211,6 +211,7 @@ describe("performMcpOAuthFlow", () => {
       code: "manual-code",
       clientId: "static-client-id",
       clientSecret: "stored-static-secret",
+      extraParams: { code_verifier: "manual-code-verifier" },
     });
   });
 });

--- a/lib/__tests__/mcp-oauth.test.ts
+++ b/lib/__tests__/mcp-oauth.test.ts
@@ -1,0 +1,235 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+type PromptResult =
+  | { type: "success"; params: { code?: string } }
+  | { type: "dismiss" }
+  | { type: "error"; error?: string; error_description?: string; params?: Record<string, unknown> };
+
+const secureState = {
+  clientId: null as string | null,
+  clientSecret: null as string | null,
+  refreshToken: null as string | null,
+  tokenEndpoint: null as string | null,
+  savedBearerTokens: [] as string[],
+  savedClientIds: [] as { id: string; clientId: string }[],
+  savedClientSecrets: [] as { id: string; clientSecret: string }[],
+  savedRefreshTokens: [] as string[],
+  savedTokenEndpoints: [] as { id: string; tokenEndpoint: string }[],
+  savedAuthModes: [] as { id: string; mode: string }[],
+};
+
+const authState = {
+  promptResult: { type: "success", params: { code: "auth-code" } } as PromptResult,
+  exchangeResponse: {
+    accessToken: "access-token",
+    refreshToken: "refresh-token",
+  },
+  refreshResponse: {
+    accessToken: "refreshed-token",
+    refreshToken: "rotated-refresh-token",
+  },
+  lastAuthRequestConfig: null as Record<string, unknown> | null,
+  exchangeCalls: [] as Record<string, unknown>[],
+  refreshCalls: [] as Record<string, unknown>[],
+};
+
+const extensionState = {
+  resourceMetadata: {
+    authorizationServers: ["https://auth.example.com"],
+    resource: "https://resource.example.com",
+  },
+  oauthMetadata: {
+    authorizationEndpoint: "https://auth.example.com/authorize",
+    tokenEndpoint: "https://auth.example.com/token",
+    registrationEndpoint: "https://auth.example.com/register",
+  },
+  registeredClientId: "registered-client-id",
+};
+
+mock.module("../secure-storage", () => ({
+  deleteMcpClientSecret: async () => {},
+  getMcpAuthMode: async () => null,
+  getMcpClientId: async () => secureState.clientId,
+  getMcpClientSecret: async () => secureState.clientSecret,
+  getMcpRefreshToken: async () => secureState.refreshToken,
+  getMcpTokenEndpoint: async () => secureState.tokenEndpoint,
+  saveMcpAuthMode: async (id: string, mode: string) => {
+    secureState.savedAuthModes.push({ id, mode });
+  },
+  saveMcpBearerToken: async (_id: string, token: string) => {
+    secureState.savedBearerTokens.push(token);
+  },
+  saveMcpClientId: async (id: string, clientId: string) => {
+    secureState.savedClientIds.push({ id, clientId });
+  },
+  saveMcpClientSecret: async (id: string, clientSecret: string) => {
+    secureState.savedClientSecrets.push({ id, clientSecret });
+  },
+  saveMcpRefreshToken: async (_id: string, refreshToken: string) => {
+    secureState.savedRefreshTokens.push(refreshToken);
+  },
+  saveMcpTokenEndpoint: async (id: string, tokenEndpoint: string) => {
+    secureState.savedTokenEndpoints.push({ id, tokenEndpoint });
+  },
+}));
+
+mock.module("../logger", () => ({
+  log: {
+    info: () => {},
+    warn: () => {},
+    error: () => {},
+  },
+}));
+
+mock.module("../../modules/vm-webrtc/src/mcp_client/extensions", () => ({
+  fetchOAuthServerMetadata: async () => extensionState.oauthMetadata,
+  fetchResourceMetadata: async () => extensionState.resourceMetadata,
+  registerOAuthClient: async () => ({ clientId: extensionState.registeredClientId }),
+}));
+
+mock.module("expo-auth-session", () => ({
+  ResponseType: {
+    Code: "code",
+  },
+  makeRedirectUri: () => "vibemachine://mcp-oauth-callback",
+  AuthRequest: class AuthRequest {
+    codeVerifier = "generated-code-verifier";
+
+    constructor(config: Record<string, unknown>) {
+      authState.lastAuthRequestConfig = config;
+    }
+
+    async makeAuthUrlAsync() {
+      return "https://auth.example.com/authorize";
+    }
+
+    async promptAsync() {
+      return authState.promptResult;
+    }
+  },
+  exchangeCodeAsync: async (config: Record<string, unknown>, discovery: Record<string, unknown>) => {
+    authState.exchangeCalls.push({ ...config, ...discovery });
+    return authState.exchangeResponse;
+  },
+  refreshAsync: async (config: Record<string, unknown>, discovery: Record<string, unknown>) => {
+    authState.refreshCalls.push({ ...config, ...discovery });
+    return authState.refreshResponse;
+  },
+}));
+
+const oauthModule = await import("../mcp-oauth");
+
+beforeEach(() => {
+  secureState.clientId = null;
+  secureState.clientSecret = null;
+  secureState.refreshToken = null;
+  secureState.tokenEndpoint = null;
+  secureState.savedBearerTokens = [];
+  secureState.savedClientIds = [];
+  secureState.savedClientSecrets = [];
+  secureState.savedRefreshTokens = [];
+  secureState.savedTokenEndpoints = [];
+  secureState.savedAuthModes = [];
+
+  authState.promptResult = { type: "success", params: { code: "auth-code" } };
+  authState.exchangeResponse = {
+    accessToken: "access-token",
+    refreshToken: "refresh-token",
+  };
+  authState.refreshResponse = {
+    accessToken: "refreshed-token",
+    refreshToken: "rotated-refresh-token",
+  };
+  authState.lastAuthRequestConfig = null;
+  authState.exchangeCalls = [];
+  authState.refreshCalls = [];
+});
+
+describe("performMcpOAuthFlow", () => {
+  test("uses static credentials without probing resource metadata and disables PKCE for confidential clients", async () => {
+    const result = await (oauthModule.performMcpOAuthFlow as any)(
+      "extension-1",
+      "",
+      "Static Connector",
+      undefined,
+      {
+        clientId: "static-client-id",
+        clientSecret: "static-client-secret",
+        authorizationEndpoint: "https://provider.example.com/authorize",
+        tokenEndpoint: "https://provider.example.com/token",
+        scopes: ["openid", "profile"],
+      },
+    );
+
+    expect(result).toEqual({
+      type: "success",
+      accessToken: "access-token",
+      refreshToken: "refresh-token",
+    });
+    expect(authState.lastAuthRequestConfig).toMatchObject({
+      clientId: "static-client-id",
+      scopes: ["openid", "profile"],
+      usePKCE: false,
+    });
+    expect(authState.exchangeCalls[0]).toMatchObject({
+      clientId: "static-client-id",
+      clientSecret: "static-client-secret",
+      tokenEndpoint: "https://provider.example.com/token",
+    });
+    expect(secureState.savedClientIds).toContainEqual({
+      id: "extension-1",
+      clientId: "static-client-id",
+    });
+    expect(secureState.savedClientSecrets).toContainEqual({
+      id: "extension-1",
+      clientSecret: "static-client-secret",
+    });
+    expect(secureState.savedAuthModes).toContainEqual({
+      id: "extension-1",
+      mode: "static",
+    });
+  });
+
+  test("restores static client secrets for manual callback completion", async () => {
+    secureState.clientSecret = "stored-static-secret";
+
+    await oauthModule.completeMcpOAuthFromCallbackUrl(
+      "vibemachine://mcp-oauth-callback?code=manual-code",
+      {
+        extensionId: "extension-2",
+        codeVerifier: "",
+        redirectUri: "vibemachine://mcp-oauth-callback",
+        clientId: "static-client-id",
+        tokenEndpoint: "https://provider.example.com/token",
+        extensionName: "Static Connector",
+        extensionServerUrl: "",
+        extensionNormalizedName: "",
+      },
+    );
+
+    expect(authState.exchangeCalls[0]).toMatchObject({
+      code: "manual-code",
+      clientId: "static-client-id",
+      clientSecret: "stored-static-secret",
+    });
+  });
+});
+
+describe("refreshMcpAccessToken", () => {
+  test("includes stored client secrets for confidential static clients during refresh", async () => {
+    secureState.clientId = "static-client-id";
+    secureState.clientSecret = "stored-static-secret";
+    secureState.refreshToken = "stored-refresh-token";
+    secureState.tokenEndpoint = "https://provider.example.com/token";
+
+    const token = await oauthModule.refreshMcpAccessToken("extension-3", "Static Connector");
+
+    expect(token).toBe("refreshed-token");
+    expect(authState.refreshCalls[0]).toMatchObject({
+      clientId: "static-client-id",
+      clientSecret: "stored-static-secret",
+      refreshToken: "stored-refresh-token",
+      tokenEndpoint: "https://provider.example.com/token",
+    });
+  });
+});

--- a/lib/mcp-oauth.ts
+++ b/lib/mcp-oauth.ts
@@ -35,12 +35,11 @@ export type McpOAuthFlowResult =
   | { type: "success"; accessToken: string; refreshToken?: string }
   | { type: "needs_manual_callback"; pendingState: McpOAuthPendingState };
 
+// Static client credentials — only the client ID and optional secret are needed.
+// OAuth endpoints are auto-discovered from the MCP server, just like DCR mode.
 export interface StaticOAuthCredentials {
   clientId: string;
   clientSecret?: string;
-  authorizationEndpoint: string;
-  tokenEndpoint: string;
-  scopes?: string[];
 }
 
 export async function performMcpOAuthFlow(
@@ -50,21 +49,14 @@ export async function performMcpOAuthFlow(
   extensionInfo?: { serverUrl: string; normalizedName: string },
   staticCredentials?: StaticOAuthCredentials,
 ): Promise<McpOAuthFlowResult> {
-  if (staticCredentials) {
-    log.info(
-      "[mcp_oauth] Starting OAuth flow with static credentials",
-      {},
-      { extension_id: extensionId, connector_name: connectorName },
-    );
-    return performStaticOAuthFlow(extensionId, staticCredentials, connectorName);
-  }
-
+  const mode = staticCredentials ? "static" : "dcr";
   log.info(
-    "[mcp_oauth] Starting OAuth flow with DCR",
+    "[mcp_oauth] Starting OAuth flow",
     {},
-    { extension_id: extensionId, connector_name: connectorName },
+    { extension_id: extensionId, connector_name: connectorName, mode },
   );
 
+  // Both DCR and static share OAuth endpoint discovery from the MCP server.
   const resourceMetadata = await fetchResourceMetadata(resourceMetadataUrl, connectorName);
   const authServerUrl = resourceMetadata.authorizationServers[0];
   const oauthMeta = await fetchOAuthServerMetadata(authServerUrl, connectorName);
@@ -74,23 +66,44 @@ export async function performMcpOAuthFlow(
     path: "mcp-oauth-callback",
   });
 
-  let clientId = await getMcpClientId(extensionId);
-  if (!clientId) {
-    if (!oauthMeta.registrationEndpoint) {
-      throw new Error(
-        "Server requires OAuth but has no registration_endpoint and no cached client_id",
-      );
-    }
-    const reg = await registerOAuthClient(
-      oauthMeta.registrationEndpoint,
-      redirectUri,
-      connectorName,
-    );
-    clientId = reg.clientId;
+  let clientId: string;
+  let clientSecret: string | undefined;
+
+  if (staticCredentials) {
+    // Static mode: use provided credentials, skip dynamic client registration.
+    clientId = staticCredentials.clientId;
+    clientSecret = staticCredentials.clientSecret;
     await saveMcpClientId(extensionId, clientId);
+    if (clientSecret) {
+      await saveMcpClientSecret(extensionId, clientSecret);
+    } else {
+      await deleteMcpClientSecret(extensionId);
+    }
+    await saveMcpAuthMode(extensionId, "static");
+  } else {
+    // DCR mode: register a new public client or reuse a cached one.
+    const cachedId = await getMcpClientId(extensionId);
+    if (cachedId) {
+      clientId = cachedId;
+    } else {
+      if (!oauthMeta.registrationEndpoint) {
+        throw new Error(
+          "Server requires OAuth but has no registration_endpoint and no cached client_id",
+        );
+      }
+      const reg = await registerOAuthClient(
+        oauthMeta.registrationEndpoint,
+        redirectUri,
+        connectorName,
+      );
+      clientId = reg.clientId;
+      await saveMcpClientId(extensionId, clientId);
+    }
+    await deleteMcpClientSecret(extensionId);
+    await saveMcpAuthMode(extensionId, "dcr");
   }
-  await deleteMcpClientSecret(extensionId);
-  await saveMcpAuthMode(extensionId, "dcr");
+
+  await saveMcpTokenEndpoint(extensionId, oauthMeta.tokenEndpoint);
 
   const discovery = {
     authorizationEndpoint: oauthMeta.authorizationEndpoint,
@@ -102,7 +115,7 @@ export async function performMcpOAuthFlow(
     responseType: AuthSession.ResponseType.Code,
     redirectUri,
     scopes: [],
-    usePKCE: true,
+    usePKCE: !clientSecret,
     extraParams: { resource: resourceMetadata.resource },
   });
 
@@ -120,9 +133,9 @@ export async function performMcpOAuthFlow(
   };
 
   log.info(
-    "[mcp_oauth] Step 5: opening browser for authorization",
+    "[mcp_oauth] Opening browser for authorization",
     {},
-    { connector_name: connectorName },
+    { connector_name: connectorName, mode },
   );
 
   const result = await request.promptAsync(discovery);
@@ -139,7 +152,7 @@ export async function performMcpOAuthFlow(
 
   if (result.type === "success" && result.params.code) {
     log.info(
-      "[mcp_oauth] Step 6: exchanging code for token",
+      "[mcp_oauth] Exchanging code for token",
       {},
       { connector_name: connectorName },
     );
@@ -151,7 +164,7 @@ export async function performMcpOAuthFlow(
       oauthMeta.tokenEndpoint,
       extensionId,
       connectorName,
-      undefined,
+      clientSecret,
     );
     return { type: "success", ...tokens };
   }
@@ -166,107 +179,8 @@ export async function performMcpOAuthFlow(
     throw new Error(`OAuth error: ${detail}`);
   }
 
-  // Browser was dismissed or redirect wasn't intercepted — surface manual paste UI
   log.info(
     "[mcp_oauth] Browser closed without redirect, returning manual callback state",
-    {},
-    { connector_name: connectorName, result_type: result.type },
-  );
-  return { type: "needs_manual_callback", pendingState };
-}
-
-async function performStaticOAuthFlow(
-  extensionId: string,
-  credentials: StaticOAuthCredentials,
-  connectorName?: string,
-): Promise<McpOAuthFlowResult> {
-  const redirectUri = AuthSession.makeRedirectUri({
-    scheme: "vibemachine",
-    path: "mcp-oauth-callback",
-  });
-
-  await saveMcpClientId(extensionId, credentials.clientId);
-  if (credentials.clientSecret) {
-    await saveMcpClientSecret(extensionId, credentials.clientSecret);
-  } else {
-    await deleteMcpClientSecret(extensionId);
-  }
-  await saveMcpTokenEndpoint(extensionId, credentials.tokenEndpoint);
-  await saveMcpAuthMode(extensionId, "static");
-
-  const discovery = {
-    authorizationEndpoint: credentials.authorizationEndpoint,
-    tokenEndpoint: credentials.tokenEndpoint,
-  };
-
-  const request = new AuthSession.AuthRequest({
-    clientId: credentials.clientId,
-    responseType: AuthSession.ResponseType.Code,
-    redirectUri,
-    scopes: credentials.scopes ?? [],
-    usePKCE: !credentials.clientSecret,
-  });
-
-  await request.makeAuthUrlAsync(discovery);
-
-  const pendingState: McpOAuthPendingState = {
-    extensionId,
-    codeVerifier: request.codeVerifier ?? "",
-    redirectUri,
-    clientId: credentials.clientId,
-    tokenEndpoint: credentials.tokenEndpoint,
-    extensionName: connectorName ?? "",
-    extensionServerUrl: "",
-    extensionNormalizedName: "",
-  };
-
-  log.info(
-    "[mcp_oauth] Opening browser for static OAuth authorization",
-    {},
-    { connector_name: connectorName },
-  );
-
-  const result = await request.promptAsync(discovery);
-
-  log.info(
-    "[mcp_oauth] Static OAuth promptAsync returned",
-    {},
-    {
-      result_type: result.type,
-      error: (result as any).error ?? undefined,
-      connector_name: connectorName,
-    },
-  );
-
-  if (result.type === "success" && result.params.code) {
-    const tokens = await exchangeAndStore(
-      result.params.code,
-      credentials.clientId,
-      redirectUri,
-      request.codeVerifier ?? "",
-      credentials.tokenEndpoint,
-      extensionId,
-      connectorName,
-      credentials.clientSecret,
-    );
-    return { type: "success", ...tokens };
-  }
-
-  if (result.type === "error") {
-    const detail =
-      (result as any).error_description ??
-      (result as any).error ??
-      JSON.stringify((result as any).params ?? result);
-    log.error(
-      "[mcp_oauth] Static OAuth error",
-      {},
-      { connector_name: connectorName, result_type: result.type, error: detail },
-    );
-    throw new Error(`OAuth error: ${detail}`);
-  }
-
-  log.info(
-    "[mcp_oauth] Browser closed, returning manual callback state",
     {},
     { connector_name: connectorName, result_type: result.type },
   );

--- a/lib/mcp-oauth.ts
+++ b/lib/mcp-oauth.ts
@@ -115,7 +115,7 @@ export async function performMcpOAuthFlow(
     responseType: AuthSession.ResponseType.Code,
     redirectUri,
     scopes: [],
-    usePKCE: !clientSecret,
+    usePKCE: true,
     extraParams: { resource: resourceMetadata.resource },
   });
 

--- a/lib/mcp-oauth.ts
+++ b/lib/mcp-oauth.ts
@@ -7,11 +7,15 @@ import {
 } from "../modules/vm-webrtc/src/mcp_client/extensions";
 import { log } from "./logger";
 import {
+  deleteMcpClientSecret,
+  getMcpClientSecret,
   getMcpClientId,
   getMcpRefreshToken,
   getMcpTokenEndpoint,
+  saveMcpAuthMode,
   saveMcpBearerToken,
   saveMcpClientId,
+  saveMcpClientSecret,
   saveMcpRefreshToken,
   saveMcpTokenEndpoint,
 } from "./secure-storage";
@@ -31,14 +35,32 @@ export type McpOAuthFlowResult =
   | { type: "success"; accessToken: string; refreshToken?: string }
   | { type: "needs_manual_callback"; pendingState: McpOAuthPendingState };
 
+export interface StaticOAuthCredentials {
+  clientId: string;
+  clientSecret?: string;
+  authorizationEndpoint: string;
+  tokenEndpoint: string;
+  scopes?: string[];
+}
+
 export async function performMcpOAuthFlow(
   extensionId: string,
   resourceMetadataUrl: string,
   connectorName?: string,
   extensionInfo?: { serverUrl: string; normalizedName: string },
+  staticCredentials?: StaticOAuthCredentials,
 ): Promise<McpOAuthFlowResult> {
+  if (staticCredentials) {
+    log.info(
+      "[mcp_oauth] Starting OAuth flow with static credentials",
+      {},
+      { extension_id: extensionId, connector_name: connectorName },
+    );
+    return performStaticOAuthFlow(extensionId, staticCredentials, connectorName);
+  }
+
   log.info(
-    "[mcp_oauth] Starting OAuth flow",
+    "[mcp_oauth] Starting OAuth flow with DCR",
     {},
     { extension_id: extensionId, connector_name: connectorName },
   );
@@ -67,6 +89,8 @@ export async function performMcpOAuthFlow(
     clientId = reg.clientId;
     await saveMcpClientId(extensionId, clientId);
   }
+  await deleteMcpClientSecret(extensionId);
+  await saveMcpAuthMode(extensionId, "dcr");
 
   const discovery = {
     authorizationEndpoint: oauthMeta.authorizationEndpoint,
@@ -108,7 +132,6 @@ export async function performMcpOAuthFlow(
     {},
     {
       result_type: result.type,
-      params: result.type === "success" ? result.params : undefined,
       error: (result as any).error ?? undefined,
       connector_name: connectorName,
     },
@@ -128,6 +151,7 @@ export async function performMcpOAuthFlow(
       oauthMeta.tokenEndpoint,
       extensionId,
       connectorName,
+      undefined,
     );
     return { type: "success", ...tokens };
   }
@@ -145,6 +169,104 @@ export async function performMcpOAuthFlow(
   // Browser was dismissed or redirect wasn't intercepted — surface manual paste UI
   log.info(
     "[mcp_oauth] Browser closed without redirect, returning manual callback state",
+    {},
+    { connector_name: connectorName, result_type: result.type },
+  );
+  return { type: "needs_manual_callback", pendingState };
+}
+
+async function performStaticOAuthFlow(
+  extensionId: string,
+  credentials: StaticOAuthCredentials,
+  connectorName?: string,
+): Promise<McpOAuthFlowResult> {
+  const redirectUri = AuthSession.makeRedirectUri({
+    scheme: "vibemachine",
+    path: "mcp-oauth-callback",
+  });
+
+  await saveMcpClientId(extensionId, credentials.clientId);
+  if (credentials.clientSecret) {
+    await saveMcpClientSecret(extensionId, credentials.clientSecret);
+  } else {
+    await deleteMcpClientSecret(extensionId);
+  }
+  await saveMcpTokenEndpoint(extensionId, credentials.tokenEndpoint);
+  await saveMcpAuthMode(extensionId, "static");
+
+  const discovery = {
+    authorizationEndpoint: credentials.authorizationEndpoint,
+    tokenEndpoint: credentials.tokenEndpoint,
+  };
+
+  const request = new AuthSession.AuthRequest({
+    clientId: credentials.clientId,
+    responseType: AuthSession.ResponseType.Code,
+    redirectUri,
+    scopes: credentials.scopes ?? [],
+    usePKCE: !credentials.clientSecret,
+  });
+
+  await request.makeAuthUrlAsync(discovery);
+
+  const pendingState: McpOAuthPendingState = {
+    extensionId,
+    codeVerifier: request.codeVerifier ?? "",
+    redirectUri,
+    clientId: credentials.clientId,
+    tokenEndpoint: credentials.tokenEndpoint,
+    extensionName: connectorName ?? "",
+    extensionServerUrl: "",
+    extensionNormalizedName: "",
+  };
+
+  log.info(
+    "[mcp_oauth] Opening browser for static OAuth authorization",
+    {},
+    { connector_name: connectorName },
+  );
+
+  const result = await request.promptAsync(discovery);
+
+  log.info(
+    "[mcp_oauth] Static OAuth promptAsync returned",
+    {},
+    {
+      result_type: result.type,
+      error: (result as any).error ?? undefined,
+      connector_name: connectorName,
+    },
+  );
+
+  if (result.type === "success" && result.params.code) {
+    const tokens = await exchangeAndStore(
+      result.params.code,
+      credentials.clientId,
+      redirectUri,
+      request.codeVerifier ?? "",
+      credentials.tokenEndpoint,
+      extensionId,
+      connectorName,
+      credentials.clientSecret,
+    );
+    return { type: "success", ...tokens };
+  }
+
+  if (result.type === "error") {
+    const detail =
+      (result as any).error_description ??
+      (result as any).error ??
+      JSON.stringify((result as any).params ?? result);
+    log.error(
+      "[mcp_oauth] Static OAuth error",
+      {},
+      { connector_name: connectorName, result_type: result.type, error: detail },
+    );
+    throw new Error(`OAuth error: ${detail}`);
+  }
+
+  log.info(
+    "[mcp_oauth] Browser closed, returning manual callback state",
     {},
     { connector_name: connectorName, result_type: result.type },
   );
@@ -171,6 +293,8 @@ export async function completeMcpOAuthFromCallbackUrl(
     { extension_id: pendingState.extensionId },
   );
 
+  const clientSecret = await getMcpClientSecret(pendingState.extensionId);
+
   return exchangeAndStore(
     code,
     pendingState.clientId,
@@ -178,6 +302,8 @@ export async function completeMcpOAuthFromCallbackUrl(
     pendingState.codeVerifier,
     pendingState.tokenEndpoint,
     pendingState.extensionId,
+    undefined,
+    clientSecret ?? undefined,
   );
 }
 
@@ -189,14 +315,21 @@ async function exchangeAndStore(
   tokenEndpoint: string,
   extensionId: string,
   connectorName?: string,
+  clientSecret?: string,
 ): Promise<{ accessToken: string; refreshToken?: string }> {
+  const exchangeConfig: any = {
+    code,
+    clientId,
+    redirectUri,
+  };
+  if (clientSecret) {
+    exchangeConfig.clientSecret = clientSecret;
+  }
+  if (codeVerifier) {
+    exchangeConfig.extraParams = { code_verifier: codeVerifier };
+  }
   const tokenResponse = await AuthSession.exchangeCodeAsync(
-    {
-      code,
-      clientId,
-      redirectUri,
-      extraParams: { code_verifier: codeVerifier },
-    },
+    exchangeConfig,
     { tokenEndpoint },
   );
 
@@ -209,7 +342,11 @@ async function exchangeAndStore(
   log.info(
     "[mcp_oauth] OAuth flow complete",
     {},
-    { connector_name: connectorName, has_refresh_token: !!tokenResponse.refreshToken },
+    {
+      connector_name: connectorName,
+      has_refresh_token: !!tokenResponse.refreshToken,
+      used_client_secret: !!clientSecret,
+    },
   );
 
   return {
@@ -222,25 +359,35 @@ export async function refreshMcpAccessToken(
   extensionId: string,
   connectorName?: string,
 ): Promise<string | null> {
-  const [refreshToken, tokenEndpoint] = await Promise.all([
+  const [refreshToken, tokenEndpoint, clientId, clientSecret] = await Promise.all([
     getMcpRefreshToken(extensionId),
     getMcpTokenEndpoint(extensionId),
+    getMcpClientId(extensionId),
+    getMcpClientSecret(extensionId),
   ]);
 
-  if (!refreshToken || !tokenEndpoint) return null;
-
-  const clientId = await getMcpClientId(extensionId);
-  if (!clientId) return null;
+  if (!refreshToken || !tokenEndpoint || !clientId) return null;
 
   log.info(
     "[mcp_oauth] Refreshing access token",
     {},
-    { extension_id: extensionId, connector_name: connectorName },
+    {
+      extension_id: extensionId,
+      connector_name: connectorName,
+      has_client_secret: !!clientSecret,
+    },
   );
 
   try {
+    const refreshConfig: any = {
+      clientId,
+      refreshToken,
+    };
+    if (clientSecret) {
+      refreshConfig.clientSecret = clientSecret;
+    }
     const tokenResponse = await AuthSession.refreshAsync(
-      { clientId, refreshToken },
+      refreshConfig,
       { tokenEndpoint },
     );
 

--- a/lib/secure-storage.ts
+++ b/lib/secure-storage.ts
@@ -778,6 +778,7 @@ export interface McpExtensionRecord {
   normalizedName: string;
   serverUrl: string;
   disabled?: boolean;
+  authMode?: "dcr" | "static" | "bearer";
 }
 
 // "My Cool Server!" → "my_cool_server"
@@ -814,8 +815,10 @@ export function uniqueNormalizedName(
 const MCP_EXTENSIONS_KEY = "VIBEMACHINE_MCP_EXTENSIONS";
 const MCP_TOKEN_PREFIX = "VIBEMACHINE_MCP_TOKEN_";
 const MCP_CLIENT_ID_PREFIX = "VIBEMACHINE_MCP_CLIENT_ID_";
+const MCP_CLIENT_SECRET_PREFIX = "VIBEMACHINE_MCP_CLIENT_SECRET_";
 const MCP_REFRESH_TOKEN_PREFIX = "VIBEMACHINE_MCP_REFRESH_TOKEN_";
 const MCP_TOKEN_ENDPOINT_PREFIX = "VIBEMACHINE_MCP_TOKEN_ENDPOINT_";
+const MCP_AUTH_MODE_PREFIX = "VIBEMACHINE_MCP_AUTH_MODE_";
 
 export async function getMcpExtensions(): Promise<McpExtensionRecord[]> {
   try {
@@ -888,6 +891,47 @@ export async function getMcpClientId(id: string): Promise<string | null> {
   }
 }
 
+export async function saveMcpClientSecret(id: string, secret: string): Promise<void> {
+  await setCachedValue(`${MCP_CLIENT_SECRET_PREFIX}${id}`, secret);
+}
+
+export async function getMcpClientSecret(id: string): Promise<string | null> {
+  try {
+    return await getCachedValue(`${MCP_CLIENT_SECRET_PREFIX}${id}`);
+  } catch {
+    return null;
+  }
+}
+
+export async function deleteMcpClientSecret(id: string): Promise<void> {
+  try {
+    await deleteCachedValue(`${MCP_CLIENT_SECRET_PREFIX}${id}`);
+  } catch {
+    // secret may not exist
+  }
+}
+
+export async function saveMcpAuthMode(
+  id: string,
+  mode: "dcr" | "static" | "bearer",
+): Promise<void> {
+  await setCachedValue(`${MCP_AUTH_MODE_PREFIX}${id}`, mode);
+}
+
+export async function getMcpAuthMode(
+  id: string,
+): Promise<"dcr" | "static" | "bearer" | null> {
+  try {
+    const mode = await getCachedValue(`${MCP_AUTH_MODE_PREFIX}${id}`);
+    if (mode === "dcr" || mode === "static" || mode === "bearer") {
+      return mode;
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
+
 export async function saveMcpRefreshToken(id: string, token: string): Promise<void> {
   await setCachedValue(`${MCP_REFRESH_TOKEN_PREFIX}${id}`, token);
 }
@@ -917,6 +961,8 @@ export async function clearMcpAuthCredentials(id: string): Promise<void> {
     deleteCachedValue(`${MCP_CLIENT_ID_PREFIX}${id}`),
     deleteCachedValue(`${MCP_REFRESH_TOKEN_PREFIX}${id}`),
     deleteCachedValue(`${MCP_TOKEN_ENDPOINT_PREFIX}${id}`),
+    deleteCachedValue(`${MCP_CLIENT_SECRET_PREFIX}${id}`),
+    deleteCachedValue(`${MCP_AUTH_MODE_PREFIX}${id}`),
   ]);
 }
 
@@ -1006,8 +1052,10 @@ export async function clearAllStoredSecrets(): Promise<void> {
     secureStoreKeys.push(
       `${MCP_TOKEN_PREFIX}${ext.id}`,
       `${MCP_CLIENT_ID_PREFIX}${ext.id}`,
+      `${MCP_CLIENT_SECRET_PREFIX}${ext.id}`,
       `${MCP_REFRESH_TOKEN_PREFIX}${ext.id}`,
       `${MCP_TOKEN_ENDPOINT_PREFIX}${ext.id}`,
+      `${MCP_AUTH_MODE_PREFIX}${ext.id}`,
     );
   }
 


### PR DESCRIPTION
Summary:
	•	Adds OAuth2 auth for MCP connectors using a static pre-registered client ID/secret
	•	Implements PKCE flow
	•	New McpConnectorAuthConfig module separates auth config from the connector UI
	•	Extends lib/mcp-oauth.ts with full token lifecycle (acquire, refresh, secure storage)
	•	Adds lib/secure-storage.ts for credential persistence
	•	Unit tests for OAuth flow and auth config