### PR TITLE
Refresh oauth tokens

### DIFF
--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -1,0 +1,6 @@
+[mcp_servers.arty-build-eas]
+command = "bun"
+args = [
+    "run",
+    "mcp-server/index.ts",
+]

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,6 +5,7 @@
 - When logging, default to logging full values and not substrings.  Later we can prune as needed, but right now there is an observability crisis.
 - Certain swift objects like AVAudioPlayerDelegate should have serialized access when called from multiple threads. Consider protecting shared state with a serial DispatchQueue or ensuring all method calls dispatch to the main queue.
 - Prefer convention over configuration, this keeps things light, de-coupled, and avoids needless boilerplate.
+- In logfire, the project is using the old name: vibemachine
 
 Always use expo libraries, for example:
 

--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2025 Vibemachine LLC
+   Copyright 2025 Traun Leyden
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/app.json
+++ b/app.json
@@ -3,7 +3,7 @@
     "owner": "tleyden",
     "name": "vibemachine",
     "slug": "vibemachine",
-    "version": "0.3.3",
+    "version": "0.3.4",
     "orientation": "portrait",
     "icon": "./assets/images/icon.png",
     "scheme": "vibemachine",
@@ -78,7 +78,7 @@
         "projectId": "f3a6322c-ba58-4e74-902e-89a4d9fccb52"
       }
     },
-    "runtimeVersion": "0.3.3",
+    "runtimeVersion": "0.3.4",
     "updates": {
       "url": "https://u.expo.dev/f3a6322c-ba58-4e74-902e-89a4d9fccb52"
     }

--- a/app.json
+++ b/app.json
@@ -3,7 +3,7 @@
     "owner": "tleyden",
     "name": "vibemachine",
     "slug": "vibemachine",
-    "version": "1.0.0",
+    "version": "0.3.3",
     "orientation": "portrait",
     "icon": "./assets/images/icon.png",
     "scheme": "vibemachine",
@@ -78,7 +78,7 @@
         "projectId": "f3a6322c-ba58-4e74-902e-89a4d9fccb52"
       }
     },
-    "runtimeVersion": "1.0.0",
+    "runtimeVersion": "0.3.3",
     "updates": {
       "url": "https://u.expo.dev/f3a6322c-ba58-4e74-902e-89a4d9fccb52"
     }

--- a/app/index.tsx
+++ b/app/index.tsx
@@ -765,6 +765,7 @@ export default function Index() {
         visible={mcpExtensionsVisible}
         onClose={() => setMcpExtensionsVisible(false)}
         onBeforeBrowserOpen={() => {
+          log.info("[index] onBeforeBrowserOpen: hiding McpExtensionsScreen before OAuth — will NOT auto-reopen on success");
           setMcpExtensionsVisible(false);
           setMenuVisible(false);
         }}

--- a/components/settings/McpConnectorConfig.tsx
+++ b/components/settings/McpConnectorConfig.tsx
@@ -301,6 +301,7 @@ export const McpConnectorConfig: React.FC<McpConnectorConfigProps> = ({
         });
 
         try {
+          log.info("[mcp_connector] Calling onBeforeBrowserOpen (static) — parent screen will be hidden", {}, { id });
           onBeforeBrowserOpen?.();
           const oauthResult = await performMcpOAuthFlow(
             id,
@@ -311,6 +312,7 @@ export const McpConnectorConfig: React.FC<McpConnectorConfigProps> = ({
           );
           log.info("[mcp_connector] Static OAuth flow returned", {}, { oauthResult_type: oauthResult.type });
           if (oauthResult.type === "success") {
+            log.info("[mcp_connector] Static OAuth success — no re-open of parent screen on success path", {}, { id });
             await persistExtension(id, sanitizedForm, undefined, {
               preserveExistingToken: true,
               authMode: "static",
@@ -358,6 +360,7 @@ export const McpConnectorConfig: React.FC<McpConnectorConfigProps> = ({
           },
         );
         try {
+          log.info("[mcp_connector] Calling onBeforeBrowserOpen (dcr) — parent screen will be hidden", {}, { id });
           onBeforeBrowserOpen?.();
           const oauthResult = await performMcpOAuthFlow(
             id,
@@ -370,6 +373,7 @@ export const McpConnectorConfig: React.FC<McpConnectorConfigProps> = ({
           );
           log.info("[mcp_connector] OAuth flow returned", {}, { oauthResult_type: oauthResult.type });
           if (oauthResult.type === "success") {
+            log.info("[mcp_connector] DCR OAuth success — no re-open of parent screen on success path", {}, { id });
             await persistExtension(id, sanitizedForm, undefined, {
               preserveExistingToken: true,
               authMode: "dcr",

--- a/components/settings/McpExtensionDetailScreen.tsx
+++ b/components/settings/McpExtensionDetailScreen.tsx
@@ -27,7 +27,8 @@ import {
   getMcpBearerToken,
   type McpExtensionRecord,
 } from "../../lib/secure-storage";
-import { refreshMcpAccessToken } from "../../lib/mcp-oauth";
+import { refreshMcpAccessTokenWithDetails } from "../../lib/mcp-oauth";
+import { log } from "../../lib/logger";
 import { CONNECTOR_SETTINGS_CHANGED_EVENT } from "../../modules/vm-webrtc/src/ToolkitManager";
 import { McpConnectorConfig } from "./McpConnectorConfig";
 
@@ -169,13 +170,32 @@ export const McpExtensionDetailScreen: React.FC<McpExtensionDetailScreenProps> =
 
     setRefreshingAccessToken(true);
     try {
-      const token = await refreshMcpAccessToken(currentExtension.id, currentExtension.name);
-      if (!token) {
-        Alert.alert(
-          "Refresh Failed",
-          "Could not refresh the access token. Check that this extension has a saved refresh token and client credentials, or re-authenticate.",
-          [{ text: "OK" }]
+      log.info(
+        "[mcp_detail] Manual access token refresh requested",
+        {},
+        {
+          extension_id: currentExtension.id,
+          extension_name: currentExtension.name,
+          server_url: currentExtension.serverUrl,
+        }
+      );
+
+      const result = await refreshMcpAccessTokenWithDetails(
+        currentExtension.id,
+        currentExtension.name
+      );
+      if (result.type === "failure") {
+        log.warn(
+          "[mcp_detail] Manual access token refresh failed",
+          {},
+          {
+            extension_id: currentExtension.id,
+            extension_name: currentExtension.name,
+            user_message: result.userMessage,
+            oauth_error_code: result.oauthErrorCode,
+          }
         );
+        Alert.alert("Refresh Failed", result.userMessage, [{ text: "OK" }]);
         return;
       }
 
@@ -183,9 +203,21 @@ export const McpExtensionDetailScreen: React.FC<McpExtensionDetailScreenProps> =
       fetchTools();
       Alert.alert("Access Token Refreshed", "A new access token was saved.", [{ text: "OK" }]);
     } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      log.error(
+        "[mcp_detail] Manual access token refresh threw unexpected error",
+        {},
+        {
+          extension_id: currentExtension.id,
+          extension_name: currentExtension.name,
+          error_name: err instanceof Error ? err.name : undefined,
+          error_message: message,
+          error_stack: err instanceof Error ? err.stack : undefined,
+        }
+      );
       Alert.alert(
         "Refresh Failed",
-        err instanceof Error ? err.message : String(err),
+        `Could not refresh the access token: ${message}`,
         [{ text: "OK" }]
       );
     } finally {

--- a/components/settings/McpExtensionDetailScreen.tsx
+++ b/components/settings/McpExtensionDetailScreen.tsx
@@ -27,6 +27,7 @@ import {
   getMcpBearerToken,
   type McpExtensionRecord,
 } from "../../lib/secure-storage";
+import { refreshMcpAccessToken } from "../../lib/mcp-oauth";
 import { CONNECTOR_SETTINGS_CHANGED_EVENT } from "../../modules/vm-webrtc/src/ToolkitManager";
 import { McpConnectorConfig } from "./McpConnectorConfig";
 
@@ -52,6 +53,7 @@ export const McpExtensionDetailScreen: React.FC<McpExtensionDetailScreenProps> =
   const [toolsError, setToolsError] = useState<string | null>(null);
   const [configureVisible, setConfigureVisible] = useState(false);
   const [urlCopied, setUrlCopied] = useState(false);
+  const [refreshingAccessToken, setRefreshingAccessToken] = useState(false);
 
   useEffect(() => {
     setCurrentExtension(extension);
@@ -159,6 +161,35 @@ export const McpExtensionDetailScreen: React.FC<McpExtensionDetailScreenProps> =
           { text: "Reset Auth", style: "destructive", onPress: doReset },
         ]
       );
+    }
+  };
+
+  const handleRefreshAccessToken = async () => {
+    if (refreshingAccessToken) return;
+
+    setRefreshingAccessToken(true);
+    try {
+      const token = await refreshMcpAccessToken(currentExtension.id, currentExtension.name);
+      if (!token) {
+        Alert.alert(
+          "Refresh Failed",
+          "Could not refresh the access token. Check that this extension has a saved refresh token and client credentials, or re-authenticate.",
+          [{ text: "OK" }]
+        );
+        return;
+      }
+
+      DeviceEventEmitter.emit(CONNECTOR_SETTINGS_CHANGED_EVENT);
+      fetchTools();
+      Alert.alert("Access Token Refreshed", "A new access token was saved.", [{ text: "OK" }]);
+    } catch (err) {
+      Alert.alert(
+        "Refresh Failed",
+        err instanceof Error ? err.message : String(err),
+        [{ text: "OK" }]
+      );
+    } finally {
+      setRefreshingAccessToken(false);
     }
   };
 
@@ -339,6 +370,21 @@ export const McpExtensionDetailScreen: React.FC<McpExtensionDetailScreenProps> =
             onPress={handleResetAccessToken}
           >
             <Text style={styles.resetAccessTokenButtonText}>Reset Access Token</Text>
+          </Pressable>
+          <Pressable
+            disabled={refreshingAccessToken}
+            style={({ pressed }) => [
+              styles.refreshAccessTokenButton,
+              pressed && styles.refreshAccessTokenButtonPressed,
+              refreshingAccessToken && styles.refreshAccessTokenButtonDisabled,
+            ]}
+            onPress={handleRefreshAccessToken}
+          >
+            {refreshingAccessToken ? (
+              <ActivityIndicator size="small" color="#FFFFFF" />
+            ) : (
+              <Text style={styles.refreshAccessTokenButtonText}>Refresh Access Token</Text>
+            )}
           </Pressable>
         </View>
       </SafeAreaView>
@@ -624,5 +670,22 @@ const styles = StyleSheet.create({
     fontSize: 16,
     fontWeight: "600",
     color: "#0A84FF",
+  },
+  refreshAccessTokenButton: {
+    paddingVertical: 14,
+    borderRadius: 12,
+    alignItems: "center",
+    backgroundColor: "#0A84FF",
+  },
+  refreshAccessTokenButtonPressed: {
+    backgroundColor: "#006EDB",
+  },
+  refreshAccessTokenButtonDisabled: {
+    opacity: 0.65,
+  },
+  refreshAccessTokenButtonText: {
+    fontSize: 16,
+    fontWeight: "600",
+    color: "#FFFFFF",
   },
 });

--- a/components/settings/McpExtensionDetailScreen.tsx
+++ b/components/settings/McpExtensionDetailScreen.tsx
@@ -162,6 +162,38 @@ export const McpExtensionDetailScreen: React.FC<McpExtensionDetailScreenProps> =
     }
   };
 
+  const handleResetAccessToken = () => {
+    const doReset = async () => {
+      await deleteMcpBearerToken(currentExtension.id);
+      DeviceEventEmitter.emit(CONNECTOR_SETTINGS_CHANGED_EVENT);
+    };
+
+    if (Platform.OS === "ios") {
+      ActionSheetIOS.showActionSheetWithOptions(
+        {
+          title: `Reset access token for "${currentExtension.name}"?`,
+          message:
+            "The access token will be dropped. The app will use the refresh token on the next MCP call.",
+          options: ["Cancel", "Reset Access Token"],
+          destructiveButtonIndex: 1,
+          cancelButtonIndex: 0,
+        },
+        (buttonIndex) => {
+          if (buttonIndex === 1) doReset();
+        }
+      );
+    } else {
+      Alert.alert(
+        "Reset Access Token",
+        `Drop the access token for "${currentExtension.name}"? The app will use the refresh token on the next MCP call.`,
+        [
+          { text: "Cancel", style: "cancel" },
+          { text: "Reset Access Token", style: "destructive", onPress: doReset },
+        ]
+      );
+    }
+  };
+
   return (
     <Modal
       animationType="slide"
@@ -270,23 +302,43 @@ export const McpExtensionDetailScreen: React.FC<McpExtensionDetailScreenProps> =
         </ScrollView>
 
         <View style={[styles.footer, { paddingBottom: insets.bottom + 16 }]}>
+          <View style={styles.footerPrimaryActions}>
+            <Pressable
+              style={({ pressed }) => [
+                styles.configureButton,
+                pressed && styles.configureButtonPressed,
+              ]}
+              onPress={() => setConfigureVisible(true)}
+            >
+              <Text style={styles.configureButtonText}>Configure</Text>
+            </Pressable>
+            <Pressable
+              style={({ pressed }) => [
+                styles.resetAuthButton,
+                pressed && styles.resetAuthButtonPressed,
+              ]}
+              onPress={handleResetAuth}
+            >
+              <Text style={styles.resetAuthButtonText}>Reset Auth</Text>
+            </Pressable>
+            <Pressable
+              style={({ pressed }) => [
+                styles.removeButton,
+                pressed && styles.removeButtonPressed,
+              ]}
+              onPress={handleRemove}
+            >
+              <Text style={styles.removeButtonText}>Remove</Text>
+            </Pressable>
+          </View>
           <Pressable
-            style={({ pressed }) => [styles.configureButton, pressed && styles.configureButtonPressed]}
-            onPress={() => setConfigureVisible(true)}
+            style={({ pressed }) => [
+              styles.resetAccessTokenButton,
+              pressed && styles.resetAccessTokenButtonPressed,
+            ]}
+            onPress={handleResetAccessToken}
           >
-            <Text style={styles.configureButtonText}>Configure</Text>
-          </Pressable>
-          <Pressable
-            style={({ pressed }) => [styles.resetAuthButton, pressed && styles.resetAuthButtonPressed]}
-            onPress={handleResetAuth}
-          >
-            <Text style={styles.resetAuthButtonText}>Reset Auth</Text>
-          </Pressable>
-          <Pressable
-            style={({ pressed }) => [styles.removeButton, pressed && styles.removeButtonPressed]}
-            onPress={handleRemove}
-          >
-            <Text style={styles.removeButtonText}>Remove</Text>
+            <Text style={styles.resetAccessTokenButtonText}>Reset Access Token</Text>
           </Pressable>
         </View>
       </SafeAreaView>
@@ -497,13 +549,16 @@ const styles = StyleSheet.create({
     lineHeight: 17,
   },
   footer: {
-    flexDirection: "row",
     gap: 12,
     paddingHorizontal: 20,
     paddingTop: 16,
     borderTopWidth: 1,
     borderTopColor: "#E5E5EA",
     backgroundColor: "#F5F5F7",
+  },
+  footerPrimaryActions: {
+    flexDirection: "row",
+    gap: 12,
   },
   configureButton: {
     flex: 1,
@@ -553,5 +608,21 @@ const styles = StyleSheet.create({
     fontSize: 16,
     fontWeight: "600",
     color: "#FF3B30",
+  },
+  resetAccessTokenButton: {
+    paddingVertical: 14,
+    borderRadius: 12,
+    alignItems: "center",
+    backgroundColor: "#FFFFFF",
+    borderWidth: 1,
+    borderColor: "#0A84FF",
+  },
+  resetAccessTokenButtonPressed: {
+    backgroundColor: "#F0F6FF",
+  },
+  resetAccessTokenButtonText: {
+    fontSize: 16,
+    fontWeight: "600",
+    color: "#0A84FF",
   },
 });

--- a/components/settings/McpExtensionsScreen.tsx
+++ b/components/settings/McpExtensionsScreen.tsx
@@ -16,6 +16,7 @@ import {
   type McpExtensionRecord,
 } from "../../lib/secure-storage";
 import { MCP_REAUTH_REQUIRED_EVENT } from "../../modules/vm-webrtc/src/ToolkitManager";
+import { log } from "../../lib/logger";
 import { McpConnectorConfig } from "./McpConnectorConfig";
 import { McpExtensionDetailScreen } from "./McpExtensionDetailScreen";
 
@@ -53,15 +54,28 @@ export const McpExtensionsScreen: React.FC<McpExtensionsScreenProps> = ({
     const sub = DeviceEventEmitter.addListener(
       MCP_REAUTH_REQUIRED_EVENT,
       ({ id, name }: { id: string; name: string }) => {
+        log.info("[McpExtensionsScreen] MCP_REAUTH_REQUIRED_EVENT received", {}, { id, name });
         const ext = extensionsRef.current.find((e) => e.id === id);
+        log.info(
+          "[McpExtensionsScreen] Showing reauth alert",
+          {},
+          { id, name, ext_found_in_ref: !!ext, ref_length: extensionsRef.current.length },
+        );
         Alert.alert(
           `"${name}" needs to sign in again`,
           "Your session has expired.",
           [
-            { text: "Later", style: "cancel" },
+            {
+              text: "Later",
+              style: "cancel",
+              onPress: () => log.info("[McpExtensionsScreen] Reauth alert dismissed (Later)", {}, { id, name }),
+            },
             {
               text: "Re-authenticate",
-              onPress: () => setReauthExtension(ext ?? { id, name, normalizedName: "", serverUrl: "" }),
+              onPress: () => {
+                log.info("[McpExtensionsScreen] Reauth alert accepted, opening re-auth flow", {}, { id, name });
+                setReauthExtension(ext ?? { id, name, normalizedName: "", serverUrl: "" });
+              },
             },
           ],
         );

--- a/docs/plan-reset-access-token-button.md
+++ b/docs/plan-reset-access-token-button.md
@@ -1,0 +1,103 @@
+# Plan: "Reset Access Token" button in MCP detail screen
+
+## Goal
+
+Add a "Reset Access Token" button next to "Reset Auth" in `McpExtensionDetailScreen`. It drops only the bearer token so the next MCP call uses the refresh token — without wiping credentials or forcing re-auth.
+
+---
+
+## File touched
+
+`components/settings/McpExtensionDetailScreen.tsx` only.  
+`deleteMcpBearerToken(id)` already exists in `lib/secure-storage.ts:874`.
+
+---
+
+## Step 1 — New handler `handleResetAccessToken`
+
+Insert after `handleResetAuth` (~line 163):
+
+```ts
+const handleResetAccessToken = () => {
+  const doReset = async () => {
+    await deleteMcpBearerToken(currentExtension.id);
+    DeviceEventEmitter.emit(CONNECTOR_SETTINGS_CHANGED_EVENT);
+  };
+
+  if (Platform.OS === "ios") {
+    ActionSheetIOS.showActionSheetWithOptions(
+      {
+        title: `Reset access token for "${currentExtension.name}"?`,
+        message: "The access token will be dropped. The app will use the refresh token on the next MCP call.",
+        options: ["Cancel", "Reset Access Token"],
+        destructiveButtonIndex: 1,
+        cancelButtonIndex: 0,
+      },
+      (buttonIndex) => {
+        if (buttonIndex === 1) doReset();
+      }
+    );
+  } else {
+    Alert.alert(
+      "Reset Access Token",
+      `Drop the access token for "${currentExtension.name}"? The app will use the refresh token on the next MCP call.`,
+      [
+        { text: "Cancel", style: "cancel" },
+        { text: "Reset Access Token", style: "destructive", onPress: doReset },
+      ]
+    );
+  }
+};
+```
+
+**Key differences from `handleResetAuth`:**
+- Only calls `deleteMcpBearerToken` — does **not** touch client ID, client secret, refresh token, token endpoint, or auth mode
+- Does **not** open the configure dialog afterward
+
+---
+
+## Step 2 — Footer layout
+
+Currently the footer is a single `flexDirection: "row"` with three `flex: 1` buttons:
+
+```
+[ Configure ]  [ Reset Auth ]  [ Remove ]
+```
+
+Adding a 4th long-label button inline would be cramped. Restructure into **two rows**:
+
+```
+[ Configure ]  [ Reset Auth ]  [ Remove ]
+[        Reset Access Token        ]
+```
+
+The outer `View` becomes a column container; the existing three buttons move into an inner `View` with `flexDirection: "row"`.
+
+---
+
+## Step 3 — New styles
+
+```ts
+resetAccessTokenButton: {
+  paddingVertical: 14,
+  borderRadius: 12,
+  alignItems: "center",
+  backgroundColor: "#FFFFFF",
+  borderWidth: 1,
+  borderColor: "#0A84FF",   // blue = less destructive than orange Reset Auth
+},
+resetAccessTokenButtonPressed: {
+  backgroundColor: "#F0F6FF",
+},
+resetAccessTokenButtonText: {
+  fontSize: 16,
+  fontWeight: "600",
+  color: "#0A84FF",
+},
+```
+
+---
+
+## No other files change
+
+`deleteMcpBearerToken(id)` in `lib/secure-storage.ts:874` already handles deleting the bearer token key from SecureStore and the in-memory cache.

--- a/docs/superpowers/plans/2026-06-25-fix-invalid-client-refresh.md
+++ b/docs/superpowers/plans/2026-06-25-fix-invalid-client-refresh.md
@@ -1,0 +1,364 @@
+# Plan: Fix `invalid_client` Refresh Failure
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+## RCA Validation
+
+**What the incident RCA claimed:** `client_id` was missing from the token refresh POST body.
+
+**What the code actually does:** `refreshMcpAccessToken` (lib/mcp-oauth.ts:296-306) _does_ include `clientId` in `refreshConfig.clientId` before calling `AuthSession.refreshAsync`. The guard at line 283 (`if (!refreshToken || !tokenEndpoint || !clientId) return null`) ensures the server is never contacted without a `clientId`. The POST body is correct per OAuth 2.1 `client_secret_post`.
+
+**Confirmed gap in the RCA:** The "Refreshing access token" log (line 287-292) records `has_client_secret` but not `has_client_id`. The field `extension_id` logged there is arty's internal UUID — not the OAuth `client_id`. These are different values; the RCA author conflated them. This logging gap made it look like `client_id` was absent when it was not.
+
+**Actual root cause:** The stored OAuth client credentials were valid (non-null, passed the early-return guard) but the Brain3 auth server rejected them with `invalid_client`. This means the credentials are stale or mismatched — most likely one of:
+
+- **DCR expiry**: Brain3 allowed the DCR client registration to expire. The stored `clientId` is no longer recognized.
+- **Secret rotation**: The `clientSecret` on Brain3's server was rotated and the stored copy is stale.
+
+**Secondary bug not fixed by this plan:** `initializeSecureStorageCache` does not pre-load MCP per-extension keys, so in WebRTC/background contexts the refresh token returns null without even reaching the server. That scenario is documented and fixed separately in `2026-06-25-refresh-oauth-token.md`.
+
+## Problem
+
+When `AuthSession.refreshAsync` receives an `invalid_client` OAuth error back from Brain3:
+
+1. The catch block in `refreshMcpAccessToken` logs only `error.message` (not the OAuth error code) and returns `null`.
+2. `refreshTokenSingleFlight` propagates `null` to `ToolkitManager`.
+3. `ToolkitManager` emits `MCP_REAUTH_REQUIRED_EVENT` and throws "needs to sign in again".
+4. The user opens the browser and logs in manually.
+5. For **DCR mode** — `performMcpOAuthFlow` checks `getMcpClientId(extensionId)` and reuses the same stale `clientId` (line 85-87), so the next refresh will fail with `invalid_client` again.
+6. For **static mode** — re-auth saves the user-configured `clientId`/`clientSecret` from the form again, which does reset correct values, so re-auth genuinely fixes it for static connectors.
+
+## Fix
+
+### 1. Log `has_client_id` and the OAuth error code
+
+**File: `lib/mcp-oauth.ts`**
+
+In `refreshMcpAccessToken`, add `has_client_id` to the pre-refresh log so future incidents reveal whether the lookup returned a value. Also log the OAuth `error` field from the caught error when available.
+
+Change the pre-refresh log block:
+
+```typescript
+log.info(
+  "[mcp_oauth] Refreshing access token",
+  {},
+  {
+    extension_id: extensionId,
+    connector_name: connectorName,
+    has_client_id: !!clientId,
+    has_client_secret: !!clientSecret,
+  },
+);
+```
+
+Change the catch block to extract the OAuth error code when present:
+
+```typescript
+} catch (err) {
+  const oauthCode =
+    (err as any)?.code ??
+    (err as any)?.error ??
+    (typeof (err as any)?.message === "string" && (err as any).message.match(/\b(invalid_\w+|unauthorized_client|access_denied)\b/)?.[0]) ??
+    undefined;
+  log.warn(
+    "[mcp_oauth] Token refresh failed",
+    {},
+    {
+      connector_name: connectorName,
+      error: err instanceof Error ? err.message : String(err),
+      oauth_error_code: oauthCode,
+    },
+  );
+  return null;
+}
+```
+
+### 2. Clear stale DCR `clientId` on `invalid_client` so re-registration fires
+
+**File: `lib/mcp-oauth.ts`**
+
+When the refresh failure is `invalid_client` _and_ the extension is in DCR mode, the stored `clientId` is the expired registration. The next full OAuth flow (triggered by `MCP_REAUTH_REQUIRED_EVENT`) will call `performMcpOAuthFlow`, which checks `getMcpClientId(extensionId)` — if the stale ID is still there, it reuses it. Clear it so `registerOAuthClient` is called fresh.
+
+Import `getMcpAuthMode` and `deleteCachedValue` (or use the already-imported `getMcpClientId`/`saveMcpClientId` pattern — use `deleteMcpClientId` described below).
+
+Add a `deleteMcpClientId` helper in `lib/secure-storage.ts` (next to `deleteMcpClientSecret`):
+
+```typescript
+export async function deleteMcpClientId(id: string): Promise<void> {
+  try {
+    await deleteCachedValue(`${MCP_CLIENT_ID_PREFIX}${id}`);
+  } catch {
+    // may not exist
+  }
+}
+```
+
+Import `getMcpAuthMode` and `deleteMcpClientId` in `lib/mcp-oauth.ts`. In the catch block of `refreshMcpAccessToken`, after extracting `oauthCode`, add:
+
+```typescript
+if (oauthCode === "invalid_client") {
+  const mode = await getMcpAuthMode(extensionId).catch(() => null);
+  if (mode === "dcr") {
+    await deleteMcpClientId(extensionId).catch(() => {});
+    log.info(
+      "[mcp_oauth] Cleared stale DCR client_id after invalid_client",
+      {},
+      { extension_id: extensionId },
+    );
+  }
+}
+```
+
+This is safe for static mode because `oauthCode === "invalid_client"` in static mode means the user's configured credentials are wrong — clearing the DCR `clientId` is a no-op for static mode since `getMcpAuthMode` returns `"static"` and the branch is skipped.
+
+## Files Changed
+
+| File | Change |
+|------|--------|
+| `lib/mcp-oauth.ts` | Add `has_client_id` to pre-refresh log; parse OAuth error code in catch; clear stale DCR `clientId` on `invalid_client` |
+| `lib/secure-storage.ts` | Add `deleteMcpClientId` helper |
+| `lib/__tests__/mcp-oauth.test.ts` | Add test: refresh with `invalid_client` error clears DCR `clientId`; static mode does not clear |
+
+---
+
+## Tasks
+
+### Task 1: Add `deleteMcpClientId` to secure-storage
+
+**Files:**
+- Modify: `lib/secure-storage.ts`
+
+- [ ] **Step 1: Add `deleteMcpClientId` after `deleteMcpClientSecret`**
+
+In `lib/secure-storage.ts`, directly after the `deleteMcpClientSecret` function (around line 906), add:
+
+```typescript
+export async function deleteMcpClientId(id: string): Promise<void> {
+  try {
+    await deleteCachedValue(`${MCP_CLIENT_ID_PREFIX}${id}`);
+  } catch {
+    // may not exist
+  }
+}
+```
+
+- [ ] **Step 2: Run TypeScript check**
+
+```bash
+./node_modules/.bin/tsc --noEmit --pretty false
+```
+
+Expected: exits 0, no errors.
+
+---
+
+### Task 2: Improve refresh logging and add `invalid_client` DCR recovery
+
+**Files:**
+- Modify: `lib/mcp-oauth.ts`
+
+- [ ] **Step 1: Add `getMcpAuthMode` and `deleteMcpClientId` to imports from `./secure-storage`**
+
+In the import block at the top of `lib/mcp-oauth.ts`, add `getMcpAuthMode` and `deleteMcpClientId`:
+
+```typescript
+import {
+  deleteMcpClientSecret,
+  deleteMcpClientId,
+  getMcpAuthMode,
+  getMcpClientSecret,
+  getMcpClientId,
+  getMcpRefreshToken,
+  getMcpTokenEndpoint,
+  saveMcpAuthMode,
+  saveMcpBearerToken,
+  saveMcpClientId,
+  saveMcpClientSecret,
+  saveMcpRefreshToken,
+  saveMcpTokenEndpoint,
+} from "./secure-storage";
+```
+
+- [ ] **Step 2: Add `has_client_id` to the pre-refresh log**
+
+In `refreshMcpAccessToken`, find the `log.info("[mcp_oauth] Refreshing access token", ...)` call and update it:
+
+```typescript
+log.info(
+  "[mcp_oauth] Refreshing access token",
+  {},
+  {
+    extension_id: extensionId,
+    connector_name: connectorName,
+    has_client_id: !!clientId,
+    has_client_secret: !!clientSecret,
+  },
+);
+```
+
+- [ ] **Step 3: Update the catch block to extract and act on the OAuth error code**
+
+Replace the existing catch block in `refreshMcpAccessToken`:
+
+```typescript
+  } catch (err) {
+    const oauthCode =
+      (err as any)?.code ??
+      (err as any)?.error ??
+      (typeof (err as any)?.message === "string"
+        ? (err as any).message.match(/\b(invalid_\w+|unauthorized_client|access_denied)\b/)?.[0]
+        : undefined) ??
+      undefined;
+    log.warn(
+      "[mcp_oauth] Token refresh failed",
+      {},
+      {
+        connector_name: connectorName,
+        error: err instanceof Error ? err.message : String(err),
+        oauth_error_code: oauthCode,
+      },
+    );
+    if (oauthCode === "invalid_client") {
+      const mode = await getMcpAuthMode(extensionId).catch(() => null);
+      if (mode === "dcr") {
+        await deleteMcpClientId(extensionId).catch(() => {});
+        log.info(
+          "[mcp_oauth] Cleared stale DCR client_id after invalid_client",
+          {},
+          { extension_id: extensionId },
+        );
+      }
+    }
+    return null;
+  }
+```
+
+- [ ] **Step 4: Run TypeScript check**
+
+```bash
+./node_modules/.bin/tsc --noEmit --pretty false
+```
+
+Expected: exits 0, no errors.
+
+---
+
+### Task 3: Add tests for the new behaviour
+
+**Files:**
+- Modify: `lib/__tests__/mcp-oauth.test.ts`
+
+- [ ] **Step 1: Add an `invalid_client` refresh test for DCR mode**
+
+In `mcp-oauth.test.ts`, inside the `describe("refreshMcpAccessToken", ...)` block, add two new tests after the existing one:
+
+```typescript
+  test("clears DCR client_id when refresh fails with invalid_client", async () => {
+    secureState.clientId = "dcr-client-id";
+    secureState.clientSecret = null;
+    secureState.refreshToken = "stored-refresh-token";
+    secureState.tokenEndpoint = "https://provider.example.com/token";
+
+    // Patch refreshAsync to throw with invalid_client
+    const { refreshAsync: _orig } = await import("expo-auth-session");
+    const authSessionMod = await import("expo-auth-session");
+    const origRefresh = authSessionMod.refreshAsync;
+    (authSessionMod as any).refreshAsync = async () => {
+      const err: any = new Error("invalid_client");
+      err.error = "invalid_client";
+      throw err;
+    };
+
+    // Patch getMcpAuthMode to return "dcr"
+    const storageMod = await import("../secure-storage");
+    const origAuthMode = storageMod.getMcpAuthMode;
+    (storageMod as any).getMcpAuthMode = async () => "dcr";
+    let deletedId: string | null = null;
+    const origDeleteClientId = storageMod.deleteMcpClientId;
+    (storageMod as any).deleteMcpClientId = async (id: string) => { deletedId = id; };
+
+    const token = await oauthModule.refreshMcpAccessToken("extension-dcr", "DCR Connector");
+
+    expect(token).toBeNull();
+    expect(deletedId).toBe("extension-dcr");
+
+    // Restore
+    (authSessionMod as any).refreshAsync = origRefresh;
+    (storageMod as any).getMcpAuthMode = origAuthMode;
+    (storageMod as any).deleteMcpClientId = origDeleteClientId;
+  });
+
+  test("does not clear client_id for static mode on invalid_client", async () => {
+    secureState.clientId = "static-client-id";
+    secureState.clientSecret = "stored-static-secret";
+    secureState.refreshToken = "stored-refresh-token";
+    secureState.tokenEndpoint = "https://provider.example.com/token";
+
+    const authSessionMod = await import("expo-auth-session");
+    const origRefresh = authSessionMod.refreshAsync;
+    (authSessionMod as any).refreshAsync = async () => {
+      const err: any = new Error("invalid_client");
+      err.error = "invalid_client";
+      throw err;
+    };
+
+    const storageMod = await import("../secure-storage");
+    const origAuthMode = storageMod.getMcpAuthMode;
+    (storageMod as any).getMcpAuthMode = async () => "static";
+    let deletedId: string | null = null;
+    const origDeleteClientId = storageMod.deleteMcpClientId;
+    (storageMod as any).deleteMcpClientId = async (id: string) => { deletedId = id; };
+
+    const token = await oauthModule.refreshMcpAccessToken("extension-static", "Static Connector");
+
+    expect(token).toBeNull();
+    expect(deletedId).toBeNull(); // must NOT clear for static mode
+
+    // Restore
+    (authSessionMod as any).refreshAsync = origRefresh;
+    (storageMod as any).getMcpAuthMode = origAuthMode;
+    (storageMod as any).deleteMcpClientId = origDeleteClientId;
+  });
+```
+
+- [ ] **Step 2: Run all OAuth tests**
+
+```bash
+bun test lib/__tests__/mcp-oauth.test.ts
+```
+
+Expected:
+
+```text
+5 pass
+0 fail
+```
+
+- [ ] **Step 3: Run TypeScript check**
+
+```bash
+./node_modules/.bin/tsc --noEmit --pretty false
+```
+
+Expected: exits 0, no errors.
+
+---
+
+## Manual QA
+
+- [ ] Configure a Brain3 MCP connector in static OAuth mode.
+- [ ] Manually corrupt the stored `client_secret` (via factory reset and re-save with wrong value) so the next refresh fails with `invalid_client`.
+- [ ] Trigger a tool call that returns 401 to exercise the refresh path.
+- [ ] Confirm Logfire shows `oauth_error_code: "invalid_client"` in the "Token refresh failed" log entry.
+- [ ] Confirm `has_client_id: true` appears in the "Refreshing access token" log entry.
+- [ ] For a DCR connector: confirm after `invalid_client` that `getMcpClientId` returns null (stale entry cleared) and re-auth triggers fresh DCR registration.
+
+---
+
+## Self-Review
+
+- Spec coverage: logging gap (has_client_id), error code extraction, DCR stale-registration recovery, static-mode guard.
+- No behaviour change for the happy path (successful refresh).
+- `deleteMcpClientId` mirrors the existing `deleteMcpClientSecret` pattern exactly.
+- The `invalid_client` check is gated on `mode === "dcr"` so static connectors are unaffected.
+- Tests cover both DCR-clears and static-does-not-clear branches.

--- a/docs/superpowers/plans/2026-06-25-refresh-oauth-token.md
+++ b/docs/superpowers/plans/2026-06-25-refresh-oauth-token.md
@@ -1,0 +1,100 @@
+# Plan: Use Refresh Token to Avoid Re-Auth
+
+## Root Cause
+
+`initializeSecureStorageCache()` in `lib/secure-storage.ts` pre-loads only 7
+hardcoded global keys at app startup. It does **not** pre-load per-extension MCP
+keys (bearer token, refresh token, client ID, client secret, token endpoint, auth
+mode). These are dynamically named `${PREFIX}${extensionId}`.
+
+The in-memory cache is the only way to read SecureStore during WebRTC/background
+states — the code comment says:
+
+> SecureStore is not accessible when the device screen is locked or during certain
+> app lifecycle states (background, WebRTC event handlers, etc.)
+
+**Sequence that causes re-auth today:**
+
+1. App restarts (or hasn't seen this extension yet this session).
+2. A tool call is made → server returns 401.
+3. `ToolkitManager` calls `refreshTokenSingleFlight` → `refreshMcpAccessToken`.
+4. `getMcpRefreshToken(extensionId)` → `getCachedValue(MCP_REFRESH_TOKEN_PREFIX + id)`
+   → **cache miss** (key was never loaded at startup).
+5. Falls back to `SecureStore.getItemAsync()` — but the call originates from a
+   WebRTC/background handler → SecureStore throws or returns null.
+6. `getCachedValue` writes `null` into the cache (poisoning the entry), returns `null`.
+7. `refreshMcpAccessToken` returns `null` → `MCP_REAUTH_REQUIRED_EVENT` emitted
+   → user prompted to sign in again.
+
+The cache-poison problem (step 6) also means that even if SecureStore becomes
+accessible later in the session, the null is served from cache and the refresh
+token is never picked up without an app restart.
+
+## What Already Works
+
+- `refreshMcpAccessToken` (`lib/mcp-oauth.ts`) is fully implemented: reads refresh
+  token + token endpoint + client ID + client secret, calls
+  `AuthSession.refreshAsync`, saves the new access token and the rotated refresh
+  token.
+- `ToolkitManager.ts` already has the 401 → refresh → retry loop for both tool
+  calls and tool discovery. Single-flight deduplication is in place.
+- `saveMcpRefreshToken` is called during the initial `exchangeAndStore` and after
+  each successful refresh. Brain3 rotates refresh tokens (confirmed by
+  `refresh_rotates_refresh_token_and_replaces_old_access_token` test), and the
+  save logic handles this correctly.
+- The factory-reset function already iterates extensions and pushes all 6
+  per-extension MCP keys — the pattern is established.
+
+## Fix
+
+**File: `lib/secure-storage.ts`**
+
+Extend `initializeSecureStorageCache()` to also pre-load per-extension MCP keys,
+following the same pattern used in the factory-reset function (line ~1049):
+
+```typescript
+export async function initializeSecureStorageCache(): Promise<void> {
+  const keys = [
+    OPENAI_API_KEY,
+    GITHUB_TOKEN_KEY,
+    GDRIVE_CLIENT_ID_OVERRIDE_KEY,
+    GDRIVE_ACCESS_TOKEN_KEY,
+    GDRIVE_REFRESH_TOKEN_KEY,
+    LOGFIRE_API_KEY,
+    CONTEXT7_API_KEY,
+  ];
+
+  // Pre-load per-extension MCP keys so they are available during
+  // WebRTC/background states where SecureStore is inaccessible.
+  const mcpExtensions = await getMcpExtensions().catch(() => [] as McpExtensionRecord[]);
+  for (const ext of mcpExtensions) {
+    keys.push(
+      `${MCP_TOKEN_PREFIX}${ext.id}`,
+      `${MCP_CLIENT_ID_PREFIX}${ext.id}`,
+      `${MCP_CLIENT_SECRET_PREFIX}${ext.id}`,
+      `${MCP_REFRESH_TOKEN_PREFIX}${ext.id}`,
+      `${MCP_TOKEN_ENDPOINT_PREFIX}${ext.id}`,
+      `${MCP_AUTH_MODE_PREFIX}${ext.id}`,
+    );
+  }
+
+  // ... rest of the function unchanged (Promise.allSettled load, logging, etc.)
+}
+```
+
+`initializeSecureStorageCache()` is called in `app/_layout.tsx` at app startup
+while the app is foregrounded — exactly when SecureStore is guaranteed accessible.
+After this change, all refresh tokens are in cache before any tool calls, and the
+401 → refresh → retry loop in `ToolkitManager` will succeed without prompting the
+user to re-authenticate.
+
+## Files Changed
+
+| File | Change |
+|------|--------|
+| `lib/secure-storage.ts` | Pre-load per-extension MCP keys in `initializeSecureStorageCache()` |
+
+## No Other Changes Needed
+
+The refresh flow, token rotation save, and 401-retry loop are all already
+correct. This one cache pre-population fix is all that's needed.

--- a/lib/__tests__/mcp-oauth.test.ts
+++ b/lib/__tests__/mcp-oauth.test.ts
@@ -31,6 +31,7 @@ const authState = {
   lastAuthRequestConfig: null as Record<string, unknown> | null,
   exchangeCalls: [] as Record<string, unknown>[],
   refreshCalls: [] as Record<string, unknown>[],
+  refreshError: null as Error | null,
 };
 
 const extensionState = {
@@ -44,6 +45,12 @@ const extensionState = {
     registrationEndpoint: "https://auth.example.com/register",
   },
   registeredClientId: "registered-client-id",
+};
+
+const logState = {
+  info: [] as unknown[][],
+  warn: [] as unknown[][],
+  error: [] as unknown[][],
 };
 
 mock.module("../secure-storage", () => ({
@@ -75,9 +82,15 @@ mock.module("../secure-storage", () => ({
 
 mock.module("../logger", () => ({
   log: {
-    info: () => {},
-    warn: () => {},
-    error: () => {},
+    info: (...args: unknown[]) => {
+      logState.info.push(args);
+    },
+    warn: (...args: unknown[]) => {
+      logState.warn.push(args);
+    },
+    error: (...args: unknown[]) => {
+      logState.error.push(args);
+    },
   },
 }));
 
@@ -113,6 +126,9 @@ mock.module("expo-auth-session", () => ({
   },
   refreshAsync: async (config: Record<string, unknown>, discovery: Record<string, unknown>) => {
     authState.refreshCalls.push({ ...config, ...discovery });
+    if (authState.refreshError) {
+      throw authState.refreshError;
+    }
     return authState.refreshResponse;
   },
 }));
@@ -143,6 +159,10 @@ beforeEach(() => {
   authState.lastAuthRequestConfig = null;
   authState.exchangeCalls = [];
   authState.refreshCalls = [];
+  authState.refreshError = null;
+  logState.info = [];
+  logState.warn = [];
+  logState.error = [];
 });
 
 describe("performMcpOAuthFlow", () => {
@@ -232,5 +252,72 @@ describe("refreshMcpAccessToken", () => {
       refreshToken: "stored-refresh-token",
       tokenEndpoint: "https://provider.example.com/token",
     });
+  });
+
+  test("returns user-facing details and logs missing refresh prerequisites", async () => {
+    secureState.clientId = "static-client-id";
+    secureState.refreshToken = null;
+    secureState.tokenEndpoint = "https://provider.example.com/token";
+
+    const result = await oauthModule.refreshMcpAccessTokenWithDetails(
+      "extension-4",
+      "Static Connector",
+    );
+
+    expect(result).toEqual({
+      type: "failure",
+      userMessage: "Missing saved refresh token. Re-authenticate this connector, then try again.",
+      oauthErrorCode: undefined,
+    });
+    expect(logState.warn[0]).toEqual([
+      "[mcp_oauth] Cannot refresh access token because stored OAuth refresh prerequisites are missing",
+      {},
+      {
+        extension_id: "extension-4",
+        connector_name: "Static Connector",
+        missing_fields: ["refresh_token"],
+        has_refresh_token: false,
+        has_token_endpoint: true,
+        has_client_id: true,
+        has_client_secret: false,
+      },
+    ]);
+  });
+
+  test("returns user-facing details and logs OAuth provider refresh failures", async () => {
+    secureState.clientId = "static-client-id";
+    secureState.clientSecret = "stored-static-secret";
+    secureState.refreshToken = "stored-refresh-token";
+    secureState.tokenEndpoint = "https://provider.example.com/token";
+    authState.refreshError = Object.assign(new Error("invalid_grant: refresh token expired"), {
+      code: "invalid_grant",
+    });
+
+    const result = await oauthModule.refreshMcpAccessTokenWithDetails(
+      "extension-5",
+      "Static Connector",
+    );
+
+    expect(result).toEqual({
+      type: "failure",
+      userMessage:
+        "The OAuth provider rejected the refresh request (invalid_grant). Re-authenticate this connector, then try again.",
+      oauthErrorCode: "invalid_grant",
+    });
+    expect(logState.warn[0]).toEqual([
+      "[mcp_oauth] Token refresh failed",
+      {},
+      expect.objectContaining({
+        extension_id: "extension-5",
+        connector_name: "Static Connector",
+        error_message: "invalid_grant: refresh token expired",
+        oauth_error_code: "invalid_grant",
+        token_endpoint: "https://provider.example.com/token",
+        has_refresh_token: true,
+        has_client_id: true,
+        client_id: "static-client-id",
+        has_client_secret: true,
+      }),
+    ]);
   });
 });

--- a/lib/app_version.ts
+++ b/lib/app_version.ts
@@ -1,2 +1,2 @@
-export const APP_VERSION = "12.27.2";
+export const APP_VERSION = "0.3.0";
 export const APP_VERSION_SUBTITLE = `Version ${APP_VERSION}`;

--- a/lib/app_version.ts
+++ b/lib/app_version.ts
@@ -1,2 +1,2 @@
-export const APP_VERSION = "0.3.1";
+export const APP_VERSION = "0.3.3";
 export const APP_VERSION_SUBTITLE = `Version ${APP_VERSION}`;

--- a/lib/app_version.ts
+++ b/lib/app_version.ts
@@ -1,2 +1,2 @@
-export const APP_VERSION = "0.3.3";
+export const APP_VERSION = "0.3.4";
 export const APP_VERSION_SUBTITLE = `Version ${APP_VERSION}`;

--- a/lib/app_version.ts
+++ b/lib/app_version.ts
@@ -1,2 +1,2 @@
-export const APP_VERSION = "0.3.0";
+export const APP_VERSION = "0.3.1";
 export const APP_VERSION_SUBTITLE = `Version ${APP_VERSION}`;

--- a/lib/mcp-oauth.ts
+++ b/lib/mcp-oauth.ts
@@ -1,4 +1,5 @@
 import * as AuthSession from "expo-auth-session";
+import * as Crypto from "expo-crypto";
 
 import {
   fetchOAuthServerMetadata,
@@ -11,12 +12,14 @@ import {
   getMcpClientSecret,
   getMcpClientId,
   getMcpRefreshToken,
+  getMcpResource,
   getMcpTokenEndpoint,
   saveMcpAuthMode,
   saveMcpBearerToken,
   saveMcpClientId,
   saveMcpClientSecret,
   saveMcpRefreshToken,
+  saveMcpResource,
   saveMcpTokenEndpoint,
 } from "./secure-storage";
 
@@ -104,6 +107,7 @@ export async function performMcpOAuthFlow(
   }
 
   await saveMcpTokenEndpoint(extensionId, oauthMeta.tokenEndpoint);
+  await saveMcpResource(extensionId, resourceMetadata.resource);
 
   const discovery = {
     authorizationEndpoint: oauthMeta.authorizationEndpoint,
@@ -165,6 +169,7 @@ export async function performMcpOAuthFlow(
       extensionId,
       connectorName,
       clientSecret,
+      resourceMetadata.resource,
     );
     return { type: "success", ...tokens };
   }
@@ -207,7 +212,10 @@ export async function completeMcpOAuthFromCallbackUrl(
     { extension_id: pendingState.extensionId },
   );
 
-  const clientSecret = await getMcpClientSecret(pendingState.extensionId);
+  const [clientSecret, resource] = await Promise.all([
+    getMcpClientSecret(pendingState.extensionId),
+    getMcpResource(pendingState.extensionId),
+  ]);
 
   return exchangeAndStore(
     code,
@@ -218,6 +226,7 @@ export async function completeMcpOAuthFromCallbackUrl(
     pendingState.extensionId,
     undefined,
     clientSecret ?? undefined,
+    resource ?? undefined,
   );
 }
 
@@ -230,6 +239,7 @@ async function exchangeAndStore(
   extensionId: string,
   connectorName?: string,
   clientSecret?: string,
+  resource?: string,
 ): Promise<{ accessToken: string; refreshToken?: string }> {
   const exchangeConfig: any = {
     code,
@@ -239,8 +249,15 @@ async function exchangeAndStore(
   if (clientSecret) {
     exchangeConfig.clientSecret = clientSecret;
   }
+  const extraParams: Record<string, string> = {};
   if (codeVerifier) {
-    exchangeConfig.extraParams = { code_verifier: codeVerifier };
+    extraParams.code_verifier = codeVerifier;
+  }
+  if (resource) {
+    extraParams.resource = resource;
+  }
+  if (Object.keys(extraParams).length > 0) {
+    exchangeConfig.extraParams = extraParams;
   }
   const tokenResponse = await AuthSession.exchangeCodeAsync(
     exchangeConfig,
@@ -281,6 +298,12 @@ export type McpAccessTokenRefreshResult =
   | { type: "success"; accessToken: string }
   | { type: "failure"; userMessage: string; oauthErrorCode?: string };
 
+const sha256Prefix = async (value: string | null | undefined): Promise<string> => {
+  if (!value) return "(none)";
+  const hash = await Crypto.digestStringAsync(Crypto.CryptoDigestAlgorithm.SHA256, value);
+  return hash.slice(0, 8);
+};
+
 const getOAuthRefreshErrorCode = (err: unknown): string | undefined =>
   (err as any)?.code ??
   (err as any)?.error ??
@@ -310,11 +333,12 @@ export async function refreshMcpAccessTokenWithDetails(
   extensionId: string,
   connectorName?: string,
 ): Promise<McpAccessTokenRefreshResult> {
-  const [refreshToken, tokenEndpoint, clientId, clientSecret] = await Promise.all([
+  const [refreshToken, tokenEndpoint, clientId, clientSecret, resource] = await Promise.all([
     getMcpRefreshToken(extensionId),
     getMcpTokenEndpoint(extensionId),
     getMcpClientId(extensionId),
     getMcpClientSecret(extensionId),
+    getMcpResource(extensionId),
   ]);
 
   const missingFields = [
@@ -344,6 +368,11 @@ export async function refreshMcpAccessTokenWithDetails(
     };
   }
 
+  const [clientIdHash, clientSecretHash] = await Promise.all([
+    sha256Prefix(clientId),
+    sha256Prefix(clientSecret),
+  ]);
+
   log.info(
     "[mcp_oauth] Refreshing access token",
     {},
@@ -352,9 +381,12 @@ export async function refreshMcpAccessTokenWithDetails(
       connector_name: connectorName,
       has_client_id: !!clientId,
       client_id: clientId,
+      client_id_hash: clientIdHash,
       has_client_secret: !!clientSecret,
       client_secret_length: clientSecret?.length ?? 0,
+      client_secret_hash: clientSecretHash,
       token_endpoint: tokenEndpoint,
+      resource: resource ?? null,
     },
   );
 
@@ -365,6 +397,9 @@ export async function refreshMcpAccessTokenWithDetails(
     };
     if (clientSecret) {
       refreshConfig.clientSecret = clientSecret;
+    }
+    if (resource) {
+      refreshConfig.extraParams = { resource };
     }
     const tokenResponse = await AuthSession.refreshAsync(
       refreshConfig,
@@ -413,7 +448,9 @@ export async function refreshMcpAccessTokenWithDetails(
         has_refresh_token: !!refreshToken,
         has_client_id: !!clientId,
         client_id: clientId,
+        client_id_hash: clientIdHash,
         has_client_secret: !!clientSecret,
+        client_secret_hash: clientSecretHash,
       },
     );
     return {

--- a/lib/mcp-oauth.ts
+++ b/lib/mcp-oauth.ts
@@ -288,7 +288,10 @@ export async function refreshMcpAccessToken(
     {
       extension_id: extensionId,
       connector_name: connectorName,
+      has_client_id: !!clientId,
+      client_id_length: clientId?.length ?? 0,
       has_client_secret: !!clientSecret,
+      client_secret_length: clientSecret?.length ?? 0,
     },
   );
 
@@ -313,10 +316,21 @@ export async function refreshMcpAccessToken(
     log.info("[mcp_oauth] Token refresh succeeded", {}, { connector_name: connectorName });
     return tokenResponse.accessToken;
   } catch (err) {
+    const oauthCode =
+      (err as any)?.code ??
+      (err as any)?.error ??
+      (typeof (err as any)?.message === "string"
+        ? (err as any).message.match(/\b(invalid_\w+|unauthorized_client|access_denied)\b/)?.[0]
+        : undefined) ??
+      undefined;
     log.warn(
       "[mcp_oauth] Token refresh failed",
       {},
-      { connector_name: connectorName, error: err instanceof Error ? err.message : String(err) },
+      {
+        connector_name: connectorName,
+        error: err instanceof Error ? err.message : String(err),
+        oauth_error_code: oauthCode,
+      },
     );
     return null;
   }

--- a/lib/mcp-oauth.ts
+++ b/lib/mcp-oauth.ts
@@ -273,6 +273,43 @@ export async function refreshMcpAccessToken(
   extensionId: string,
   connectorName?: string,
 ): Promise<string | null> {
+  const result = await refreshMcpAccessTokenWithDetails(extensionId, connectorName);
+  return result.type === "success" ? result.accessToken : null;
+}
+
+export type McpAccessTokenRefreshResult =
+  | { type: "success"; accessToken: string }
+  | { type: "failure"; userMessage: string; oauthErrorCode?: string };
+
+const getOAuthRefreshErrorCode = (err: unknown): string | undefined =>
+  (err as any)?.code ??
+  (err as any)?.error ??
+  (typeof (err as any)?.message === "string"
+    ? (err as any).message.match(/\b(invalid_\w+|unauthorized_client|access_denied)\b/)?.[0]
+    : undefined) ??
+  undefined;
+
+const buildMissingRefreshPrerequisiteMessage = (missingFields: string[]): string => {
+  if (missingFields.length === 1) {
+    const missingField = missingFields[0];
+    if (missingField === "refresh_token") {
+      return "Missing saved refresh token. Re-authenticate this connector, then try again.";
+    }
+    if (missingField === "token_endpoint") {
+      return "Missing saved token endpoint. Re-authenticate this connector, then try again.";
+    }
+    if (missingField === "client_id") {
+      return "Missing saved client ID. Re-authenticate this connector, then try again.";
+    }
+  }
+
+  return `Missing saved OAuth refresh credentials (${missingFields.join(", ")}). Re-authenticate this connector, then try again.`;
+};
+
+export async function refreshMcpAccessTokenWithDetails(
+  extensionId: string,
+  connectorName?: string,
+): Promise<McpAccessTokenRefreshResult> {
   const [refreshToken, tokenEndpoint, clientId, clientSecret] = await Promise.all([
     getMcpRefreshToken(extensionId),
     getMcpTokenEndpoint(extensionId),
@@ -280,7 +317,32 @@ export async function refreshMcpAccessToken(
     getMcpClientSecret(extensionId),
   ]);
 
-  if (!refreshToken || !tokenEndpoint || !clientId) return null;
+  const missingFields = [
+    !refreshToken ? "refresh_token" : null,
+    !tokenEndpoint ? "token_endpoint" : null,
+    !clientId ? "client_id" : null,
+  ].filter((field): field is string => !!field);
+
+  if (!refreshToken || !tokenEndpoint || !clientId) {
+    log.warn(
+      "[mcp_oauth] Cannot refresh access token because stored OAuth refresh prerequisites are missing",
+      {},
+      {
+        extension_id: extensionId,
+        connector_name: connectorName,
+        missing_fields: missingFields,
+        has_refresh_token: !!refreshToken,
+        has_token_endpoint: !!tokenEndpoint,
+        has_client_id: !!clientId,
+        has_client_secret: !!clientSecret,
+      },
+    );
+    return {
+      type: "failure",
+      userMessage: buildMissingRefreshPrerequisiteMessage(missingFields),
+      oauthErrorCode: undefined,
+    };
+  }
 
   log.info(
     "[mcp_oauth] Refreshing access token",
@@ -289,9 +351,10 @@ export async function refreshMcpAccessToken(
       extension_id: extensionId,
       connector_name: connectorName,
       has_client_id: !!clientId,
-      client_id_length: clientId?.length ?? 0,
+      client_id: clientId,
       has_client_secret: !!clientSecret,
       client_secret_length: clientSecret?.length ?? 0,
+      token_endpoint: tokenEndpoint,
     },
   );
 
@@ -308,30 +371,57 @@ export async function refreshMcpAccessToken(
       { tokenEndpoint },
     );
 
+    if (!tokenResponse.accessToken) {
+      log.error(
+        "[mcp_oauth] Token refresh response did not include an access token",
+        {},
+        {
+          extension_id: extensionId,
+          connector_name: connectorName,
+          token_endpoint: tokenEndpoint,
+          response_keys: Object.keys(tokenResponse),
+        },
+      );
+      return {
+        type: "failure",
+        userMessage:
+          "The OAuth provider refresh response did not include an access token. Re-authenticate this connector, then try again.",
+      };
+    }
+
     await saveMcpBearerToken(extensionId, tokenResponse.accessToken);
     if (tokenResponse.refreshToken) {
       await saveMcpRefreshToken(extensionId, tokenResponse.refreshToken);
     }
 
     log.info("[mcp_oauth] Token refresh succeeded", {}, { connector_name: connectorName });
-    return tokenResponse.accessToken;
+    return { type: "success", accessToken: tokenResponse.accessToken };
   } catch (err) {
-    const oauthCode =
-      (err as any)?.code ??
-      (err as any)?.error ??
-      (typeof (err as any)?.message === "string"
-        ? (err as any).message.match(/\b(invalid_\w+|unauthorized_client|access_denied)\b/)?.[0]
-        : undefined) ??
-      undefined;
+    const oauthCode = getOAuthRefreshErrorCode(err);
+    const errorMessage = err instanceof Error ? err.message : String(err);
     log.warn(
       "[mcp_oauth] Token refresh failed",
       {},
       {
+        extension_id: extensionId,
         connector_name: connectorName,
-        error: err instanceof Error ? err.message : String(err),
+        error_name: err instanceof Error ? err.name : undefined,
+        error_message: errorMessage,
+        error_stack: err instanceof Error ? err.stack : undefined,
         oauth_error_code: oauthCode,
+        token_endpoint: tokenEndpoint,
+        has_refresh_token: !!refreshToken,
+        has_client_id: !!clientId,
+        client_id: clientId,
+        has_client_secret: !!clientSecret,
       },
     );
-    return null;
+    return {
+      type: "failure",
+      userMessage: oauthCode
+        ? `The OAuth provider rejected the refresh request (${oauthCode}). Re-authenticate this connector, then try again.`
+        : `Could not refresh the access token: ${errorMessage}`,
+      oauthErrorCode: oauthCode,
+    };
   }
 }

--- a/lib/mcp-oauth.ts
+++ b/lib/mcp-oauth.ts
@@ -395,11 +395,18 @@ export async function refreshMcpAccessTokenWithDetails(
       clientId,
       refreshToken,
     };
+    // Use client_secret_post (credentials in body) not client_secret_basic (Authorization header).
+    // expo-auth-session switches to Basic auth when clientSecret is set directly, but
+    // brain3-dev only accepts client_secret_post.
+    const extraParams: Record<string, string> = {};
     if (clientSecret) {
-      refreshConfig.clientSecret = clientSecret;
+      extraParams.client_secret = clientSecret;
     }
     if (resource) {
-      refreshConfig.extraParams = { resource };
+      extraParams.resource = resource;
+    }
+    if (Object.keys(extraParams).length > 0) {
+      refreshConfig.extraParams = extraParams;
     }
     const tokenResponse = await AuthSession.refreshAsync(
       refreshConfig,

--- a/lib/secure-storage.ts
+++ b/lib/secure-storage.ts
@@ -819,6 +819,7 @@ const MCP_CLIENT_SECRET_PREFIX = "VIBEMACHINE_MCP_CLIENT_SECRET_";
 const MCP_REFRESH_TOKEN_PREFIX = "VIBEMACHINE_MCP_REFRESH_TOKEN_";
 const MCP_TOKEN_ENDPOINT_PREFIX = "VIBEMACHINE_MCP_TOKEN_ENDPOINT_";
 const MCP_AUTH_MODE_PREFIX = "VIBEMACHINE_MCP_AUTH_MODE_";
+const MCP_RESOURCE_PREFIX = "VIBEMACHINE_MCP_RESOURCE_";
 
 export async function getMcpExtensions(): Promise<McpExtensionRecord[]> {
   try {
@@ -956,6 +957,18 @@ export async function getMcpTokenEndpoint(id: string): Promise<string | null> {
   }
 }
 
+export async function saveMcpResource(id: string, resource: string): Promise<void> {
+  await setCachedValue(`${MCP_RESOURCE_PREFIX}${id}`, resource);
+}
+
+export async function getMcpResource(id: string): Promise<string | null> {
+  try {
+    return await getCachedValue(`${MCP_RESOURCE_PREFIX}${id}`);
+  } catch {
+    return null;
+  }
+}
+
 export async function clearMcpAuthCredentials(id: string): Promise<void> {
   await Promise.allSettled([
     deleteCachedValue(`${MCP_CLIENT_ID_PREFIX}${id}`),
@@ -963,6 +976,7 @@ export async function clearMcpAuthCredentials(id: string): Promise<void> {
     deleteCachedValue(`${MCP_TOKEN_ENDPOINT_PREFIX}${id}`),
     deleteCachedValue(`${MCP_CLIENT_SECRET_PREFIX}${id}`),
     deleteCachedValue(`${MCP_AUTH_MODE_PREFIX}${id}`),
+    deleteCachedValue(`${MCP_RESOURCE_PREFIX}${id}`),
   ]);
 }
 
@@ -1056,6 +1070,7 @@ export async function clearAllStoredSecrets(): Promise<void> {
       `${MCP_REFRESH_TOKEN_PREFIX}${ext.id}`,
       `${MCP_TOKEN_ENDPOINT_PREFIX}${ext.id}`,
       `${MCP_AUTH_MODE_PREFIX}${ext.id}`,
+      `${MCP_RESOURCE_PREFIX}${ext.id}`,
     );
   }
 

--- a/modules/vm-webrtc/src/ToolkitManager.ts
+++ b/modules/vm-webrtc/src/ToolkitManager.ts
@@ -771,8 +771,18 @@ async function registerUserExtensionToolsFromCache(
             return { result: JSON.stringify(result, null, 2), updatedToolSessionContext: {} };
           } catch (retryError) {
             if (!(retryError instanceof McpAuthError)) throw retryError;
+            log.warn(
+              "[ToolkitManager] Retry with refreshed token still got 401",
+              {},
+              { name: ext.name, toolName },
+            );
           }
         }
+        log.warn(
+          "[ToolkitManager] Emitting MCP_REAUTH_REQUIRED_EVENT from tool-call path",
+          {},
+          { name: ext.name, toolName, had_new_token: !!newToken },
+        );
         DeviceEventEmitter.emit(MCP_REAUTH_REQUIRED_EVENT, { id: ext.id, name: ext.name });
         throw new Error(`${ext.name} needs to sign in again. Open Extensions (MCP) to re-authenticate.`);
       }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "vibemachine",
   "main": "expo-router/entry",
-  "version": "1.0.0",
+  "version": "0.3.3",
   "scripts": {
     "start": "expo start",
     "reset-project": "node ./scripts/reset-project.js",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added “Refresh Access Token” controls on the MCP extension detail screen (including loading/disable behavior), alongside the existing reset action.
* **Bug Fixes**
  * Improved OAuth/token-refresh reliability and troubleshooting with more informative warnings and clearer re-auth behavior when refresh still fails.
  * Enhanced token refresh handling to carry additional OAuth resource details and return richer failure info (including OAuth error codes) instead of silent nulls.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->